### PR TITLE
adding protocol and destination to LB rules

### DIFF
--- a/cosmic-core/nucleo/src/main/java/com/cloud/network/HAProxyConfigurator.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/network/HAProxyConfigurator.java
@@ -639,6 +639,15 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
             final StringBuilder sb = new StringBuilder();
             sb.append(lbTO.getSrcIp()).append(":");
             sb.append(lbTO.getSrcPort()).append(":");
+            sb.append(lbTO.getProtocol()).append(":");
+            for (final DestinationTO dest : lbTO.getDestinations()) {
+                // add dst entry like this: "10.1.1.4:80"
+                if (dest.isRevoked()) {
+                    continue;
+                }
+                sb.append(dest.getDestIp()).append(":");
+                sb.append(dest.getDestPort()).append(":");
+            }
             final String lbRuleEntry = sb.toString();
             if (!lbTO.isRevoked()) {
                 toAdd.add(lbRuleEntry);

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsLoadBalancer.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsLoadBalancer.py
@@ -53,27 +53,29 @@ class CsLoadBalancer(CsDataBag):
             path = rules.split(':')
             ip = path[0]
             port = path[1]
+            protocol = path[2]
+            dstport = path[4]
             if ingress_rules is None:
-                firewall.append(["filter", "", "-A INPUT -p tcp -m tcp -d %s --dport %s -m state --state NEW -j ACCEPT" % (ip, port)])
+                firewall.append(["filter", "", "-A INPUT -p %s -d %s --dport %s -m state --state NEW -j ACCEPT" % (protocol, ip, port)])
             else:
                 for ingress_rule in ingress_rules:
-                    if 'first_port' in ingress_rule.keys() and ingress_rule['first_port'] == int(port):
-                        firewall.append(["filter", "", "-A INPUT -i eth1 -s %s -p %s -m %s -d %s --dport %s -m state --state NEW -j ACCEPT" % (ingress_rule['cidr'], ingress_rule['type'], ingress_rule['type'], ip, port)])
+                    if 'first_port' in ingress_rule.keys() and 'type' in ingress_rule.keys() and ingress_rule['first_port'] == int(dstport) and ingress_rule['type'] == protocol:
+                        firewall.append(["filter", "", "-A INPUT -i eth1 -s %s -p %s -d %s --dport %s -m state --state NEW -j ACCEPT" % (ingress_rule['cidr'], protocol, ip, port)])
 
         for rules in stat_rules:
             path = rules.split(':')
             ip = path[0]
             port = path[1]
             if ingress_rules is None:
-                firewall.append(["filter", "", "-A INPUT -p tcp -m tcp -d %s --dport %s -m state --state NEW -j ACCEPT" % (ip, port)])
+                firewall.append(["filter", "", "-A INPUT -p tcp -d %s --dport %s -m state --state NEW -j ACCEPT" % (ip, port)])
             else:
                 for ingress_rule in ingress_rules:
                     if 'first_port' in ingress_rule.keys() and ingress_rule['first_port'] == int(port):
-                        firewall.append(["filter", "", "-A INPUT -i eth1 -s %s -p %s -m %s -d %s --dport %s -m state --state NEW -j ACCEPT" % (ingress_rule['cidr'], ingress_rule['type'], ingress_rule['type'], ip, port)])
+                        firewall.append(["filter", "", "-A INPUT -i eth1 -s %s -p %s -d %s --dport %s -m state --state NEW -j ACCEPT" % (ingress_rule['cidr'], ingress_rule['type'], ip, port)])
 
         for rules in remove_rules:
             path = rules.split(':')
             ip = path[0]
             port = path[1]
-            if ["filter", "", "-A INPUT -p tcp -m tcp -d %s --dport %s -m state --state NEW -j ACCEPT" % (ip, port)] in firewall:
-                firewall.remove(["filter", "", "-A INPUT -p tcp -m tcp -d %s --dport %s -m state --state NEW -j ACCEPT" % (ip, port)])
+            if ["filter", "", "-A INPUT -p tcp -d %s --dport %s -m state --state NEW -j ACCEPT" % (ip, port)] in firewall:
+                firewall.remove(["filter", "", "-A INPUT -p tcp -d %s --dport %s -m state --state NEW -j ACCEPT" % (ip, port)])

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsLoadBalancer.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsLoadBalancer.py
@@ -54,8 +54,12 @@ class CsLoadBalancer(CsDataBag):
             ip = path[0]
             port = path[1]
             protocol = path[2]
-            dstport = path[4]
-            if ingress_rules is None:
+            if len(path) > 4:
+                dstport = path[4]
+            else:
+                dstport = None
+
+            if ingress_rules is None or dstport is None:
                 firewall.append(["filter", "", "-A INPUT -p %s -d %s --dport %s -m state --state NEW -j ACCEPT" % (protocol, ip, port)])
             else:
                 for ingress_rule in ingress_rules:


### PR DESCRIPTION
both protocol and private port of the haproxy rule need to match
the start port and protocol of an ingress rule, CIDR list is then allowed
access on the public interface for the protocol and LB public port.
