### PR TITLE
Disable Maintenance mode for Hosts in the UI

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/system.js
+++ b/cosmic-client/src/main/webapp/scripts/system.js
@@ -14483,14 +14483,14 @@
 
         if (jsonObj.resourcestate == "Enabled") {
             allowedActions.push("edit");
-            allowedActions.push("enableMaintenanceMode");
+            //allowedActions.push("enableMaintenanceMode");
             allowedActions.push("disable");
 
             if (jsonObj.state != "Disconnected")
                 allowedActions.push("forceReconnect");
         } else if (jsonObj.resourcestate == "ErrorInMaintenance") {
             allowedActions.push("edit");
-            allowedActions.push("enableMaintenanceMode");
+            //allowedActions.push("enableMaintenanceMode");
             allowedActions.push("cancelMaintenanceMode");
         } else if (jsonObj.resourcestate == "PrepareForMaintenance") {
             allowedActions.push("edit");


### PR DESCRIPTION
The feature is horribly broken and we should prevent people from using it (until it is properly fixed).

![screen shot 2016-12-05 at 21 00 37](https://cloud.githubusercontent.com/assets/1630096/20900296/f193117a-bb2d-11e6-8359-ac193594f535.png)
