### PR TITLE
List root volumes as well

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -1680,7 +1680,6 @@ public class QueryManagerImpl extends ManagerBase implements QueryService, Confi
         // Only return volumes that are not destroyed
         sb.and("state", sb.entity().getState(), SearchCriteria.Op.NEQ);
         sb.and("systemUse", sb.entity().isSystemUse(), SearchCriteria.Op.NEQ);
-        sb.and("nulltype", sb.entity().getVmType(), SearchCriteria.Op.NULL);
 
         // now set the SC criteria...
         final SearchCriteria<VolumeJoinVO> sc = sb.create();


### PR DESCRIPTION
Somehow since BareMetal was removed, this broke.

Works again:
![rootdisksback](https://cloud.githubusercontent.com/assets/1630096/16226638/b2b7a1a0-37ac-11e6-85df-75c9e6e25054.png)

Problem:
![norootdisks](https://cloud.githubusercontent.com/assets/1630096/16226424/a67aae92-37ab-11e6-9127-c5e3cce873a8.png)
