### PR TITLE
Improve force stopping VMs

### DIFF
--- a/cosmic-core/engine/api/src/main/java/com/cloud/vm/VirtualMachineManager.java
+++ b/cosmic-core/engine/api/src/main/java/com/cloud/vm/VirtualMachineManager.java
@@ -91,6 +91,8 @@ public interface VirtualMachineManager extends Manager {
 
     void destroy(String vmUuid) throws AgentUnavailableException, OperationTimedoutException, ConcurrentOperationException;
 
+    void stopForced(String vmUuid) throws ResourceUnavailableException;
+
     void migrateAway(String vmUuid, long hostId) throws InsufficientServerCapacityException;
 
     void migrate(String vmUuid, long srcHostId, DeployDestination dest) throws ResourceUnavailableException, ConcurrentOperationException;

--- a/cosmic-core/engine/api/src/main/java/com/cloud/vm/VirtualMachineManager.java
+++ b/cosmic-core/engine/api/src/main/java/com/cloud/vm/VirtualMachineManager.java
@@ -69,8 +69,6 @@ public interface VirtualMachineManager extends Manager {
 
     void stop(String vmUuid) throws ResourceUnavailableException;
 
-    void stop(String vmUuid, boolean forced) throws ResourceUnavailableException;
-
     void expunge(String vmUuid) throws ResourceUnavailableException;
 
     void registerGuru(VirtualMachine.Type type, VirtualMachineGuru guru);

--- a/cosmic-core/engine/api/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VirtualMachineEntity.java
+++ b/cosmic-core/engine/api/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VirtualMachineEntity.java
@@ -67,6 +67,11 @@ public interface VirtualMachineEntity extends CloudStackEntity {
     boolean stop(String caller) throws CloudException;
 
     /**
+     * Stop the virtual machine, by force if necessary
+     */
+    boolean stopForced(String caller) throws ResourceUnavailableException, CloudException;
+
+    /**
      * Cleans up after any botched starts.  CloudStack Orchestration Platform
      * will attempt a best effort to actually shutdown any resource but
      * even if it cannot, it releases the resource from its database.

--- a/cosmic-core/engine/api/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VirtualMachineEntity.java
+++ b/cosmic-core/engine/api/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VirtualMachineEntity.java
@@ -67,11 +67,6 @@ public interface VirtualMachineEntity extends CloudStackEntity {
     boolean stop(String caller) throws CloudException;
 
     /**
-     * Stop the virtual machine, optionally force
-     */
-    boolean stop(String caller, boolean forced) throws ResourceUnavailableException, CloudException;
-
-    /**
      * Cleans up after any botched starts.  CloudStack Orchestration Platform
      * will attempt a best effort to actually shutdown any resource but
      * even if it cannot, it releases the resource from its database.

--- a/cosmic-core/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/cosmic-core/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2617,6 +2617,17 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         }
     }
 
+    @Override
+    public void stopForced(String vmUuid) throws ResourceUnavailableException {
+        try {
+            advanceStop(vmUuid, true);
+        } catch (final OperationTimedoutException e) {
+            throw new AgentUnavailableException("Unable to stop vm because the operation to stop timed out", e.getAgentId(), e);
+        } catch (final ConcurrentOperationException e) {
+            throw new CloudRuntimeException("Unable to stop vm because of a concurrent operation", e);
+        }
+    }
+
     public Command cleanup(final String vmName) {
         return new StopCommand(vmName, getExecuteInSequence(null), false);
     }

--- a/cosmic-core/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/cosmic-core/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2608,13 +2608,8 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
 
     @Override
     public void stop(final String vmUuid) throws ResourceUnavailableException {
-        stop(vmUuid, false);
-    }
-
-    @Override
-    public void stop(String vmUuid, boolean forced) throws ResourceUnavailableException {
         try {
-            advanceStop(vmUuid, forced);
+            advanceStop(vmUuid, false);
         } catch (final OperationTimedoutException e) {
             throw new AgentUnavailableException("Unable to stop vm because the operation to stop timed out", e.getAgentId(), e);
         } catch (final ConcurrentOperationException e) {

--- a/cosmic-core/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManager.java
+++ b/cosmic-core/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManager.java
@@ -27,5 +27,7 @@ public interface VMEntityManager {
 
     boolean stopvirtualmachine(VMEntityVO vmEntityVO, String caller) throws ResourceUnavailableException;
 
+    boolean stopvirtualmachineforced(VMEntityVO vmEntityVO, String caller) throws ResourceUnavailableException;
+
     boolean destroyVirtualMachine(VMEntityVO vmEntityVO, String caller) throws AgentUnavailableException, OperationTimedoutException, ConcurrentOperationException;
 }

--- a/cosmic-core/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManager.java
+++ b/cosmic-core/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManager.java
@@ -27,7 +27,5 @@ public interface VMEntityManager {
 
     boolean stopvirtualmachine(VMEntityVO vmEntityVO, String caller) throws ResourceUnavailableException;
 
-    boolean stopvirtualmachine(VMEntityVO vmEntityVO, String caller, boolean forced) throws ResourceUnavailableException;
-
     boolean destroyVirtualMachine(VMEntityVO vmEntityVO, String caller) throws AgentUnavailableException, OperationTimedoutException, ConcurrentOperationException;
 }

--- a/cosmic-core/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManagerImpl.java
+++ b/cosmic-core/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManagerImpl.java
@@ -250,6 +250,12 @@ public class VMEntityManagerImpl implements VMEntityManager {
     }
 
     @Override
+    public boolean stopvirtualmachineforced(VMEntityVO vmEntityVO, String caller) throws ResourceUnavailableException {
+        _itMgr.stopForced(vmEntityVO.getUuid());
+        return true;
+    }
+
+    @Override
     public boolean destroyVirtualMachine(final VMEntityVO vmEntityVO, final String caller) throws AgentUnavailableException, OperationTimedoutException,
             ConcurrentOperationException {
 

--- a/cosmic-core/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManagerImpl.java
+++ b/cosmic-core/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManagerImpl.java
@@ -250,12 +250,6 @@ public class VMEntityManagerImpl implements VMEntityManager {
     }
 
     @Override
-    public boolean stopvirtualmachine(VMEntityVO vmEntityVO, String caller, boolean forced) throws ResourceUnavailableException {
-        _itMgr.stop(vmEntityVO.getUuid(), forced);
-        return true;
-    }
-
-    @Override
     public boolean destroyVirtualMachine(final VMEntityVO vmEntityVO, final String caller) throws AgentUnavailableException, OperationTimedoutException,
             ConcurrentOperationException {
 

--- a/cosmic-core/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VirtualMachineEntityImpl.java
+++ b/cosmic-core/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VirtualMachineEntityImpl.java
@@ -135,6 +135,11 @@ public class VirtualMachineEntityImpl implements VirtualMachineEntity {
     }
 
     @Override
+    public boolean stopForced(String caller) throws ResourceUnavailableException {
+        return manager.stopvirtualmachineforced(this.vmEntityVO, caller);
+    }
+
+    @Override
     public void cleanup() {
         // TODO Auto-generated method stub
 

--- a/cosmic-core/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VirtualMachineEntityImpl.java
+++ b/cosmic-core/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VirtualMachineEntityImpl.java
@@ -135,11 +135,6 @@ public class VirtualMachineEntityImpl implements VirtualMachineEntity {
     }
 
     @Override
-    public boolean stop(String caller, boolean forced) throws ResourceUnavailableException {
-        return manager.stopvirtualmachine(this.vmEntityVO, caller, forced);
-    }
-
-    @Override
     public void cleanup() {
         // TODO Auto-generated method stub
 

--- a/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -2786,7 +2786,13 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         boolean status = false;
         try {
             final VirtualMachineEntity vmEntity = _orchSrvc.getVirtualMachine(vm.getUuid());
-            status = vmEntity.stop(Long.toString(userId));
+
+            if(forced) {
+                status = vmEntity.stopForced(Long.toString(userId));
+            } else {
+                status = vmEntity.stop(Long.toString(userId));
+            }
+
             if (status) {
                 return _vmDao.findById(vmId);
             } else {

--- a/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -2786,7 +2786,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         boolean status = false;
         try {
             final VirtualMachineEntity vmEntity = _orchSrvc.getVirtualMachine(vm.getUuid());
-            status = vmEntity.stop(Long.toString(userId), forced);
+            status = vmEntity.stop(Long.toString(userId));
             if (status) {
                 return _vmDao.findById(vmId);
             } else {

--- a/cosmic-core/test/integration/smoke/test_privategw_acl.py
+++ b/cosmic-core/test/integration/smoke/test_privategw_acl.py
@@ -424,6 +424,7 @@ class TestPrivateGwACL(cloudstackTestCase):
         self.logger.debug('Stopping router %s' % router.id)
         cmd = stopRouter.stopRouterCmd()
         cmd.id = router.id
+        cmd.forced = "true"
         self.apiclient.stopRouter(cmd)
 
     def start_routers(self, routers):

--- a/cosmic-core/test/integration/smoke/test_routers.py
+++ b/cosmic-core/test/integration/smoke/test_routers.py
@@ -663,6 +663,7 @@ class TestRouterServices(cloudstackTestCase):
         # Stop the router
         cmd = stopRouter.stopRouterCmd()
         cmd.id = router.id
+        cmd.forced = "true"
         self.apiclient.stopRouter(cmd)
 
         # List routers to check state of router

--- a/cosmic-core/test/integration/smoke/test_routers_iptables_default_policy.py
+++ b/cosmic-core/test/integration/smoke/test_routers_iptables_default_policy.py
@@ -606,6 +606,7 @@ class EntityManager(object):
         for router in self.routers:
             self.stop_router(router)
             cmd = destroyRouter.destroyRouterCmd()
+            cmd.forced = "true"
             cmd.id = router.id
             self.apiclient.destroyRouter(cmd)
         self.routers = []

--- a/cosmic-core/test/integration/smoke/test_ssvm.py
+++ b/cosmic-core/test/integration/smoke/test_ssvm.py
@@ -459,6 +459,7 @@ class TestSSVMs(cloudstackTestCase):
         self.logger.debug("Stopping System VM: %s" % svm.id)
         cmd = stopSystemVm.stopSystemVmCmd()
         cmd.id = svm.id
+        cmd.forced = "true"
         self.apiclient.stopSystemVm(cmd)
         self.wait_for_svm_state(svm.id, 'Stopped', self.services["timeout"], self.services["sleep"])
 

--- a/cosmic-core/test/integration/smoke/test_vpc_redundant.py
+++ b/cosmic-core/test/integration/smoke/test_vpc_redundant.py
@@ -394,6 +394,7 @@ class TestVPCRedundancy(cloudstackTestCase):
         self.logger.debug('Stopping router %s' % router.id)
         cmd = stopRouter.stopRouterCmd()
         cmd.id = router.id
+        cmd.forced = "true"
         self.apiclient.stopRouter(cmd)
 
     def reboot_router(self, router):

--- a/cosmic-core/test/integration/smoke/test_vpc_router_nics.py
+++ b/cosmic-core/test/integration/smoke/test_vpc_router_nics.py
@@ -269,6 +269,7 @@ class TestVPCNics(cloudstackTestCase):
         self.logger.debug('Stopping router')
         cmd = stopRouter.stopRouterCmd()
         cmd.id = router.id
+        cmd.forced = "true"
         self.apiclient.stopRouter(cmd)
 
     def destroy_routers(self):


### PR DESCRIPTION
Builds on top of PR #85 (has same commit).

The rest is revert of an earlier approach and backport of ACS PR.

It seems "force stop" is now done only when the normal stop fails (after 120 sec). Immediately killing the VM doesn't work yet (as does work on destroy/expunge). At least this prevents waiting very long for a VM to shut down.
