### PR TITLE
Display resize button for all users

### DIFF
--- a/cosmic-client/cosmic-ui/scripts/storage.js
+++ b/cosmic-client/cosmic-ui/scripts/storage.js
@@ -2363,10 +2363,8 @@
             }
         }
 
-        if (jsonObj.hypervisor == "KVM" || jsonObj.hypervisor == "XenServer") {
-            if (jsonObj.state == "Ready" || jsonObj.state == "Allocated") {
-                allowedActions.push("resize");
-            }
+        if (jsonObj.state == "Ready" || jsonObj.state == "Allocated") {
+            allowedActions.push("resize");
         }
 
         if (jsonObj.state != "Allocated") {


### PR DESCRIPTION
The hypervisor check only worked for root admins because for domain admins and users the hypervisor type is hidden. The check was removed to have the button display. It worked via the API already.

Before:
![screen shot 2016-06-23 at 21 45 41 pm](https://cloud.githubusercontent.com/assets/1630096/16317719/c5662704-398c-11e6-92e4-e08addd892f4.png)

After:
![screen shot 2016-06-23 at 21 47 08 pm](https://cloud.githubusercontent.com/assets/1630096/16317715/c184037c-398c-11e6-8b32-6a8f2760bde8.png)

Port of ACS PR 1595.
