### PR TITLE
publicLoadBalancerProvider info is not used when creating a VPC

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/network.js
+++ b/cosmic-client/src/main/webapp/scripts/network.js
@@ -635,19 +635,6 @@
                                         label: 'label.DNS.domain.for.guest.networks'
                                         //format: FQDN
                                     },
-                                    publicLoadBalancerProvider: {
-                                        label: 'label.public.load.balancer.provider',
-                                        select: function (args) {
-                                            var items = [];
-                                            items.push({
-                                                id: 'VpcVirtualRouter',
-                                                description: 'VpcVirtualRouter'
-                                            });
-                                            args.response.success({
-                                                data: items
-                                            });
-                                        }
-                                    },
                                     vpcoffering: {
                                         label: 'label.vpc.offering',
                                         validation: {


### PR DESCRIPTION
Backport of PR 756 of ACS