### PR TITLE
Use predictable ip addresses for the guest-nic of a redundant router

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/network/NetworkModel.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/NetworkModel.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
 
 /**
  * The NetworkModel presents a read-only view into the Network data such as L2 networks,
@@ -220,7 +221,7 @@ public interface NetworkModel {
 
     NicProfile getNicProfile(VirtualMachine vm, long networkId, String broadcastUri);
 
-    Set<Long> getAvailableIps(Network network, String requestedIp);
+    SortedSet<Long> getAvailableIps(Network network, String requestedIp);
 
     String getDomainNetworkDomain(long domainId, long zoneId);
 

--- a/cosmic-core/engine/components-api/src/main/java/com/cloud/network/IpAddressManager.java
+++ b/cosmic-core/engine/components-api/src/main/java/com/cloud/network/IpAddressManager.java
@@ -77,7 +77,9 @@ public interface IpAddressManager {
 
     IPAddressVO markIpAsUnavailable(long addrId);
 
-    public String acquireGuestIpAddress(Network network, String requestedIp);
+    String acquireGuestIpAddress(Network network, String requestedIp);
+
+    String acquireGuestIpAddressForRouter(Network network, String requestedIp);
 
     boolean applyStaticNats(List<? extends StaticNat> staticNats, boolean continueOnError, boolean forRevoke) throws ResourceUnavailableException;
 

--- a/cosmic-core/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
@@ -148,6 +148,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.UUID;
 
 import org.slf4j.Logger;
@@ -1659,7 +1660,7 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
             return null;
         }
 
-        final Set<Long> availableIps = _networkModel.getAvailableIps(network, requestedIp);
+        final SortedSet<Long> availableIps = _networkModel.getAvailableIps(network, requestedIp);
 
         if (availableIps == null || availableIps.isEmpty()) {
             s_logger.debug("There are no free ips in the  network " + network);
@@ -1683,6 +1684,15 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
         }
 
         return NetUtils.long2Ip(array[_rand.nextInt(array.length)]);
+    }
+
+    public String acquireGuestIpAddressForRouter(final Network network, final String requestedIp) {
+
+        final SortedSet<Long> availableIps = _networkModel.getAvailableIps(network, requestedIp);
+
+        return (availableIps.isEmpty())
+                ? this.acquireGuestIpAddress(network, requestedIp)
+                : this.acquireGuestIpAddress(network, NetUtils.long2Ip(availableIps.first()));
     }
 
     @Override

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -100,6 +100,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.TreeSet;
 
 import org.apache.commons.codec.binary.Base64;
@@ -1814,10 +1815,10 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
     }
 
     @Override
-    public Set<Long> getAvailableIps(final Network network, final String requestedIp) {
+    public SortedSet<Long> getAvailableIps(final Network network, final String requestedIp) {
         final String[] cidr = network.getCidr().split("/");
         final List<String> ips = getUsedIpsInNetwork(network);
-        final Set<Long> usedIps = new TreeSet<>();
+        final SortedSet<Long> usedIps = new TreeSet<>();
 
         for (final String ip : ips) {
             if (requestedIp != null && requestedIp.equals(ip)) {
@@ -1828,7 +1829,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
             usedIps.add(NetUtils.ip2Long(ip));
         }
 
-        final Set<Long> allPossibleIps = NetUtils.getAllIpsFromCidr(cidr[0], Integer.parseInt(cidr[1]), usedIps);
+        final SortedSet<Long> allPossibleIps = NetUtils.getAllIpsFromCidr(cidr[0], Integer.parseInt(cidr[1]), usedIps);
 
         final String gateway = network.getGateway();
         if (gateway != null && allPossibleIps.contains(NetUtils.ip2Long(gateway))) {

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -168,7 +168,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.UUID;
 
 import org.slf4j.Logger;
@@ -3942,29 +3941,6 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
         final List<UserVmVO> vms = _userVmDao.listByNetworkIdAndStates(networkId, VirtualMachine.State.Starting, VirtualMachine.State.Running, VirtualMachine.State.Migrating,
                 VirtualMachine.State.Stopping);
         return vms.isEmpty();
-    }
-
-    protected Set<Long> getAvailableIps(final Network network, final String requestedIp) {
-        final String[] cidr = network.getCidr().split("/");
-        final List<String> ips = _nicDao.listIpAddressInNetwork(network.getId());
-        final Set<Long> usedIps = new TreeSet<>();
-
-        for (final String ip : ips) {
-            if (requestedIp != null && requestedIp.equals(ip)) {
-                s_logger.warn("Requested ip address " + requestedIp + " is already in use in network" + network);
-                return null;
-            }
-
-            usedIps.add(NetUtils.ip2Long(ip));
-        }
-        final Set<Long> allPossibleIps = NetUtils.getAllIpsFromCidr(cidr[0], Integer.parseInt(cidr[1]), usedIps);
-
-        final String gateway = network.getGateway();
-        if (gateway != null && allPossibleIps.contains(NetUtils.ip2Long(gateway))) {
-            allPossibleIps.remove(NetUtils.ip2Long(gateway));
-        }
-
-        return allPossibleIps;
     }
 
     protected boolean canUpgrade(final Network network, final long oldNetworkOfferingId, final long newNetworkOfferingId) {

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
@@ -715,7 +715,7 @@ public class NetworkHelperImpl implements NetworkHelper {
             final NicProfile gatewayNic = new NicProfile(defaultNetworkStartIp, defaultNetworkStartIpv6);
             if (routerDeploymentDefinition.isPublicNetwork()) {
                 if (routerDeploymentDefinition.isRedundant()) {
-                    gatewayNic.setIPv4Address(_ipAddrMgr.acquireGuestIpAddress(guestNetwork, null));
+                    gatewayNic.setIPv4Address(_ipAddrMgr.acquireGuestIpAddressForRouter(guestNetwork, null));
                 } else {
                     gatewayNic.setIPv4Address(guestNetwork.getGateway());
                 }

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/NicProfileHelperImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/NicProfileHelperImpl.java
@@ -100,7 +100,7 @@ public class NicProfileHelperImpl implements NicProfileHelper {
         // Redundant VPCs should not acquire the gateway ip because that is the VIP between the two routers to which guest VMs connect
         // VPCs without sourcenat service also should not acquire the gateway ip because it is in use by an external device on the network
         if (vpcRouterDeploymentDefinition.isRedundant() || !vpcRouterDeploymentDefinition.hasSourceNatService()) {
-            guestNic.setIPv4Address(_ipAddrMgr.acquireGuestIpAddress(guestNetwork, null));
+            guestNic.setIPv4Address(_ipAddrMgr.acquireGuestIpAddressForRouter(guestNetwork, null));
         } else {
             guestNic.setIPv4Address(guestNetwork.getGateway());
         }

--- a/cosmic-core/server/src/test/java/com/cloud/network/MockNetworkModelImpl.java
+++ b/cosmic-core/server/src/test/java/com/cloud/network/MockNetworkModelImpl.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
 
 public class MockNetworkModelImpl extends ManagerBase implements NetworkModel {
 
@@ -756,7 +757,7 @@ public class MockNetworkModelImpl extends ManagerBase implements NetworkModel {
      * @see com.cloud.network.NetworkModel#getAvailableIps(com.cloud.network.Network, java.lang.String)
      */
     @Override
-    public Set<Long> getAvailableIps(final Network network, final String requestedIp) {
+    public SortedSet<Long> getAvailableIps(final Network network, final String requestedIp) {
         // TODO Auto-generated method stub
         return null;
     }

--- a/cosmic-core/server/src/test/java/com/cloud/vpc/MockNetworkModelImpl.java
+++ b/cosmic-core/server/src/test/java/com/cloud/vpc/MockNetworkModelImpl.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
 
 public class MockNetworkModelImpl extends ManagerBase implements NetworkModel {
 
@@ -771,7 +772,7 @@ public class MockNetworkModelImpl extends ManagerBase implements NetworkModel {
      * @see com.cloud.network.NetworkModel#getAvailableIps(com.cloud.network.Network, java.lang.String)
      */
     @Override
-    public Set<Long> getAvailableIps(final Network network, final String requestedIp) {
+    public SortedSet<Long> getAvailableIps(final Network network, final String requestedIp) {
         // TODO Auto-generated method stub
         return null;
     }

--- a/cosmic-core/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/cosmic-core/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -550,9 +550,9 @@ public class NetUtils {
         return true;
     }
 
-    public static Set<Long> getAllIpsFromCidr(final String cidr, final long size, final Set<Long> usedIps) {
+    public static SortedSet<Long> getAllIpsFromCidr(final String cidr, final long size, final Set<Long> usedIps) {
         assert size < MAX_CIDR : "You do know this is not for ipv6 right?  Keep it smaller than 32 but you have " + size;
-        final Set<Long> result = new TreeSet<>();
+        final SortedSet<Long> result = new TreeSet<>();
         final long ip = ip2Long(cidr);
         final long startNetMask = ip2Long(getCidrNetmask(size));
         long start = (ip & startNetMask) + 1;


### PR DESCRIPTION
We see clashes with VM deployments with specified ip, as this ip could also be grabbed by the router nic in case of redundant routers (which leads to `InsufficientVirtualNetworkCapacityException` without the user being able to influence/fix it).

This PR makes routers that need to grab an ip address in the guest network, pick the lowest possible ip address from the range. If users want to use static/preselected ip addresses, they should not use the first few addresses. Apart from that, there should be no more clashes.

User VMs are given a randomly selected ip address from the pool, that is unchanged.

Router1:
```
root@r-3-VM:~# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN 
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 0e:00:a9:fe:00:b2 brd ff:ff:ff:ff:ff:ff
    inet 169.254.0.178/16 brd 169.254.255.255 scope global eth0
       valid_lft forever preferred_lft forever
3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 06:a1:20:00:00:18 brd ff:ff:ff:ff:ff:ff
    inet 192.168.23.4/24 brd 192.168.23.255 scope global eth1
       valid_lft forever preferred_lft forever
4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 02:00:58:18:00:03 brd ff:ff:ff:ff:ff:ff
    inet 10.0.0.3/24 brd 10.0.0.255 scope global eth2
       valid_lft forever preferred_lft forever
    inet 10.0.0.1/24 brd 10.0.0.255 scope global secondary eth2
       valid_lft forever preferred_lft forever
```
Router2:
```
root@r-4-VM:~# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN 
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 0e:00:a9:fe:01:56 brd ff:ff:ff:ff:ff:ff
    inet 169.254.1.86/16 brd 169.254.255.255 scope global eth0
       valid_lft forever preferred_lft forever
3: eth1: <BROADCAST,MULTICAST> mtu 1500 qdisc pfifo_fast state DOWN qlen 1000
    link/ether 06:a1:20:00:00:18 brd ff:ff:ff:ff:ff:ff
    inet 192.168.23.4/24 brd 192.168.23.255 scope global eth1
       valid_lft forever preferred_lft forever
4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 02:00:52:a5:00:02 brd ff:ff:ff:ff:ff:ff
    inet 10.0.0.2/24 brd 10.0.0.255 scope global eth2
       valid_lft forever preferred_lft forever
```

UserVM:
```
root@r-4-VM:~# cat /etc/hosts
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
::1     localhost ip6-localhost ip6-loopback
127.0.0.1       localhost r-4-VM
10.0.0.63       VM-4f910e73-8d59-4b65-b11b-651b37ca9c70
```

