### PR TITLE
Fix to find /dev/vport

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/cosmic-core/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -99,8 +99,9 @@ get_boot_params() {
           sed -i "s/%/ /g" /var/cache/cloud/cmdline
           ;;
      kvm)
-          if [ ! -e /dev/vport0p1 ]; then
-            log_it "/dev/vport0p1 not loaded, perhaps guest kernel is too old." && exit 2
+          VPORT=$(find /dev/virtio-ports -type l -name '*.vport' 2>/dev/null|head -1)
+          if [ ! -e "$VPORT" ]; then
+            log_it "/dev/virtio-ports not loaded, perhaps guest kernel is too old." && exit 2
           fi
 
 		  for i in {1..120}
@@ -114,7 +115,7 @@ get_boot_params() {
 	            echo $pubkey > /var/cache/cloud/authorized_keys
 	            echo $pubkey > /root/.ssh/authorized_keys
               fi
-            done < /dev/vport0p1
+            done < $VPORT
             # In case of reboot of secstoragevm or consoleproxyvm we do not send the boot args again.
             # So, no need to wait for them, as the boot args are already set at startup
             # Routers and VPC do get new boot args (new linklocal address) so we should wait for it


### PR DESCRIPTION
The old script assumes there is always /dev/vport0p1 which is not the case with the new kernel. This fix just finds the vport in /dev/virtio-ports.
