### PR TITLE
Fix the KVM HA heartbeat timeout checker

### DIFF
--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/KvmHaBase.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/KvmHaBase.java
@@ -20,7 +20,6 @@ public class KvmHaBase {
     private final long timeout = 60000; /* 1 minutes */
     protected long heartBeatUpdateTimeout = 60000;
     protected long heartBeatUpdateFreq = 60000;
-    protected long heartBeatUpdateMaxRetry = 3;
 
     protected String getMountPoint(final NfsStoragePool storagePool) {
 

--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/KvmHaChecker.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/KvmHaChecker.java
@@ -37,11 +37,11 @@ public class KvmHaChecker extends KvmHaBase implements Callable<Boolean> {
             cmd.add("-m", pool.innerMountDestPath);
             cmd.add("-h", hostIp);
             cmd.add("-r");
-            cmd.add("-t", String.valueOf(heartBeatUpdateFreq));
+            cmd.add("-t", String.valueOf(heartBeatUpdateFreq / 1000));
             final OutputInterpreter.OneLineParser parser = new OutputInterpreter.OneLineParser();
             final String result = cmd.execute(parser);
             logger.debug("pool: " + pool.innetPoolIp);
-            logger.debug("reture: " + result);
+            logger.debug("return: " + result);
             logger.debug("parser: " + parser.getLine());
             if (result == null && parser.getLine().contains("> DEAD <")) {
                 logger.debug("read heartbeat failed: " + result);


### PR DESCRIPTION
When the checkstyle code style was applied a while back, a devision by 1000 was removed. This resulted in a timeout being bumped to 60K seconds, instead of the intended 60 seconds.

I run into this today during OAT when I noticed a KVM hypervisor that I pulled the plugs from, didn't trigger an HA event. Instead, only Alert state was reached. This was due to the fact that the 60K seconds timeout wasn't reached when the neighbouring hosts were checking the HA state.

With this patch, the timeout is 60 seconds and the host is marked down and HA starts.

It's worth a discussion whether the timeout should be 180 seconds instead of 60. Although this piece of code is only run after say 6 minutes so by then we need to start HA asap when the heartbeat hasn't been updated.

Regression:
(before)
MissionCriticalCloudOldRepos/cosmic-plugin-hypervisor-kvm@0d04723#diff-fd2769f5eb2edd2010a013abc6f3b48eL52
(after)
MissionCriticalCloudOldRepos/cosmic-plugin-hypervisor-kvm@0d04723#diff-376c605d430d7b885a8f7090196e745cR34
