### PR TITLE
Fix restart with cleanup of (redundant) non-VPC network

### DIFF
--- a/cosmic-core/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
@@ -556,7 +556,7 @@ public class NetworkVO implements Network {
         return Network.class;
     }
 
-    public void setIsReduntant(final boolean reduntant) {
-        this.isRedundant = reduntant;
+    public void setIsRedundant(final boolean redundant) {
+        this.isRedundant = redundant;
     }
 }

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -1625,8 +1625,8 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
                 restartNetwork = true;
                 networkOfferingChanged = true;
 
-                //Setting the new network's isReduntant to the new network offering's RedundantRouter.
-                network.setIsReduntant(_networkOfferingDao.findById(networkOfferingId).getRedundantRouter());
+                //Setting the new network's isRedundant to the new network offering's RedundantRouter.
+                network.setIsRedundant(_networkOfferingDao.findById(networkOfferingId).getRedundantRouter());
             }
         }
 


### PR DESCRIPTION
Backport of PR 1781 of ACS. Didn't use the commits in the PR but followed a comment for easier solution.