### PR TITLE
Prevent connecting without working storage

### DIFF
--- a/cosmic-core/engine/orchestration/src/test/java/com/cloud/agent/manager/AgentManagerImplTest.java
+++ b/cosmic-core/engine/orchestration/src/test/java/com/cloud/agent/manager/AgentManagerImplTest.java
@@ -1,0 +1,70 @@
+package com.cloud.agent.manager;
+
+import com.cloud.agent.Listener;
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.ReadyCommand;
+import com.cloud.agent.api.StartupCommand;
+import com.cloud.agent.api.StartupRoutingCommand;
+import com.cloud.exception.ConnectionException;
+import com.cloud.host.HostVO;
+import com.cloud.host.Status;
+import com.cloud.host.dao.HostDao;
+import com.cloud.utils.Pair;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+
+public class AgentManagerImplTest {
+
+    private HostDao hostDao;
+    private Listener storagePoolMonitor;
+    private AgentAttache attache;
+    private AgentManagerImpl mgr = Mockito.spy(new AgentManagerImpl());
+    private HostVO host;
+    private StartupCommand[] cmds;
+
+    @Before
+    public void setUp() throws Exception {
+        host = new HostVO("some-Uuid");
+        host.setDataCenterId(1L);
+        cmds = new StartupCommand[]{new StartupRoutingCommand()};
+        attache = new ConnectedAgentAttache(null, 1L, "kvm-attache", null, false);
+
+        hostDao = Mockito.mock(HostDao.class);
+        storagePoolMonitor = Mockito.mock(Listener.class);
+
+        mgr._hostDao = hostDao;
+        mgr._hostMonitors = new ArrayList<>();
+        mgr._hostMonitors.add(new Pair<>(0, storagePoolMonitor));
+    }
+
+    @Test
+    public void testNotifyMonitorsOfConnectionNormal() throws ConnectionException {
+        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(host);
+        Mockito.doNothing().when(storagePoolMonitor).processConnect(Mockito.eq(host), Mockito.eq(cmds[0]), Mockito.eq(false));
+        Mockito.doReturn(true).when(mgr).handleDisconnectWithoutInvestigation(Mockito.any(attache.getClass()), Mockito.any(Status.Event.class), Mockito.anyBoolean(), Mockito.anyBoolean());
+        Mockito.doReturn(Mockito.mock(Answer.class)).when(mgr).easySend(Mockito.anyLong(), Mockito.any(ReadyCommand.class));
+        Mockito.doReturn(true).when(mgr).agentStatusTransitTo(Mockito.eq(host), Mockito.eq(Status.Event.Ready), Mockito.anyLong());
+
+        final AgentAttache agentAttache = mgr.notifyMonitorsOfConnection(attache, cmds, false);
+        Assert.assertTrue(agentAttache.isReady()); // Agent is in UP state
+    }
+
+    @Test
+    public void testNotifyMonitorsOfConnectionWhenStoragePoolConnectionHostFailure() throws ConnectionException {
+        ConnectionException connectionException = new ConnectionException(true, "storage pool could not be connected on host");
+        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(host);
+        Mockito.doThrow(connectionException).when(storagePoolMonitor).processConnect(Mockito.eq(host), Mockito.eq(cmds[0]), Mockito.eq(false));
+        Mockito.doReturn(true).when(mgr).handleDisconnectWithoutInvestigation(Mockito.any(attache.getClass()), Mockito.any(Status.Event.class), Mockito.anyBoolean(), Mockito.anyBoolean());
+        try {
+            mgr.notifyMonitorsOfConnection(attache, cmds, false);
+            Assert.fail("Connection Exception was expected");
+        } catch (ConnectionException e) {
+            Assert.assertEquals(e.getMessage(), connectionException.getMessage());
+        }
+        Mockito.verify(mgr, Mockito.times(1)).handleDisconnectWithoutInvestigation(Mockito.any(attache.getClass()), Mockito.eq(Status.Event.AgentDisconnected), Mockito.eq(true), Mockito.eq(true));
+    }
+}

--- a/cosmic-core/server/src/main/java/com/cloud/storage/listener/StoragePoolMonitor.java
+++ b/cosmic-core/server/src/main/java/com/cloud/storage/listener/StoragePoolMonitor.java
@@ -79,12 +79,12 @@ public class StoragePoolMonitor implements Listener {
                     }
 
                     final Long hostId = host.getId();
-                    s_logger.debug("Host " + hostId + " connected, sending down storage pool information ...");
+                    s_logger.debug("Host " + hostId + " connected, connecting host to shared pool id " + pool.getId() + " and sending storage pool information ...");
                     try {
                         _storageManager.connectHostToSharedPool(hostId, pool.getId());
                         _storageManager.createCapacityEntry(pool.getId());
                     } catch (final Exception e) {
-                        s_logger.warn("Unable to connect host " + hostId + " to pool " + pool + " due to " + e.toString(), e);
+                        throw new ConnectionException(true, "Unable to connect host " + hostId + " to storage pool id " + pool.getId() + " due to " + e.toString(), e);
                     }
                 }
             }

--- a/cosmic-core/server/src/test/java/com/cloud/storage/listener/StoragePoolMonitorTest.java
+++ b/cosmic-core/server/src/test/java/com/cloud/storage/listener/StoragePoolMonitorTest.java
@@ -1,0 +1,64 @@
+package com.cloud.storage.listener;
+
+import com.cloud.agent.api.StartupRoutingCommand;
+import com.cloud.exception.ConnectionException;
+import com.cloud.exception.StorageUnavailableException;
+import com.cloud.host.HostVO;
+import com.cloud.hypervisor.Hypervisor;
+import com.cloud.storage.ScopeType;
+import com.cloud.storage.StorageManagerImpl;
+import com.cloud.storage.StoragePoolStatus;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+public class StoragePoolMonitorTest {
+
+    private StorageManagerImpl storageManager;
+    private PrimaryDataStoreDao poolDao;
+    private StoragePoolMonitor storagePoolMonitor;
+    private HostVO host;
+    private StoragePoolVO pool;
+    private StartupRoutingCommand cmd;
+
+    @Before
+    public void setUp() throws Exception {
+        storageManager = Mockito.mock(StorageManagerImpl.class);
+        poolDao = Mockito.mock(PrimaryDataStoreDao.class);
+
+        storagePoolMonitor = new StoragePoolMonitor(storageManager, poolDao);
+        host = new HostVO("some-uuid");
+        pool = new StoragePoolVO();
+        pool.setScope(ScopeType.CLUSTER);
+        pool.setStatus(StoragePoolStatus.Up);
+        pool.setId(123L);
+        cmd = new StartupRoutingCommand();
+        cmd.setHypervisorType(Hypervisor.HypervisorType.KVM);
+    }
+
+    @Test
+    public void testProcessConnectStoragePoolNormal() throws Exception {
+        Mockito.when(poolDao.listBy(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong(), Mockito.any(ScopeType.class))).thenReturn(Collections.singletonList(pool));
+        Mockito.when(poolDao.findZoneWideStoragePoolsByTags(Mockito.anyLong(), Mockito.any(String[].class))).thenReturn(Collections.<StoragePoolVO>emptyList());
+        Mockito.when(poolDao.findZoneWideStoragePoolsByHypervisor(Mockito.anyLong(), Mockito.any(Hypervisor.HypervisorType.class))).thenReturn(Collections.<StoragePoolVO>emptyList());
+
+        storagePoolMonitor.processConnect(host, cmd, false);
+
+        Mockito.verify(storageManager, Mockito.times(1)).connectHostToSharedPool(Mockito.eq(host.getId()), Mockito.eq(pool.getId()));
+        Mockito.verify(storageManager, Mockito.times(1)).createCapacityEntry(Mockito.eq(pool.getId()));
+    }
+
+    @Test(expected = ConnectionException.class)
+    public void testProcessConnectStoragePoolFailureOnHost() throws Exception {
+        Mockito.when(poolDao.listBy(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong(), Mockito.any(ScopeType.class))).thenReturn(Collections.singletonList(pool));
+        Mockito.when(poolDao.findZoneWideStoragePoolsByTags(Mockito.anyLong(), Mockito.any(String[].class))).thenReturn(Collections.<StoragePoolVO>emptyList());
+        Mockito.when(poolDao.findZoneWideStoragePoolsByHypervisor(Mockito.anyLong(), Mockito.any(Hypervisor.HypervisorType.class))).thenReturn(Collections.<StoragePoolVO>emptyList());
+        Mockito.doThrow(new StorageUnavailableException("unable to mount storage", 123L)).when(storageManager).connectHostToSharedPool(Mockito.anyLong(), Mockito.anyLong());
+
+        storagePoolMonitor.processConnect(host, cmd, false);
+    }
+}


### PR DESCRIPTION
Agent should be not be in Up state when its storage is not working. Backport from ACS PR 1694.
