### PR TITLE
Configure JVM memory via .mvn to enable mvn release

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,3 @@
+-Xms2048m
+-Xmx2048m
+-Djava.awt.headless=true


### PR DESCRIPTION
When releasing the JVM runs out of heap space. Setting the parameters on the job isn't working because the release plugin forks a new JVM (where it runs maven again) that does not inherit those parameters. This PR sets the parameters in the `.mvn/jvm.config` file, which should be respected by all maven processes.
