### PR TITLE
Add errorhandling in the systemvm startup cmd

### DIFF
--- a/cosmic-core/plugins/hypervisor/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -4470,7 +4470,7 @@ public class LibvirtComputingResourceTest {
             when(nic.getIp()).thenReturn(controlIp);
             when(nic.getType()).thenReturn(TrafficType.Control);
             when(libvirtComputingResource.getVirtRouterResource()).thenReturn(virtRouterResource);
-            when(virtRouterResource.connect(controlIp, 1, 5000)).thenReturn(true);
+            when(virtRouterResource.connect(controlIp, 30, 5000)).thenReturn(true);
         } catch (final InternalErrorException e) {
             fail(e.getMessage());
         } catch (final LibvirtException e) {
@@ -4545,7 +4545,7 @@ public class LibvirtComputingResourceTest {
             when(nic.getIp()).thenReturn(controlIp);
             when(nic.getType()).thenReturn(TrafficType.Control);
             when(libvirtComputingResource.getVirtRouterResource()).thenReturn(virtRouterResource);
-            when(virtRouterResource.connect(controlIp, 1, 5000)).thenReturn(true);
+            when(virtRouterResource.connect(controlIp, 30, 5000)).thenReturn(true);
         } catch (final InternalErrorException e) {
             fail(e.getMessage());
         } catch (final LibvirtException e) {


### PR DESCRIPTION
- Run the script to send the cmdline info (using QGA) until it succeeds, then stop
- When it fails, return an error
- When unable to login to linklocal address, return an error

This prevents systemvms that end up in Running state, while something went wrong.
