### PR TITLE
Fix KVM Maintenance mode

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/deploy/DeploymentPlanner.java
+++ b/cosmic-core/api/src/main/java/com/cloud/deploy/DeploymentPlanner.java
@@ -193,7 +193,7 @@ public interface DeploymentPlanner extends Adapter {
             return false;
         }
 
-        private boolean shouldAvoid(final long dataCenterId, final Long podId, final Long clusterId, final long id) {
+        private boolean shouldAvoid(final long dataCenterId, final Long podId, final Long clusterId, final long poolId) {
             if (dcIds.contains(dataCenterId)) {
                 return true;
             }
@@ -206,7 +206,7 @@ public interface DeploymentPlanner extends Adapter {
                 return true;
             }
 
-            if (hostIds.contains(id)) {
+            if (poolIds.contains(poolId)) {
                 return true;
             }
 


### PR DESCRIPTION
Maintenance mode never worked, because some IDs were mixed up resulting in adding the possible hosts to the Avoid Set. You see the method is called with a number of parameters. The final one is filled like `pool.getId()` but then in the method it compares to the `hostId` instead of the `poolId`. With this change it works fine in the bubble.

Before it'd stay in `PerpareForMaintenance` state.

While debugging noticed this error:
```
2016-12-04 21:15:24.679 DEBUG [c.c.d.FirstFitPlanner] (logid: dcd1f59a) (ctx: ee5e0d53) (job: 33/job: 67) The specified cluster is in avoid set, returning.
2016-12-04 21:15:24.679 DEBUG [c.c.v.VirtualMachineManagerImpl] (logid: dcd1f59a) (ctx: ee5e0d53) (job: 33/job: 67) Unable to find destination for migrating the vm VM[DomainRouter|r-5-VM]
2016-12-04 21:15:24.679 ERROR [c.c.v.VmWorkJobHandlerProxy] (logid: dcd1f59a) (ctx: ee5e0d53) (job: 33/job: 67) Invocation exception, caused by: com.cloud.exception.InsufficientServerCapacityException: Unable to find a server to migrate to.Scope=interface com.cloud.org.Cluster; id=1
```

After I applied the fix the Agent quickly moves to `Maintenance` state (and all VMs are properly migrated.

![image](https://cloud.githubusercontent.com/assets/1630096/20868970/da39c868-ba68-11e6-86cf-6e4079253fe0.png)

You now also see the Agent doing migrations:
```
2016-12-04 21:21:58.133  INFO (logid: e7ae9ba1) 23248 --- [agentRequest-Handler-2] c.c.h.k.r.w.LibvirtMigrateCommandWrapper : Live migration of instance r-5-VM initiated
2016-12-04 21:21:59.137  INFO (logid: e7ae9ba1) 23248 --- [agentRequest-Handler-2] c.c.h.k.r.w.LibvirtMigrateCommandWrapper : Waiting for migration of r-5-VM to complete, waited 1000ms
2016-12-04 21:22:00.146  INFO (logid: e7ae9ba1) 23248 --- [agentRequest-Handler-2] c.c.h.k.r.w.LibvirtMigrateCommandWrapper : Waiting for migration of r-5-VM to complete, waited 2000ms
2016-12-04 21:22:01.154  INFO (logid: e7ae9ba1) 23248 --- [agentRequest-Handler-2] c.c.h.k.r.w.LibvirtMigrateCommandWrapper : Waiting for migration of r-5-VM to complete, waited 3000ms
2016-12-04 21:22:01.556  INFO (logid: e7ae9ba1) 23248 --- [agentRequest-Handler-2] c.c.h.k.r.w.LibvirtMigrateCommandWrapper : Migration thread for r-5-VM is done
```