### PR TITLE
Start rVPC routers on different pods, clusters, hosts if possible

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
@@ -349,12 +349,18 @@ public class NetworkHelperImpl implements NetworkHelper {
         }
 
         final DataCenterDeployment plan = new DataCenterDeployment(0, null, null, null, null, null);
-        assert router.getIsRedundantRouter();
         final List<Long> networkIds = _routerDao.getRouterNetworks(router.getId());
 
         DomainRouterVO routerToBeAvoid = null;
-        if (networkIds.size() != 0) {
-            final List<DomainRouterVO> routerList = _routerDao.findByNetwork(networkIds.get(0));
+
+        List<DomainRouterVO> routerList = null;
+        if (router.getVpcId() != null) {
+            routerList = _routerDao.listByVpcId(router.getVpcId());
+        } else if (networkIds.size() != 0) {
+            routerList = _routerDao.findByNetwork(networkIds.get(0));
+        }
+
+        if (routerList != null) {
             for (final DomainRouterVO rrouter : routerList) {
                 if (rrouter.getHostId() != null && rrouter.getIsRedundantRouter() && rrouter.getState() == State.Running) {
                     if (routerToBeAvoid != null) {


### PR DESCRIPTION
Non-VPC routers were started on different pods and clusters but we noticed this didn't work for rVPC routers. The reason is that the routers were looked up based on their networkID. But VPCs don't have a network ID (aka tier) yet so this never worked. Added a way for it to lookup the VPC routers.

With two clusters, one router will land on either cluster. With two pods, they will be deployed on one pod each. If all else fails, it will try two different hypervisors in the same cluster.