### PR TITLE
Do not serve DefaultGateway option for non-default nics

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/cosmic-core/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -980,6 +980,9 @@ EOF
   cp /etc/cloud-nic.rules /etc/udev/rules.d/cloud-nic.rules
   echo "" > /etc/dnsmasq.d/dhcphosts.txt
   echo "dhcp-hostsfile=/etc/dhcphosts.txt" > /etc/dnsmasq.d/cloud.conf
+  echo "dhcp-optsfile=/etc/dhcpopts.txt" >> /etc/dnsmasq.d/cloud.conf
+  echo "log-dhcp" >> /etc/dnsmasq.d/cloud.conf
+  touch /etc/dhcpopts.txt
 
   [ -z $DOMAIN ] && DOMAIN="cloudnine.internal"
   #DNS server will append $DOMAIN to local queries

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
@@ -131,6 +131,7 @@ class CsDhcp(CsDataBag):
                 v['gateway'] = entry['default_gateway']
 
     def add_dhcp_opts(self, entry):
+        # This means we won't serve these DHCP options for hosts with this tag
         tag = str(entry['ipv4_adress']).replace(".","_")
         self.dhcp_opts.add("%s,%s" % (tag, 3))
         self.dhcp_opts.add("%s,%s" % (tag, 6))


### PR DESCRIPTION
Otherwise a VM will have two default gateways and that leads to confusion in most cases. It was fixed in #141 but still didn't work for VPC networks. This PR fixes that. The option to specify the dhcpops.txt file wasn't specified in cloud.conf so it didn't work.