### PR TITLE
Auto-registering of KVM agents in new or existing clusters

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/org/Cluster.java
+++ b/cosmic-core/api/src/main/java/com/cloud/org/Cluster.java
@@ -20,7 +20,7 @@ public interface Cluster extends Grouping, InternalIdentity, Identity {
 
     ManagedState getManagedState();
 
-    public static enum ClusterType {
+    enum ClusterType {
         CloudManaged, ExternalManaged
     }
 }

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/dc/ClusterDetailsDao.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/dc/ClusterDetailsDao.java
@@ -15,5 +15,4 @@ public interface ClusterDetailsDao extends GenericDao<ClusterDetailsVO, Long> {
 
     void deleteDetails(long clusterId);
 
-    String getVmwareDcName(Long clusterId);
 }

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/dc/ClusterDetailsDaoImpl.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/dc/ClusterDetailsDaoImpl.java
@@ -91,9 +91,18 @@ public class ClusterDetailsDaoImpl extends GenericDaoBase<ClusterDetailsVO, Long
         sc.setParameters("clusterId", clusterId);
         sc.setParameters("name", name);
 
-        final ClusterDetailsVO detail = findOneIncludingRemovedBy(sc);
+        ClusterDetailsVO detail = findOneIncludingRemovedBy(sc);
         if ("password".equals(name) && detail != null) {
             detail.setValue(DBEncryptionUtil.decrypt(detail.getValue()));
+        }
+        if ("cpuOvercommitRatio".equals(name) || "memoryOvercommitRatio".equals(name)) {
+            final String detailDefaultValue = "1.0";
+            if (detail != null && detail.getValue() == null) {
+                detail.setValue(detailDefaultValue);
+            } else if (detail == null) {
+                this.persist(clusterId, name, detailDefaultValue);
+                detail = findOneIncludingRemovedBy(sc);
+            }
         }
         return detail;
     }

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/dc/ClusterDetailsDaoImpl.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/dc/ClusterDetailsDaoImpl.java
@@ -14,34 +14,37 @@ import java.util.List;
 import java.util.Map;
 
 public class ClusterDetailsDaoImpl extends GenericDaoBase<ClusterDetailsVO, Long> implements ClusterDetailsDao, ScopedConfigStorage {
-    protected final SearchBuilder<ClusterDetailsVO> ClusterSearch;
-    protected final SearchBuilder<ClusterDetailsVO> DetailSearch;
+
+    private final SearchBuilder<ClusterDetailsVO> _clusterSearch;
+    private final SearchBuilder<ClusterDetailsVO> _detailSearch;
 
     protected ClusterDetailsDaoImpl() {
-        ClusterSearch = createSearchBuilder();
-        ClusterSearch.and("clusterId", ClusterSearch.entity().getClusterId(), SearchCriteria.Op.EQ);
-        ClusterSearch.done();
+        _clusterSearch = createSearchBuilder();
+        _clusterSearch.and("clusterId", _clusterSearch.entity().getClusterId(), SearchCriteria.Op.EQ);
+        _clusterSearch.done();
 
-        DetailSearch = createSearchBuilder();
-        DetailSearch.and("clusterId", DetailSearch.entity().getClusterId(), SearchCriteria.Op.EQ);
-        DetailSearch.and("name", DetailSearch.entity().getName(), SearchCriteria.Op.EQ);
-        DetailSearch.done();
+        _detailSearch = createSearchBuilder();
+        _detailSearch.and("clusterId", _detailSearch.entity().getClusterId(), SearchCriteria.Op.EQ);
+        _detailSearch.and("name", _detailSearch.entity().getName(), SearchCriteria.Op.EQ);
+        _detailSearch.done();
     }
 
     @Override
     public Map<String, String> findDetails(final long clusterId) {
-        final SearchCriteria<ClusterDetailsVO> sc = ClusterSearch.create();
+        final SearchCriteria<ClusterDetailsVO> sc = _clusterSearch.create();
         sc.setParameters("clusterId", clusterId);
 
         final List<ClusterDetailsVO> results = search(sc, null);
         final Map<String, String> details = new HashMap<>(results.size());
-        for (final ClusterDetailsVO result : results) {
-            if ("password".equals(result.getName())) {
-                details.put(result.getName(), DBEncryptionUtil.decrypt(result.getValue()));
-            } else {
-                details.put(result.getName(), result.getValue());
-            }
-        }
+
+        results.forEach(result -> {
+            final String value = "password".equals(result.getName())
+                    ? DBEncryptionUtil.decrypt(result.getValue())
+                    : result.getValue();
+
+            details.put(result.getName(), value);
+        });
+
         return details;
     }
 
@@ -49,18 +52,18 @@ public class ClusterDetailsDaoImpl extends GenericDaoBase<ClusterDetailsVO, Long
     public void persist(final long clusterId, final Map<String, String> details) {
         final TransactionLegacy txn = TransactionLegacy.currentTxn();
         txn.start();
-        final SearchCriteria<ClusterDetailsVO> sc = ClusterSearch.create();
+        final SearchCriteria<ClusterDetailsVO> sc = _clusterSearch.create();
         sc.setParameters("clusterId", clusterId);
         expunge(sc);
 
-        for (final Map.Entry<String, String> detail : details.entrySet()) {
-            String value = detail.getValue();
-            if ("password".equals(detail.getKey())) {
-                value = DBEncryptionUtil.encrypt(value);
-            }
+        details.entrySet().forEach(detail -> {
+            final String value = "password".equals(detail.getKey())
+                    ? DBEncryptionUtil.encrypt(detail.getValue())
+                    : detail.getValue();
+
             final ClusterDetailsVO vo = new ClusterDetailsVO(clusterId, detail.getKey(), value);
             persist(vo);
-        }
+        });
         txn.commit();
     }
 
@@ -68,7 +71,7 @@ public class ClusterDetailsDaoImpl extends GenericDaoBase<ClusterDetailsVO, Long
     public void persist(final long clusterId, final String name, final String value) {
         final TransactionLegacy txn = TransactionLegacy.currentTxn();
         txn.start();
-        final SearchCriteria<ClusterDetailsVO> sc = DetailSearch.create();
+        final SearchCriteria<ClusterDetailsVO> sc = _detailSearch.create();
         sc.setParameters("clusterId", clusterId);
         sc.setParameters("name", name);
         expunge(sc);
@@ -79,54 +82,44 @@ public class ClusterDetailsDaoImpl extends GenericDaoBase<ClusterDetailsVO, Long
     }
 
     @Override
-    public ClusterDetailsVO findDetail(final long clusterId, String name) {
-        final SearchCriteria<ClusterDetailsVO> sc = DetailSearch.create();
-        // This is temporary fix to support list/update configuration api for cpu and memory overprovisioning ratios
-        if (name.equalsIgnoreCase("cpu.overprovisioning.factor")) {
-            name = "cpuOvercommitRatio";
-        }
-        if (name.equalsIgnoreCase("mem.overprovisioning.factor")) {
-            name = "memoryOvercommitRatio";
-        }
+    public ClusterDetailsVO findDetail(final long clusterId, final String name) {
+        final String correctedName = correctName(name);
+
+        final SearchCriteria<ClusterDetailsVO> sc = _detailSearch.create();
         sc.setParameters("clusterId", clusterId);
-        sc.setParameters("name", name);
+        sc.setParameters("name", correctedName);
 
         ClusterDetailsVO detail = findOneIncludingRemovedBy(sc);
-        if ("password".equals(name) && detail != null) {
+        if (detail != null && "password".equals(correctedName)) {
             detail.setValue(DBEncryptionUtil.decrypt(detail.getValue()));
         }
-        if ("cpuOvercommitRatio".equals(name) || "memoryOvercommitRatio".equals(name)) {
-            final String detailDefaultValue = "1.0";
-            if (detail != null && detail.getValue() == null) {
-                detail.setValue(detailDefaultValue);
-            } else if (detail == null) {
-                this.persist(clusterId, name, detailDefaultValue);
-                detail = findOneIncludingRemovedBy(sc);
-            }
+        if ((detail == null) && ("cpuOvercommitRatio".equals(correctedName) || "memoryOvercommitRatio".equals(correctedName))) {
+            this.persist(clusterId, correctedName, "1");
+            detail = findOneIncludingRemovedBy(sc);
         }
         return detail;
     }
 
-    @Override
-    public void deleteDetails(final long clusterId) {
-        final SearchCriteria<ClusterDetailsVO> sc = ClusterSearch.create();
-        sc.setParameters("clusterId", clusterId);
-
-        final List<ClusterDetailsVO> results = search(sc, null);
-        for (final ClusterDetailsVO result : results) {
-            remove(result.getId());
+    /*
+     * This is a temporary fix to support listing/updating configuration API for CPU and memory overprovisioning ratios
+     */
+    private String correctName(final String name) {
+        String correctedName = name;
+        if ("cpu.overprovisioning.factor".equalsIgnoreCase(name)) {
+            correctedName = "cpuOvercommitRatio";
+        } else if ("mem.overprovisioning.factor".equalsIgnoreCase(name)) {
+            correctedName = "memoryOvercommitRatio";
         }
+        return correctedName;
     }
 
     @Override
-    public String getVmwareDcName(final Long clusterId) {
-        String dcName = null;
-        final String url = findDetail(clusterId, "url").getValue();
-        final String[] tokens = url.split("/"); // Cluster URL format is 'http://vcenter/dc/cluster'
-        if (tokens != null && tokens.length > 3) {
-            dcName = tokens[3];
-        }
-        return dcName;
+    public void deleteDetails(final long clusterId) {
+        final SearchCriteria<ClusterDetailsVO> sc = _clusterSearch.create();
+        sc.setParameters("clusterId", clusterId);
+
+        final List<ClusterDetailsVO> results = search(sc, null);
+        results.forEach(result -> remove(result.getId()));
     }
 
     @Override
@@ -137,6 +130,9 @@ public class ClusterDetailsDaoImpl extends GenericDaoBase<ClusterDetailsVO, Long
     @Override
     public String getConfigValue(final long id, final ConfigKey<?> key) {
         final ClusterDetailsVO vo = findDetail(id, key.key());
-        return vo == null ? null : vo.getValue();
+
+        return (vo != null)
+                ? vo.getValue()
+                : null;
     }
 }

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/dc/ClusterVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/dc/ClusterVO.java
@@ -2,10 +2,8 @@ package com.cloud.dc;
 
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.org.Cluster;
-import com.cloud.org.Grouping;
 import com.cloud.org.Managed.ManagedState;
 import com.cloud.utils.NumbersUtil;
-import com.cloud.utils.db.GenericDao;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -15,7 +13,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import java.util.Date;
 import java.util.UUID;
 
 @Entity
@@ -25,42 +22,41 @@ public class ClusterVO implements Cluster {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
-    long id;
+    private long id;
 
     @Column(name = "name")
-    String name;
+    private String name;
 
     @Column(name = "guid")
-    String guid;
+    private String guid;
 
     @Column(name = "data_center_id")
-    long dataCenterId;
+    private long dataCenterId;
 
     @Column(name = "pod_id")
-    long podId;
+    private long podId;
 
     @Column(name = "hypervisor_type")
-    String hypervisorType;
+    private String hypervisorType;
 
     @Column(name = "cluster_type")
     @Enumerated(value = EnumType.STRING)
-    Cluster.ClusterType clusterType;
+    private ClusterType clusterType;
 
     @Column(name = "allocation_state")
     @Enumerated(value = EnumType.STRING)
-    AllocationState allocationState;
+    private AllocationState allocationState;
 
     @Column(name = "managed_state")
     @Enumerated(value = EnumType.STRING)
-    ManagedState managedState;
+    private ManagedState managedState;
+
     @Column(name = "uuid")
-    String uuid;
-    @Column(name = GenericDao.REMOVED_COLUMN)
-    private Date removed;
+    private String uuid;
 
     public ClusterVO() {
-        clusterType = Cluster.ClusterType.CloudManaged;
-        allocationState = Grouping.AllocationState.Enabled;
+        clusterType = ClusterType.CloudManaged;
+        allocationState = AllocationState.Enabled;
 
         this.uuid = UUID.randomUUID().toString();
     }
@@ -69,8 +65,8 @@ public class ClusterVO implements Cluster {
         this.dataCenterId = dataCenterId;
         this.podId = podId;
         this.name = name;
-        this.clusterType = Cluster.ClusterType.CloudManaged;
-        this.allocationState = Grouping.AllocationState.Enabled;
+        this.clusterType = ClusterType.CloudManaged;
+        this.allocationState = AllocationState.Enabled;
         this.managedState = ManagedState.Managed;
         this.uuid = UUID.randomUUID().toString();
     }
@@ -101,18 +97,17 @@ public class ClusterVO implements Cluster {
 
     @Override
     public HypervisorType getHypervisorType() {
-        if (hypervisorType == null) {
-            return HypervisorType.KVM;
-        }
-        return HypervisorType.getType(hypervisorType);
+        return (hypervisorType != null)
+                ? HypervisorType.getType(hypervisorType)
+                : HypervisorType.KVM;
     }
 
     @Override
-    public Cluster.ClusterType getClusterType() {
+    public ClusterType getClusterType() {
         return clusterType;
     }
 
-    public void setClusterType(final Cluster.ClusterType clusterType) {
+    public void setClusterType(final ClusterType clusterType) {
         this.clusterType = clusterType;
     }
 
@@ -134,8 +129,8 @@ public class ClusterVO implements Cluster {
         this.managedState = managedState;
     }
 
-    public void setHypervisorType(final String hy) {
-        hypervisorType = hy;
+    public void setHypervisorType(final String hypervisorType) {
+        this.hypervisorType = hypervisorType;
     }
 
     public void setName(final String name) {
@@ -162,10 +157,6 @@ public class ClusterVO implements Cluster {
 
     public void setGuid(final String guid) {
         this.guid = guid;
-    }
-
-    public Date getRemoved() {
-        return removed;
     }
 
     @Override

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/dc/ClusterVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/dc/ClusterVO.java
@@ -101,6 +101,9 @@ public class ClusterVO implements Cluster {
 
     @Override
     public HypervisorType getHypervisorType() {
+        if (hypervisorType == null) {
+            return HypervisorType.KVM;
+        }
         return HypervisorType.getType(hypervisorType);
     }
 


### PR DESCRIPTION
One can deploy a Cosmic KVM agent and have it register itself in a cluster, new or existing. This allows for further automation of deployments.

Specifying `cluster=MCCT-KVM-123` in the `agent.properties` will create this cluster (like before) with `type=KVM` (instead of None). You also need to specify the POD and  ZONE.

Also, a bug was fixed that caused a NPE on cluster details. It works fine now.
