### PR TITLE
Simplify KVM Guest OS'es and their virtual hardware types (VirtIO or not)

### DIFF
--- a/cosmic-core/db-scripts/src/main/resources/db/schema-511to520.sql
+++ b/cosmic-core/db-scripts/src/main/resources/db/schema-511to520.sql
@@ -1,3 +1,60 @@
 --;
 -- Schema upgrade from 5.1.1 to 5.2.0;
 --;
+
+-- Remove hypervisors we no longer support
+UPDATE guest_os_hypervisor SET removed=now() WHERE hypervisor_type NOT IN ("KVM", "XenServer", "OVM3");
+
+-- Remove old templates
+UPDATE vm_template SET removed=now(), state='Inactive' WHERE `name` LIKE 'CentOS 5%' AND removed is NULL;
+
+-- Remove any non-used guest_os_id
+UPDATE `cloud`.`guest_os_hypervisor` SET removed=now() WHERE guest_os_id NOT IN (SELECT DISTINCT guest_os_id FROM vm_template WHERE state = 'active');
+UPDATE `cloud`.`guest_os` SET removed=now() WHERE id NOT IN (SELECT DISTINCT guest_os_id FROM vm_template WHERE state = 'active');
+
+-- keep only the defaults, as the others are very old
+UPDATE `cloud`.`guest_os_hypervisor` SET removed=now() WHERE hypervisor_version <> 'default';
+
+UPDATE guest_os SET display_name = 'Non-bootable ISO' WHERE id = 1;
+UPDATE guest_os SET display_name = 'SystemVM Debian 7 (32 bit)' WHERE id = 183;
+UPDATE guest_os SET display_name = 'SystemVM Debian 7 (64 bit)' WHERE id = 184;
+
+-- VirtioIO capable
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1000, UUID(), 7, 'Default - VirtIO capable OS (64-bit)', utc_timestamp());
+
+-- Linux
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1010, UUID(), 1, 'CentOS Family', now());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'CentOS Family', 1010, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1011, UUID(), 4, 'RHEL Family', now());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'RHEL Family', 1011, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1012, UUID(), 2, 'Debian Family', now());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'Debian Family', 1012, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1013, UUID(), 10, 'Ubuntu Family', now());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'Ubuntu Family', 1013, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1014, UUID(), 7, 'CoreOS Family', now());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'CoreOS Family', 1014, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1015, UUID(), 7, 'Linux Other', now());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'Linux Other', 1015, utc_timestamp(), 0);
+
+-- Windows
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1016, UUID(), 6, 'Windows 7 Family', now());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'Windows 7 Family', 1016, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1017, UUID(), 6, 'Windows 8 Family', now());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'Windows 8 Family', 1017, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1018, UUID(), 6, 'Windows 10 Family', now());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'Windows 10 Family', 1018, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1019, UUID(), 6, 'Windows 2008 Family', now());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'Windows 2008 Family', 1019, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1020, UUID(), 6, 'Windows 2012 Family', now());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'Windows 2012 Family', 1020, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1021, UUID(), 6, 'Windows 2016 Family', now());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'Windows 2016 Family', 1021, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1022, UUID(), 6, 'Windows Other', now());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'Windows Other', 1022, utc_timestamp(), 0);
+
+-- Non-VirtIO Capable
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1001, UUID(), 7, 'Non-VirtIO capable OS (64-bit)', utc_timestamp());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'Non-VirtIO capable OS (64-bit)', 1001, utc_timestamp(), 0);
+
+-- Update KVM systemvm template to be VirtIO compatible on KVM
+UPDATE vm_template SET guest_os_id = 1000 WHERE `name` LIKE 'SystemVM%' AND hypervisor_type = "KVM";

--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/VifDriverBase.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/VifDriverBase.java
@@ -38,7 +38,7 @@ public abstract class VifDriverBase implements VifDriver {
             }
         }
 
-        if (libvirtComputingResource.isGuestPvEnabled(platformEmulator)) {
+        if (libvirtComputingResource.isGuestVirtIoCapable(platformEmulator)) {
             return LibvirtVmDef.InterfaceDef.NicModel.VIRTIO;
         } else {
             return LibvirtVmDef.InterfaceDef.NicModel.E1000;

--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPlugNicCommandWrapper.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPlugNicCommandWrapper.java
@@ -45,7 +45,7 @@ public final class LibvirtPlugNicCommandWrapper
                 nicnum++;
             }
             final VifDriver vifDriver = libvirtComputingResource.getVifDriver(nic.getType());
-            final InterfaceDef interfaceDef = vifDriver.plug(nic, "Other PV", "");
+            final InterfaceDef interfaceDef = vifDriver.plug(nic, "Default - VirtIO capable OS (64-bit)", "");
             vm.attachDevice(interfaceDef.toString());
 
             return new PlugNicAnswer(command, true, "success");

--- a/cosmic-core/plugins/hypervisor/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -2711,7 +2711,7 @@ public class LibvirtComputingResourceTest {
 
             when(libvirtComputingResource.getVifDriver(nic.getType())).thenReturn(vifDriver);
 
-            when(vifDriver.plug(nic, "Other PV", "")).thenReturn(interfaceDef);
+            when(vifDriver.plug(nic, "Default - VirtIO capable OS (64-bit)", "")).thenReturn(interfaceDef);
             when(interfaceDef.toString()).thenReturn("Interface");
 
             final String interfaceDefStr = interfaceDef.toString();
@@ -2733,7 +2733,7 @@ public class LibvirtComputingResourceTest {
             verify(libvirtUtilitiesHelper, times(1)).getConnectionByVmName(command.getVmName());
             verify(libvirtComputingResource, times(1)).getDomain(conn, instanceName);
             verify(libvirtComputingResource, times(1)).getVifDriver(nic.getType());
-            verify(vifDriver, times(1)).plug(nic, "Other PV", "");
+            verify(vifDriver, times(1)).plug(nic, "Default - VirtIO capable OS (64-bit)", "");
         } catch (final LibvirtException e) {
             fail(e.getMessage());
         } catch (final InternalErrorException e) {
@@ -2805,7 +2805,7 @@ public class LibvirtComputingResourceTest {
 
             when(libvirtComputingResource.getVifDriver(nic.getType())).thenReturn(vifDriver);
 
-            when(vifDriver.plug(nic, "Other PV", "")).thenThrow(InternalErrorException.class);
+            when(vifDriver.plug(nic, "Default - VirtIO capable OS (64-bit)", "")).thenThrow(InternalErrorException.class);
         } catch (final LibvirtException e) {
             fail(e.getMessage());
         } catch (final InternalErrorException e) {
@@ -2823,7 +2823,7 @@ public class LibvirtComputingResourceTest {
             verify(libvirtUtilitiesHelper, times(1)).getConnectionByVmName(command.getVmName());
             verify(libvirtComputingResource, times(1)).getDomain(conn, instanceName);
             verify(libvirtComputingResource, times(1)).getVifDriver(nic.getType());
-            verify(vifDriver, times(1)).plug(nic, "Other PV", "");
+            verify(vifDriver, times(1)).plug(nic, "Default - VirtIO capable OS (64-bit)", "");
         } catch (final LibvirtException e) {
             fail(e.getMessage());
         } catch (final InternalErrorException e) {

--- a/cosmic-core/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
+++ b/cosmic-core/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
@@ -82,8 +82,8 @@ public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
         if (host != null) {
             guestOsMapping = _guestOsHypervisorDao.findByOsIdAndHypervisor(guestOS.getId(), getHypervisorType().toString(), host.getHypervisorVersion());
         }
-        if (guestOsMapping == null || host == null) {
-            to.setPlatformEmulator("Other");
+        if (guestOsMapping == null) {
+            to.setPlatformEmulator("Default - VirtIO capable OS (64-bit)");
         } else {
             to.setPlatformEmulator(guestOsMapping.getGuestOsName());
         }


### PR DESCRIPTION
This aims to make it easier to predict what OS Types will get `VirtIO` devices and what not. Basically by now, anything should get `VirtIO` by default unless there's a specific reason not do do that. Prefixing an OS Type's name with  `Non-VirtIO` will create VMs with emulated devices (`ide`, `e1000`, etc). To be selected when adding a template.

This will also make it possible to have Windows VMs on OS Type 'Windows' again, instead of everything on `Other PV`. There is otherwise no way to see what OS a guest is running (other than parsing the template name and hoping that makes sense). This is especially important considering placing VMs with the same OS Type (Windows) together on a hypervisor (aka 'OS Preference').