### PR TITLE
Start Qemu Guest Agent before cloud-early-config

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/cosmic-core/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -1,12 +1,12 @@
 #!/bin/bash
 ### BEGIN INIT INFO
 # Provides:          cloud-early-config
-# Required-Start:    mountkernfs $local_fs
+# Required-Start:    qemu-guest-agent mountkernfs $local_fs
 # Required-Stop:     $local_fs
 # Should-Start:
 # Should-Stop:
-# Default-Start:     S
-# Default-Stop:      0 6
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
 # Short-Description: configure according to cmdline
 ### END INIT INFO
 


### PR DESCRIPTION
Start Qemu Guest Agent before cloud-early-config as we will soon depend on QGA in cloud-early-config.
