### PR TITLE
Make it more likely that patch-via-socket happens

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/cosmic-core/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -103,9 +103,7 @@ get_boot_params() {
             log_it "/dev/vport0p1 not loaded, perhaps guest kernel is too old." && exit 2
           fi
 
-	      local factor=2
-	      local progress=1
-		  for i in {1..5}
+		  for i in {1..120}
 		  do
 	        while read line; do
 	          if [[ $line == cmdline:* ]]; then
@@ -130,8 +128,7 @@ get_boot_params() {
                 break;
               fi
             fi
-            sleep ${progress}s
-            progress=$[ progress * factor ]
+            sleep 0.5s
 		  done
           chmod go-rwx /root/.ssh/authorized_keys
           ;;


### PR DESCRIPTION
The patch only works if `patchviasocket.py` AND `cloud-early-config` are connected to the socket at the same time. This removes most of the long sleeps and tries more often.

Instead of trying 5 times in 31 seconds (1 +2+4+8+16) we now try it 120 times in 60 seconds. The short sleeps make it more likely that both sides are connected.

It's temporarily, until the Qemu Guest Agent fix is in.
