### PR TITLE
Revert "Fix egress default deny to really drop"

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -155,7 +155,8 @@ class CsAcl(CsDataBag):
             # now also with logging
             if len(self.egress) > 0:
                 self.fw.append(["mangle", "", "-A ACL_OUTBOUND_%s -m limit --limit 2/second -j LOG  --log-prefix \"iptables denied: [egress] \" --log-level 4" % self.device])
-                self.fw.append(["mangle", "", "-A ACL_OUTBOUND_%s -j DROP" % self.device])
+                # intermediate deploy will not DROP because this is the current configuration. First only adding logging.
+                #self.fw.append(["mangle", "", "-A ACL_OUTBOUND_%s -j DROP" % self.device])
 
         def process(self, direction, rule_list, base):
             count = base

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -519,7 +519,7 @@ class CsIP:
                     ["filter", "", "-A FORWARD -s %s ! -d %s -j ACCEPT" % (vpccidr, vpccidr)])
                 # adding logging here for all ingress traffic at once
                 self.fw.append(
-                    ["filter", "", "-A FORWARD -m limit --limit 2/second -j LOG  --log-prefix \"iptables denied: [ingress] \" --log-level 4"])
+                    ["filter", "", "-A FORWARD -m limit --limit 2/second -j LOG  --log-prefix \"iptables denied: [ingress]\" --log-level 4"])
                 self.fw.append(
                     ["nat", "", "-A POSTROUTING -j SNAT -o %s --to-source %s" % (self.dev, self.address['public_ip'])])
 

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs_iptables_save.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs_iptables_save.py
@@ -183,7 +183,7 @@ class Tables(UserDict):
                             print(elem, file=f)
                         # not really the correct place for this, but for now it is the only working place.
                         if key == "filter" and elem.startswith("INPUT",3):
-                            print("-A INPUT -m limit --limit 2/second -j LOG --log-prefix \"iptables denied: [input] \" --log-level 4", file=f)
+                            print("-A INPUT -m limit --limit 2/second -j LOG --log-prefix \"iptables denied: [input]\" --log-level 4", file=f)
                     print("COMMIT", file=f)
 
     def put_into_tables(self, line):


### PR DESCRIPTION
Reverts MissionCriticalCloud/cosmic#67
We should enable DROP only when the LOGging has made it to a release, so people are aware. @ddegoede I reverted this, please send a new PR when it's ready to be merged.
