### PR TITLE
Fix/blocking haproxy on public interface

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -27,8 +27,8 @@ class CsAcl(CsDataBag):
     class AclIP():
         """ For type Virtual Router """
 
-        def __init__(self, obj, fw):
-            self.fw = fw.get_fw()
+        def __init__(self, obj, config):
+            self.fw = config.get_fw()
             self.direction = 'egress'
             if obj['traffic_type'] == 'Ingress':
                 self.direction = 'ingress'
@@ -142,6 +142,7 @@ class CsAcl(CsDataBag):
             self.cidr = "%s/%s" % (self.ip, self.netmask)
             if "ingress_rules" in obj.keys():
                 self.ingress = obj['ingress_rules']
+                config.set_ingress_rules(self.ip, obj['ingress_rules'])
             if "egress_rules" in obj.keys():
                 self.egress = obj['egress_rules']
             self.fw = config.get_fw()

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsConfig.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsConfig.py
@@ -16,6 +16,7 @@ class CsConfig(object):
 
     def __init__(self):
         self.fw = []
+        self.ingress_rules = {}
 
     def set_address(self):
         self.ips = CsAddress("ips", self)
@@ -34,6 +35,12 @@ class CsConfig(object):
 
     def get_fw(self):
         return self.fw
+
+    def get_ingress_rules(self, key):
+        return self.ingress_rules[key]
+
+    def set_ingress_rules(self, key, ingress_rules):
+        self.ingress_rules[key] = ingress_rules
 
     def get_logger(self):
         return self.__LOG_FILE

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsConfig.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsConfig.py
@@ -37,7 +37,9 @@ class CsConfig(object):
         return self.fw
 
     def get_ingress_rules(self, key):
-        return self.ingress_rules[key]
+        if self.ingress_rules.has_key(key):
+            return self.ingress_rules[key]
+        return None
 
     def set_ingress_rules(self, key, ingress_rules):
         self.ingress_rules[key] = ingress_rules

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsLoadBalancer.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsLoadBalancer.py
@@ -53,17 +53,23 @@ class CsLoadBalancer(CsDataBag):
             path = rules.split(':')
             ip = path[0]
             port = path[1]
-            for ingress_rule in ingress_rules:
-                if 'first_port' in ingress_rule.keys() and ingress_rule['first_port'] == int(port):
-                    firewall.append(["filter", "", "-A INPUT -i eth1 -s %s -p %s -m %s -d %s --dport %s -m state --state NEW -j ACCEPT" % (ingress_rule['cidr'], ingress_rule['type'], ingress_rule['type'], ip, port)])
+            if ingress_rules is None:
+                firewall.append(["filter", "", "-A INPUT -p tcp -m tcp -d %s --dport %s -m state --state NEW -j ACCEPT" % (ip, port)])
+            else:
+                for ingress_rule in ingress_rules:
+                    if 'first_port' in ingress_rule.keys() and ingress_rule['first_port'] == int(port):
+                        firewall.append(["filter", "", "-A INPUT -i eth1 -s %s -p %s -m %s -d %s --dport %s -m state --state NEW -j ACCEPT" % (ingress_rule['cidr'], ingress_rule['type'], ingress_rule['type'], ip, port)])
 
         for rules in stat_rules:
             path = rules.split(':')
             ip = path[0]
             port = path[1]
-            for ingress_rule in ingress_rules:
-                if 'first_port' in ingress_rule.keys() and ingress_rule['first_port'] == int(port):
-                    firewall.append(["filter", "", "-A INPUT -i eth1 -s %s -p %s -m %s -d %s --dport %s -m state --state NEW -j ACCEPT" % (ingress_rule['cidr'], ingress_rule['type'], ingress_rule['type'], ip, port)])
+            if ingress_rules is None:
+                firewall.append(["filter", "", "-A INPUT -p tcp -m tcp -d %s --dport %s -m state --state NEW -j ACCEPT" % (ip, port)])
+            else:
+                for ingress_rule in ingress_rules:
+                    if 'first_port' in ingress_rule.keys() and ingress_rule['first_port'] == int(port):
+                        firewall.append(["filter", "", "-A INPUT -i eth1 -s %s -p %s -m %s -d %s --dport %s -m state --state NEW -j ACCEPT" % (ingress_rule['cidr'], ingress_rule['type'], ingress_rule['type'], ip, port)])
 
         for rules in remove_rules:
             path = rules.split(':')

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsLoadBalancer.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsLoadBalancer.py
@@ -43,6 +43,7 @@ class CsLoadBalancer(CsDataBag):
 
     def _configure_firewall(self, add_rules, remove_rules, stat_rules):
         firewall = self.config.get_fw()
+        ingress_rules = self.config.get_ingress_rules(self.dbag['config'][0]['router_ip'])
 
         logging.debug("CsLoadBalancer:: configuring firewall. Add rules ==> %s" % add_rules)
         logging.debug("CsLoadBalancer:: configuring firewall. Remove rules ==> %s" % remove_rules)
@@ -52,13 +53,17 @@ class CsLoadBalancer(CsDataBag):
             path = rules.split(':')
             ip = path[0]
             port = path[1]
-            firewall.append(["filter", "", "-A INPUT -p tcp -m tcp -d %s --dport %s -m state --state NEW -j ACCEPT" % (ip, port)])
+            for ingress_rule in ingress_rules:
+                if 'first_port' in ingress_rule.keys() and ingress_rule['first_port'] == int(port):
+                    firewall.append(["filter", "", "-A INPUT -i eth1 -s %s -p %s -m %s -d %s --dport %s -m state --state NEW -j ACCEPT" % (ingress_rule['cidr'], ingress_rule['type'], ingress_rule['type'], ip, port)])
 
         for rules in stat_rules:
             path = rules.split(':')
             ip = path[0]
             port = path[1]
-            firewall.append(["filter", "", "-A INPUT -p tcp -m tcp -d %s --dport %s -m state --state NEW -j ACCEPT" % (ip, port)])
+            for ingress_rule in ingress_rules:
+                if 'first_port' in ingress_rule.keys() and ingress_rule['first_port'] == int(port):
+                    firewall.append(["filter", "", "-A INPUT -i eth1 -s %s -p %s -m %s -d %s --dport %s -m state --state NEW -j ACCEPT" % (ingress_rule['cidr'], ingress_rule['type'], ingress_rule['type'], ip, port)])
 
         for rules in remove_rules:
             path = rules.split(':')


### PR DESCRIPTION
This will set the correct firewall rules to allow only traffic to HAproxy VIPs based on the ingress rules.

This does need some fine tuning as now all ingress rules that match will be used to create the rules on the public interface, even for RFC1918 addresses, which does not make sense on an internet facing interface. But would break integration tests on our bubbles, needs an if statement based on the IP address on the public interface, if that one is RFC1918 than allow those ingress rules, otherwise not.

But it will now block all traffic except for what is allowed ingress rules.

Other fixes are to send the protocol in the loadbalancer.json, so we can better match protocol.

And might not work correctly on redundant routers as the router_ip and self.ip might not match.
