### PR TITLE
Removed IP address checking on jump to inbound and outbound chain

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -428,8 +428,8 @@ class CsIP:
 
         if self.get_type() in ["guest"]:
             guestNetworkCidr = self.address['network']
-            self.fw.append(["filter", "", "-A FORWARD -d %s -o %s -j ACL_INBOUND_%s" %
-                            (guestNetworkCidr, self.dev, self.dev)])
+            self.fw.append(["filter", "", "-A FORWARD -o %s -j ACL_INBOUND_%s" %
+                            (self.dev, self.dev)])
             self.fw.append(
                 ["filter", "front", "-A ACL_INBOUND_%s -d 224.0.0.18/32 -j ACCEPT" % self.dev])
             self.fw.append(
@@ -459,8 +459,8 @@ class CsIP:
                 ["filter", "", "-A INPUT -i %s -p tcp -m tcp --dport 80 -m state --state NEW -j ACCEPT" % self.dev])
             self.fw.append(
                 ["filter", "", "-A INPUT -i %s -p tcp -m tcp --dport 8080 -m state --state NEW -j ACCEPT" % self.dev])
-            self.fw.append(["mangle", "", "-A PREROUTING -m state --state NEW -i %s -s %s ! -d %s -j ACL_OUTBOUND_%s" % (
-                self.dev, self.address['network'], self.address['network'], self.dev)])
+            self.fw.append(["mangle", "", "-A PREROUTING -m state --state NEW -i %s ! -d %s -j ACL_OUTBOUND_%s" % (
+                self.dev, self.address['network'], self.dev)])
             self.fw.append(["", "front", "-A NETWORK_STATS_%s -o %s -s %s" %
                             ("eth1", "eth1", guestNetworkCidr)])
             self.fw.append(["", "front", "-A NETWORK_STATS_%s -o %s -d %s" %


### PR DESCRIPTION
Since we now allow routing towards devices within the network tier,
we cannot use the network cidr as a valid check before we jump to the
inbound or outbound chain. Only the interface is a valid parameter.