### PR TITLE
Unset minimum jvm memory size for project

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,3 +1,2 @@
--Xms2048m
 -Xmx2048m
 -Djava.awt.headless=true


### PR DESCRIPTION
otherwise (even if start and maximum are set to the same value) there would be an error initializing the JVM saying that the start value is larger than the maximum
