### PR TITLE
Fix race condition where QGA writes incoming file before cloud-early-config deletes old version

### DIFF
--- a/cosmic-core/scripts/src/main/resources/scripts/vm/hypervisor/kvm/send_config_properties_to_systemvm.py
+++ b/cosmic-core/scripts/src/main/resources/scripts/vm/hypervisor/kvm/send_config_properties_to_systemvm.py
@@ -121,4 +121,6 @@ if __name__ == "__main__":
     compare_write_read(AUTHORIZED_KEYS_FILE_CACHE, write_count, read_count)
 
     # write file when done
-    write_file(CMDLINE_INCOMING, "DONE")
+    write_count = write_file(CMDLINE_INCOMING, "DONE")
+    read_count = read_guest_file(CMDLINE_INCOMING, write_count)
+    compare_write_read(CMDLINE_INCOMING, write_count, read_count)

--- a/cosmic-core/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/cosmic-core/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -122,7 +122,7 @@ get_boot_params() {
         CMDLINE_FILE_INCOMING=/var/cache/cloud/cmdline_incoming
 
         log_it "Waiting for a new ${CMDLINE_FILE_INCOMING} file to arrive.. (dots show progress)"
-        rm -f ${CMDLINE_FILE_INCOMING} >/dev/null 2>&1
+        find ${CMDLINE_FILE_INCOMING} -mmin +10 -type f -delete
         sleep 1
 
         sleep_times=0

--- a/cosmic-core/systemvm/patches/debian/config/etc/rc.local
+++ b/cosmic-core/systemvm/patches/debian/config/etc/rc.local
@@ -30,6 +30,9 @@ fi
 date > /var/cache/cloud/boot_up_done
 logger -t cloud "Boot up process done"
 
+logger -t cloud "Clearing the cmdline_incoming file"
+rm -f /var/cache/cloud/cmdline_incoming >/dev/null 2>&1
+
 #Restore the persistent iptables nat, rules and filters for IPv4 and IPv6 if they exist
 ipv4="/etc/iptables/router_rules.v4"
 if [ -e $ipv4 ]


### PR DESCRIPTION
Seen on templates that have QGA started before cloud-early-config.

This PR makes sure to delete only `incoming` files that are older than 10m and thus belong to a previous boot cycle.