### PR TITLE
Concurrently adding multiple tiers to vpc

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/network/PhysicalNetwork.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/PhysicalNetwork.java
@@ -19,8 +19,6 @@ public interface PhysicalNetwork extends Identity, InternalIdentity {
 
     List<String> getTags();
 
-    // TrafficType getTrafficType();
-
     List<String> getIsolationMethods();
 
     Long getDomainId();
@@ -33,15 +31,15 @@ public interface PhysicalNetwork extends Identity, InternalIdentity {
 
     String getName();
 
-    public enum State {
+    enum State {
         Disabled, Enabled
     }
 
-    public enum IsolationMethod {
+    enum IsolationMethod {
         VLAN, L3, GRE, STT, BCF_SEGMENT, MIDO, SSP, VXLAN, ODL, L3VPN, VSP, VCS
     }
 
-    public enum BroadcastDomainRange {
+    enum BroadcastDomainRange {
         POD, ZONE
     }
 }

--- a/cosmic-core/api/src/main/java/org/apache/cloudstack/network/ExternalNetworkDeviceManager.java
+++ b/cosmic-core/api/src/main/java/org/apache/cloudstack/network/ExternalNetworkDeviceManager.java
@@ -23,10 +23,8 @@ public interface ExternalNetworkDeviceManager extends Manager {
 
     class NetworkDevice {
         private static final List<NetworkDevice> supportedNetworkDevices = new ArrayList<>();
-        public static final NetworkDevice JuniperSRXFirewall = new NetworkDevice("JuniperSRXFirewall", Network.Provider.JuniperSRX.getName());
         public static final NetworkDevice ExternalDhcp = new NetworkDevice("ExternalDhcp");
         public static final NetworkDevice NiciraNvp = new NetworkDevice("NiciraNvp", Network.Provider.NiciraNvp.getName());
-        public static final NetworkDevice CiscoVnmc = new NetworkDevice("CiscoVnmc", Network.Provider.CiscoVnmc.getName());
         private final String _name;
         private final String _provider;
 

--- a/cosmic-core/api/src/main/java/org/apache/cloudstack/network/ExternalNetworkDeviceManager.java
+++ b/cosmic-core/api/src/main/java/org/apache/cloudstack/network/ExternalNetworkDeviceManager.java
@@ -22,11 +22,11 @@ public interface ExternalNetworkDeviceManager extends Manager {
     boolean deleteNetworkDevice(DeleteNetworkDeviceCmd cmd);
 
     class NetworkDevice {
-        public static final NetworkDevice ExternalDhcp = new NetworkDevice("ExternalDhcp", null);
+        private static final List<NetworkDevice> supportedNetworkDevices = new ArrayList<>();
         public static final NetworkDevice JuniperSRXFirewall = new NetworkDevice("JuniperSRXFirewall", Network.Provider.JuniperSRX.getName());
+        public static final NetworkDevice ExternalDhcp = new NetworkDevice("ExternalDhcp");
         public static final NetworkDevice NiciraNvp = new NetworkDevice("NiciraNvp", Network.Provider.NiciraNvp.getName());
         public static final NetworkDevice CiscoVnmc = new NetworkDevice("CiscoVnmc", Network.Provider.CiscoVnmc.getName());
-        private static final List<NetworkDevice> supportedNetworkDevices = new ArrayList<>();
         private final String _name;
         private final String _provider;
 
@@ -34,6 +34,10 @@ public interface ExternalNetworkDeviceManager extends Manager {
             _name = deviceName;
             _provider = ntwkServiceprovider;
             supportedNetworkDevices.add(this);
+        }
+
+        public NetworkDevice(final String deviceName) {
+            this(deviceName, null);
         }
 
         public static NetworkDevice getNetworkDevice(final String devicerName) {

--- a/cosmic-core/api/src/test/java/org/apache/cloudstack/network/NetworkDeviceTest.java
+++ b/cosmic-core/api/src/test/java/org/apache/cloudstack/network/NetworkDeviceTest.java
@@ -1,0 +1,19 @@
+package org.apache.cloudstack.network;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.apache.cloudstack.network.ExternalNetworkDeviceManager.NetworkDevice;
+
+import org.junit.Test;
+
+public class NetworkDeviceTest {
+
+    @Test
+    public void test_createNetworkDevice_canAddItSelfToDeviceList() throws Exception {
+        final String deviceName = "someDevice";
+        final NetworkDevice networkDevice = new NetworkDevice(deviceName);
+
+        assertThat(NetworkDevice.getNetworkDevice(deviceName), is(networkDevice));
+    }
+}

--- a/cosmic-core/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/cosmic-core/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -4579,36 +4579,54 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         final User user = context.getCallingUser();
         final Account account = context.getCallingAccount();
 
+        final VmWorkJobVO workJob = fetchOrCreateVmWorkJob(vm, network, requested, context, user, account);
+        AsyncJobExecutionContext.getCurrentExecutionContext().joinJob(workJob.getId());
+
+        return new VmJobVirtualMachineOutcome(workJob, vm.getId());
+    }
+
+    private VmWorkJobVO fetchOrCreateVmWorkJob(final VirtualMachine vm, final Network network, final NicProfile requested, final CallContext context, final User user, final
+    Account account) {
         final List<VmWorkJobVO> pendingWorkJobs = _workJobDao.listPendingWorkJobs(VirtualMachine.Type.Instance, vm.getId(), VmWorkAddVmToNetwork.class.getName());
 
         VmWorkJobVO workJob = null;
         if (pendingWorkJobs != null && pendingWorkJobs.size() > 0) {
             assert pendingWorkJobs.size() == 1;
             workJob = pendingWorkJobs.get(0);
-            s_logger.info("Found pending job in queue " + workJob + " and will reuse that to add vm " + vm + " to network " + network);
-        } else {
-            workJob = new VmWorkJobVO(context.getContextId());
-
-            workJob.setDispatcher(VmWorkConstants.VM_WORK_JOB_DISPATCHER);
-            workJob.setCmd(VmWorkAddVmToNetwork.class.getName());
-
-            workJob.setAccountId(account.getId());
-            workJob.setUserId(user.getId());
-            workJob.setVmType(VirtualMachine.Type.Instance);
-            workJob.setVmInstanceId(vm.getId());
-            workJob.setRelated(AsyncJobExecutionContext.getOriginJobId());
-
-            // save work context info (there are some duplications)
-            final String vmWorkJobHandler = VirtualMachineManagerImpl.VM_WORK_JOB_HANDLER;
-            final VmWorkAddVmToNetwork workInfo = new VmWorkAddVmToNetwork(user.getId(), account.getId(), vm.getId(), vmWorkJobHandler, network.getId(), requested);
-            workJob.setCmdInfo(VmWorkSerializer.serialize(workInfo));
-
-            _jobMgr.submitAsyncJob(workJob, VmWorkConstants.VM_WORK_QUEUE, vm.getId());
-            s_logger.info("Submitted new job to queue to add vm " + vm + " to network " + network);
+            if (jobIsForSameNetwork(network, workJob)) {
+                s_logger.info("Found pending job in queue " + workJob + " and will reuse that to add vm " + vm + " to network " + network);
+                return workJob;
+            }
         }
-        AsyncJobExecutionContext.getCurrentExecutionContext().joinJob(workJob.getId());
+        return createNewVmWorkJob(vm, network, requested, context, user, account);
+    }
 
-        return new VmJobVirtualMachineOutcome(workJob, vm.getId());
+    private boolean jobIsForSameNetwork(final Network network, final VmWorkJobVO workJob) {
+        return new JobHelper().jobIsForSameNetwork(workJob, network);
+    }
+
+    private VmWorkJobVO createNewVmWorkJob(final VirtualMachine vm, final Network network, final NicProfile requested, final CallContext context, final User user, final Account
+            account) {
+        final VmWorkJobVO workJob;
+        workJob = new VmWorkJobVO(context.getContextId());
+
+        workJob.setDispatcher(VmWorkConstants.VM_WORK_JOB_DISPATCHER);
+        workJob.setCmd(VmWorkAddVmToNetwork.class.getName());
+
+        workJob.setAccountId(account.getId());
+        workJob.setUserId(user.getId());
+        workJob.setVmType(VirtualMachine.Type.Instance);
+        workJob.setVmInstanceId(vm.getId());
+        workJob.setRelated(AsyncJobExecutionContext.getOriginJobId());
+
+        // save work context info (there are some duplications)
+        final String vmWorkJobHandler = VirtualMachineManagerImpl.VM_WORK_JOB_HANDLER;
+        final VmWorkAddVmToNetwork workInfo = new VmWorkAddVmToNetwork(user.getId(), account.getId(), vm.getId(), vmWorkJobHandler, network.getId(), requested);
+        workJob.setCmdInfo(VmWorkSerializer.serialize(workInfo));
+
+        _jobMgr.submitAsyncJob(workJob, VmWorkConstants.VM_WORK_QUEUE, vm.getId());
+        s_logger.info("Submitted new job to queue to add vm " + vm + " to network " + network);
+        return workJob;
     }
 
     public Outcome<VirtualMachine> removeNicFromVmThroughJobQueue(
@@ -4668,5 +4686,18 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         _workJobDao.persist(workJob);
 
         return workJob;
+    }
+
+    public static class JobHelper {
+        public boolean jobIsForSameNetwork(final VmWorkJobVO workJob, final Network network) {
+            final VmWorkAddVmToNetwork workInfo = VmWorkSerializer.deserialize(VmWorkAddVmToNetwork.class, workJob.getCmdInfo());
+            if (workInfo != null) {
+                final Long workInfoNetworkId = workInfo.getNetworkId();
+                final long networkId = network.getId();
+                return workInfoNetworkId != null && workInfoNetworkId == networkId;
+            } else {
+                return false;
+            }
+        }
     }
 }

--- a/cosmic-core/engine/orchestration/src/main/java/com/cloud/vm/VmWorkAddVmToNetwork.java
+++ b/cosmic-core/engine/orchestration/src/main/java/com/cloud/vm/VmWorkAddVmToNetwork.java
@@ -6,8 +6,7 @@ public class VmWorkAddVmToNetwork extends VmWork {
     Long networkId;
     NicProfile requstedNicProfile;
 
-    public VmWorkAddVmToNetwork(final long userId, final long accountId, final long vmId, final String handlerName,
-                                final Long networkId, final NicProfile requested) {
+    public VmWorkAddVmToNetwork(final long userId, final long accountId, final long vmId, final String handlerName, final Long networkId, final NicProfile requested) {
         super(userId, accountId, vmId, handlerName);
 
         this.networkId = networkId;

--- a/cosmic-core/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/cosmic-core/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -613,8 +613,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                     @Override
                     public void doInTransactionWithoutResult(final TransactionStatus status) {
                         final NetworkVO vo = new NetworkVO(id, network, offering.getId(), guru.getName(), owner.getDomainId(), owner.getId(), relatedFile, name, displayText,
-                                predefined
-                                        .getNetworkDomain(), offering.getGuestType(), plan.getDataCenterId(), plan.getPhysicalNetworkId(), aclType, offering.getSpecifyIpRanges(),
+                                predefined.getNetworkDomain(), offering.getGuestType(), plan.getDataCenterId(), plan.getPhysicalNetworkId(), aclType, offering.getSpecifyIpRanges(),
                                 vpcId, offering.getRedundantRouter());
                         vo.setDisplayNetwork(isDisplayNetworkEnabled == null ? true : isDisplayNetworkEnabled);
                         vo.setStrechedL2Network(offering.getSupportsStrechedL2());
@@ -2465,8 +2464,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                         s_logger.warn("Failed to re-program the network as a part of network " + network + " implement due to aggregated commands execution failure!");
                         // see DataCenterVO.java
                         final ResourceUnavailableException ex = new ResourceUnavailableException("Unable to apply network rules as a part of network " + network + " implement",
-                                DataCenter.class,
-                                network.getDataCenterId());
+                                DataCenter.class, network.getDataCenterId());
                         ex.addProxyObject(_entityMgr.findById(DataCenter.class, network.getDataCenterId()).getUuid());
                         throw ex;
                     }

--- a/cosmic-core/engine/orchestration/src/test/java/com/cloud/vm/JobHelperTest.java
+++ b/cosmic-core/engine/orchestration/src/test/java/com/cloud/vm/JobHelperTest.java
@@ -1,0 +1,60 @@
+package com.cloud.vm;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import com.cloud.network.dao.NetworkVO;
+import com.cloud.vm.VirtualMachineManagerImpl.JobHelper;
+import org.apache.cloudstack.framework.jobs.impl.VmWorkJobVO;
+
+import org.junit.Test;
+
+public class JobHelperTest {
+
+    @Test
+    public void test_jobIsForSameNetwork_whenJobIsForNetwork() throws Exception {
+        final long networkId = 1L;
+        final VmWorkAddVmToNetwork vmWorkAddVmToNetwork = new VmWorkAddVmToNetwork(0, 0, 0, "someHandler", networkId, null);
+        final VmWorkJobVO vmWorkJobVO = new VmWorkJobVO("someContext");
+        vmWorkJobVO.setCmdInfo(VmWorkSerializer.serialize(vmWorkAddVmToNetwork));
+        final NetworkVO networkVO = new NetworkVO();
+        networkVO.setId(networkId);
+
+        assertThat(new JobHelper().jobIsForSameNetwork(vmWorkJobVO, networkVO), is(true));
+    }
+
+    @Test
+    public void test_jobIsForSameNetwork_whenJobIsNotForNetwork() throws Exception {
+        final long someNetworkId = 1L;
+        final long anotherNetworkId = 2L;
+        final VmWorkAddVmToNetwork vmWorkAddVmToNetwork = new VmWorkAddVmToNetwork(0, 0, 0, "someHandler", someNetworkId, null);
+        final VmWorkJobVO vmWorkJobVO = new VmWorkJobVO("someContext");
+        vmWorkJobVO.setCmdInfo(VmWorkSerializer.serialize(vmWorkAddVmToNetwork));
+        final NetworkVO networkVO = new NetworkVO();
+        networkVO.setId(anotherNetworkId);
+
+        assertThat(new JobHelper().jobIsForSameNetwork(vmWorkJobVO, networkVO), is(false));
+    }
+
+    @Test
+    public void test_jobIsForSameNetwork_whenJobCmdInfoNetworkIdIsNull() throws Exception {
+        final long networkId = 1L;
+        final VmWorkAddVmToNetwork vmWorkAddVmToNetwork = new VmWorkAddVmToNetwork(0, 0, 0, "someHandler", null, null);
+        final VmWorkJobVO vmWorkJobVO = new VmWorkJobVO("someContext");
+        vmWorkJobVO.setCmdInfo(VmWorkSerializer.serialize(vmWorkAddVmToNetwork));
+        final NetworkVO networkVO = new NetworkVO();
+        networkVO.setId(networkId);
+
+        assertThat(new JobHelper().jobIsForSameNetwork(vmWorkJobVO, networkVO), is(false));
+    }
+
+    @Test
+    public void test_jobIsForSameNetwork_whenJobCmdInfoIsNull() throws Exception {
+        final long networkId = 1L;
+        final VmWorkJobVO vmWorkJobVO = new VmWorkJobVO("someContext");
+        final NetworkVO networkVO = new NetworkVO();
+        networkVO.setId(networkId);
+
+        assertThat(new JobHelper().jobIsForSameNetwork(vmWorkJobVO, networkVO), is(false));
+    }
+}

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
@@ -206,6 +206,10 @@ public class NetworkVO implements Network {
         uuid = UUID.randomUUID().toString();
     }
 
+    public void setId(final long id) {
+        this.id = id;
+    }
+
     @Override
     public long getId() {
         return id;

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
@@ -120,29 +120,11 @@ public class NetworkVO implements Network {
         uuid = UUID.randomUUID().toString();
     }
 
-    public NetworkVO(final long id, final Network that, final long offeringId, final String guruName, final long domainId, final long accountId, final long related, final String
-            name, final String displayText,
-                     final String networkDomain, final GuestType guestType, final long dcId, final Long physicalNetworkId, final ACLType aclType, final boolean specifyIpRanges,
-                     final Long vpcId, final boolean
-                             isRedundant) {
-        this(id,
-                that.getTrafficType(),
-                that.getMode(),
-                that.getBroadcastDomainType(),
-                offeringId,
-                domainId,
-                accountId,
-                related,
-                name,
-                displayText,
-                networkDomain,
-                guestType,
-                dcId,
-                physicalNetworkId,
-                aclType,
-                specifyIpRanges,
-                vpcId,
-                isRedundant);
+    public NetworkVO(final long id, final Network that, final long offeringId, final String guruName, final long domainId, final long accountId, final long related,
+                     final String name, final String displayText, final String networkDomain, final GuestType guestType, final long dcId, final Long physicalNetworkId,
+                     final ACLType aclType, final boolean specifyIpRanges, final Long vpcId, final boolean isRedundant) {
+        this(id, that.getTrafficType(), that.getMode(), that.getBroadcastDomainType(), offeringId, domainId, accountId, related, name, displayText, networkDomain, guestType,
+                dcId, physicalNetworkId, aclType, specifyIpRanges, vpcId, isRedundant);
         gateway = that.getGateway();
         cidr = that.getCidr();
         networkCidr = that.getNetworkCidr();
@@ -176,11 +158,10 @@ public class NetworkVO implements Network {
      * @param vpcId               TODO
      * @param dataCenterId
      */
-    public NetworkVO(final long id, final TrafficType trafficType, final Mode mode, final BroadcastDomainType broadcastDomainType, final long networkOfferingId, final long
-            domainId, final long accountId,
-                     final long related, final String name, final String displayText, final String networkDomain, final GuestType guestType, final long dcId, final Long
-                             physicalNetworkId, final ACLType aclType,
-                     final boolean specifyIpRanges, final Long vpcId, final boolean isRedundant) {
+    public NetworkVO(final long id, final TrafficType trafficType, final Mode mode, final BroadcastDomainType broadcastDomainType, final long networkOfferingId,
+                     final long domainId, final long accountId, final long related, final String name, final String displayText, final String networkDomain,
+                     final GuestType guestType, final long dcId, final Long physicalNetworkId, final ACLType aclType, final boolean specifyIpRanges, final Long vpcId,
+                     final boolean isRedundant) {
         this(trafficType, mode, broadcastDomainType, networkOfferingId, State.Allocated, dcId, physicalNetworkId, isRedundant);
         this.domainId = domainId;
         this.accountId = accountId;
@@ -207,9 +188,8 @@ public class NetworkVO implements Network {
      * @param dataCenterId
      * @param physicalNetworkId   TODO
      */
-    public NetworkVO(final TrafficType trafficType, final Mode mode, final BroadcastDomainType broadcastDomainType, final long networkOfferingId, final State state, final long
-            dataCenterId,
-                     final Long physicalNetworkId, final boolean isRedundant) {
+    public NetworkVO(final TrafficType trafficType, final Mode mode, final BroadcastDomainType broadcastDomainType, final long networkOfferingId, final State state,
+                     final long dataCenterId, final Long physicalNetworkId, final boolean isRedundant) {
         this.trafficType = trafficType;
         this.mode = mode;
         this.broadcastDomainType = broadcastDomainType;

--- a/cosmic-core/framework/config/src/main/java/org/apache/cloudstack/framework/config/ConfigKey.java
+++ b/cosmic-core/framework/config/src/main/java/org/apache/cloudstack/framework/config/ConfigKey.java
@@ -23,13 +23,13 @@ public class ConfigKey<T> {
     private final T _multiplier;
     T _value = null;
 
-    public ConfigKey(final String category, final Class<T> type, final String name, final String defaultValue, final String description, final boolean isDynamic, final Scope
-            scope) {
+    public ConfigKey(final String category, final Class<T> type, final String name, final String defaultValue, final String description, final boolean isDynamic,
+                     final Scope scope) {
         this(type, name, category, defaultValue, description, isDynamic, scope, null);
     }
 
-    public ConfigKey(final Class<T> type, final String name, final String category, final String defaultValue, final String description, final boolean isDynamic, final Scope
-            scope, final T multiplier) {
+    public ConfigKey(final Class<T> type, final String name, final String category, final String defaultValue, final String description, final boolean isDynamic,
+                     final Scope scope, final T multiplier) {
         _category = category;
         _type = type;
         _name = name;

--- a/cosmic-core/plugins/network/nicira-nvp/src/main/java/com/cloud/network/guru/NiciraNvpGuestNetworkGuru.java
+++ b/cosmic-core/plugins/network/nicira-nvp/src/main/java/com/cloud/network/guru/NiciraNvpGuestNetworkGuru.java
@@ -83,6 +83,7 @@ public class NiciraNvpGuestNetworkGuru extends GuestNetworkGuru {
 
     @Override
     protected boolean canHandle(final NetworkOffering offering, final DataCenter.NetworkType networkType, final PhysicalNetwork physicalNetwork) {
+        s_logger.debug("Checking of guru can handle request");
         // This guru handles only Guest Isolated network that supports Source nat service
         if (networkType == DataCenter.NetworkType.Advanced && isMyTrafficType(offering.getTrafficType()) && offering.getGuestType() == Network.GuestType.Isolated
                 && isMyIsolationMethod(physicalNetwork) && ntwkOfferingSrvcDao.areServicesSupportedByNetworkOffering(offering.getId(), Network.Service.Connectivity)) {

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -968,8 +968,8 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
                 }
                 network = implementedNetwork.second();
             } catch (final ResourceUnavailableException ex) {
-                s_logger.warn("Failed to implement persistent guest network " + network + "due to ", ex);
-                final CloudRuntimeException e = new CloudRuntimeException("Failed to implement persistent guest network");
+                s_logger.warn("Failed to implement persistent guest network " + network + "due to: " + ex.getMessage());
+                final CloudRuntimeException e = new CloudRuntimeException("Failed to implement persistent guest network", ex);
                 e.addProxyObject(network.getUuid(), "networkId");
                 throw e;
             }

--- a/cosmic-core/server/src/main/java/com/cloud/network/guru/ExternalGuestNetworkGuru.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/guru/ExternalGuestNetworkGuru.java
@@ -92,8 +92,7 @@ public class ExternalGuestNetworkGuru extends GuestNetworkGuru {
 
     @Override
     protected boolean canHandle(final NetworkOffering offering, final NetworkType networkType, final PhysicalNetwork physicalNetwork) {
-        // This guru handles only Guest Isolated network that supports Source
-        // nat service
+        s_logger.debug("Checking of guru can handle request");
         if (networkType == NetworkType.Advanced && isMyTrafficType(offering.getTrafficType()) && offering.getGuestType() == Network.GuestType.Isolated &&
                 isMyIsolationMethod(physicalNetwork) && !offering.isSystemOnly()) {
             return true;

--- a/cosmic-core/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
@@ -135,9 +135,15 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
             }
         }
 
-        s_logger.debug("Isolation methods '" + Arrays.toString(methods.toArray(new String[methods.size()])) + "' are not supported by this guru");
+        logMismatchInRequiredAndSupportedIsolationMethods(methods);
 
         return false;
+    }
+
+    private void logMismatchInRequiredAndSupportedIsolationMethods(final List<String> methods) {
+        final String requiredIsolationMethods = Arrays.toString(methods.toArray(new String[methods.size()]));
+        final String supportedIsolationMethods = Arrays.toString(_isolationMethods);
+        s_logger.debug("Isolation methods '" + requiredIsolationMethods + "' are not supported by this guru (supported methods are " + supportedIsolationMethods + ")");
     }
 
     public IsolationMethod[] getIsolationMethods() {

--- a/cosmic-core/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
@@ -94,7 +94,6 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
     protected NetworkDao _networkDao;
     @Inject
     protected PhysicalNetworkDao _physicalNetworkDao;
-    // Currently set to anything except STT for the Nicira integration.
     protected IsolationMethod[] _isolationMethods;
     @Inject
     ConfigurationDao _configDao;

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -2093,9 +2093,7 @@ public class VirtualNetworkApplianceManagerImpl extends ManagerBase implements V
 
     protected boolean aggregationExecution(final AggregationControlCommand.Action action, final Network network, final List<DomainRouterVO> routers)
             throws AgentUnavailableException, ResourceUnavailableException {
-
         int errors = 0;
-
         for (final DomainRouterVO router : routers) {
 
             final String routerControlIp = _routerControlHelper.getRouterControlIp(router.getId());

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
@@ -507,7 +507,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
             return true;
         } else {
             s_logger.warn("Unable to setup guest network on virtual router " + router + " is not in the right state " + router.getState());
-            throw new ResourceUnavailableException("Unable to setup guest network on the backend," + " virtual router " + router + " is not in the right state", DataCenter.class,
+            throw new ResourceUnavailableException("Unable to setup guest network on the backend, virtual router " + router + " is not in the right state", DataCenter.class,
                     router.getDataCenterId());
         }
     }


### PR DESCRIPTION
When adding multiple tiers to a VPC very fast (or at the same time) only one would be well created, although the UI would show all of them. It turns out that when adding the router to the tier network (via the job queue) once there would be a job of type add vm to network for that router, no other job would be created. 

The code is fixed by adding a check for the network ID in the existing job. IF it turns out to be a different network, a new job is created.
