### PR TITLE
Include apidoc module in default profile

### DIFF
--- a/cosmic-core/pom.xml
+++ b/cosmic-core/pom.xml
@@ -17,6 +17,7 @@
 
     <modules>
         <module>api</module>
+        <module>apidoc</module>
         <module>engine/api</module>
         <module>engine/components-api</module>
         <module>engine/network</module>
@@ -204,12 +205,6 @@
             </activation>
             <modules>
                 <module>systemvm</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>developer</id>
-            <modules>
-                <module>apidoc</module>
             </modules>
         </profile>
     </profiles>


### PR DESCRIPTION
This change will enable us to stop building the project with the `developer` profile, which can still be used during development to make things simpler.
