### PR TITLE
Use force stop to speed up tests

### DIFF
--- a/cosmic-core/test/integration/smoke/test_privategw_acl.py
+++ b/cosmic-core/test/integration/smoke/test_privategw_acl.py
@@ -424,6 +424,7 @@ class TestPrivateGwACL(cloudstackTestCase):
         self.logger.debug('Stopping router %s' % router.id)
         cmd = stopRouter.stopRouterCmd()
         cmd.id = router.id
+        cmd.forced = "true"
         self.apiclient.stopRouter(cmd)
 
     def start_routers(self, routers):

--- a/cosmic-core/test/integration/smoke/test_routers.py
+++ b/cosmic-core/test/integration/smoke/test_routers.py
@@ -663,6 +663,7 @@ class TestRouterServices(cloudstackTestCase):
         # Stop the router
         cmd = stopRouter.stopRouterCmd()
         cmd.id = router.id
+        cmd.forced = "true"
         self.apiclient.stopRouter(cmd)
 
         # List routers to check state of router

--- a/cosmic-core/test/integration/smoke/test_routers_iptables_default_policy.py
+++ b/cosmic-core/test/integration/smoke/test_routers_iptables_default_policy.py
@@ -606,6 +606,7 @@ class EntityManager(object):
         for router in self.routers:
             self.stop_router(router)
             cmd = destroyRouter.destroyRouterCmd()
+            cmd.forced = "true"
             cmd.id = router.id
             self.apiclient.destroyRouter(cmd)
         self.routers = []

--- a/cosmic-core/test/integration/smoke/test_ssvm.py
+++ b/cosmic-core/test/integration/smoke/test_ssvm.py
@@ -459,6 +459,7 @@ class TestSSVMs(cloudstackTestCase):
         self.logger.debug("Stopping System VM: %s" % svm.id)
         cmd = stopSystemVm.stopSystemVmCmd()
         cmd.id = svm.id
+        cmd.forced = "true"
         self.apiclient.stopSystemVm(cmd)
         self.wait_for_svm_state(svm.id, 'Stopped', self.services["timeout"], self.services["sleep"])
 

--- a/cosmic-core/test/integration/smoke/test_vpc_redundant.py
+++ b/cosmic-core/test/integration/smoke/test_vpc_redundant.py
@@ -394,6 +394,7 @@ class TestVPCRedundancy(cloudstackTestCase):
         self.logger.debug('Stopping router %s' % router.id)
         cmd = stopRouter.stopRouterCmd()
         cmd.id = router.id
+        cmd.forced = "true"
         self.apiclient.stopRouter(cmd)
 
     def reboot_router(self, router):

--- a/cosmic-core/test/integration/smoke/test_vpc_router_nics.py
+++ b/cosmic-core/test/integration/smoke/test_vpc_router_nics.py
@@ -269,6 +269,7 @@ class TestVPCNics(cloudstackTestCase):
         self.logger.debug('Stopping router')
         cmd = stopRouter.stopRouterCmd()
         cmd.id = router.id
+        cmd.forced = "true"
         self.apiclient.stopRouter(cmd)
 
     def destroy_routers(self):


### PR DESCRIPTION
Use force stop to speed up tests (will improve once the force option fully works).
