### PR TITLE
Remove API responses from logfiles

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/api/ApiServer.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/ApiServer.java
@@ -576,11 +576,6 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
                 SerializationContext.current().setUuidTranslation(true);
                 response = getBaseAsyncResponse(jobId, asyncCmd);
             }
-            // Always log response for async for now, I don't think any sensitive data will be in here.
-            // It might be nice to send this through scrubbing similar to how
-            // ApiResponseSerializer.toSerializedStringWithSecureLogs works. For now, this gets jobid's
-            // in the api logs.
-            log.append(response);
             return response;
         } else {
             _dispatcher.dispatch(cmdObj, params, false);


### PR DESCRIPTION
Very large responses flood the logs and make it hard to scroll through it and see what's actually going on.
