### PR TITLE
Force-reload SSH to activate new SSHD config

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/cosmic-core/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -680,7 +680,7 @@ setup_sshd(){
   [ -f /etc/ssh/sshd_config ] && sed -i -e "s/^[#]*ListenAddress.*$/ListenAddress $ip/" /etc/ssh/sshd_config
   sed -i "/3922/s/eth./$eth/" /etc/iptables/rules.v4
   sed -i "/3922/s/eth./$eth/" /etc/iptables/rules
-  /etc/init.d/ssh restart
+  /etc/init.d/ssh force-reload
 }
 
 


### PR DESCRIPTION
Restart causes unavailability of the SSH service which has proven to break VPC creation every now and then