### PR TITLE
Restrict the SSVM services to a configurable CIDR

### DIFF
--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/api/SecStorageVMSetupCommand.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/api/SecStorageVMSetupCommand.java
@@ -2,6 +2,7 @@ package com.cloud.agent.api;
 
 public class SecStorageVMSetupCommand extends Command {
     String[] allowedInternalSites = new String[0];
+    String[] allowedExternalCidrs = new String[0];
     String copyUserName;
     String copyPassword;
 
@@ -20,6 +21,14 @@ public class SecStorageVMSetupCommand extends Command {
 
     public void setAllowedInternalSites(final String[] allowedInternalSites) {
         this.allowedInternalSites = allowedInternalSites;
+    }
+
+    public String[] getAllowedExternalCidrs() {
+        return allowedExternalCidrs;
+    }
+
+    public void setAllowedExternalCidrs(final String[] allowedExternalCidrs) {
+        this.allowedExternalCidrs = allowedExternalCidrs;
     }
 
     public String getCopyUserName() {

--- a/cosmic-core/server/src/main/java/com/cloud/configuration/Config.java
+++ b/cosmic-core/server/src/main/java/com/cloud/configuration/Config.java
@@ -717,6 +717,14 @@ public enum Config {
             null,
             "Comma separated list of cidrs internal to the datacenter that can host template download servers, please note 0.0.0.0 is not a valid site",
             null),
+    SecStorageAllowedExternalAccessCidrs(
+            "Advanced",
+            ManagementServer.class,
+            String.class,
+            "secstorage.allowed.external.cidrs",
+            "0.0.0.0/0",
+            "Comma separated list of cidrs that the SSVM is accessible from",
+            null),
     SecStorageEncryptCopy(
             "Advanced",
             ManagementServer.class,

--- a/cosmic-core/server/src/main/java/com/cloud/storage/secondary/SecondaryStorageManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/storage/secondary/SecondaryStorageManagerImpl.java
@@ -943,6 +943,7 @@ public class SecondaryStorageManagerImpl extends SystemVmManagerBase implements 
         }
 
         final SecStorageVMSetupCommand setupCmd = new SecStorageVMSetupCommand();
+        _allowedInternalSites = _configDao.getValue("secstorage.allowed.internal.sites");
         if (_allowedInternalSites != null) {
             final List<String> allowedCidrs = new ArrayList<>();
             final String[] cidrs = _allowedInternalSites.split(",");

--- a/cosmic-core/services/secondary-storage-server/src/main/java/org/apache/cloudstack/storage/template/DownloadManagerImpl.java
+++ b/cosmic-core/services/secondary-storage-server/src/main/java/org/apache/cloudstack/storage/template/DownloadManagerImpl.java
@@ -881,19 +881,6 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         if (result != null) {
             s_logger.warn("Error in stopping httpd service err=" + result);
         }
-        final String port = Integer.toString(TemplateConstants.DEFAULT_TMPLT_COPY_PORT);
-        final String intf = TemplateConstants.DEFAULT_TMPLT_COPY_INTF;
-
-        command = new Script("/bin/bash", s_logger);
-        command.add("-c");
-        command.add("iptables -I INPUT -i " + intf + " -p tcp -m state --state NEW -m tcp --dport " + port + " -j ACCEPT;" + "iptables -I INPUT -i " + intf +
-                " -p tcp -m state --state NEW -m tcp --dport " + "443" + " -j ACCEPT;");
-
-        result = command.execute();
-        if (result != null) {
-            s_logger.warn("Error in opening up httpd port err=" + result);
-            return;
-        }
 
         command = new Script("/bin/bash", s_logger);
         command.add("-c");


### PR DESCRIPTION
Only CIDRs specified in the new global setting 'secstorage.allowed.external.cidrs' are able to access the SSVM from public internet. Defaults to the old behaviour of ALLOW ALL (aka 0.0.0.0/0).

![image](https://cloud.githubusercontent.com/assets/1630096/20722566/60f35adc-b667-11e6-82a6-9256af844a1b.png)

While working on this, I found that 'secstorage.allowed.internal.site' didn't work, so fixed that along the way.