### PR TITLE
Warn that only TCP is supported for loadbalancing (due to HAProxy)

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/CreateLoadBalancerRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/CreateLoadBalancerRuleCmd.java
@@ -253,6 +253,10 @@ public class CreateLoadBalancerRuleCmd extends BaseAsyncCreateCmd /*implements L
             throw new InvalidParameterValueException(
                     "Parameter cidrList is deprecated; if you need to open firewall rule for the specific CIDR, please refer to createFirewallRule command");
         }
+        if (lbProtocol != null && !lbProtocol.toLowerCase().equals("tcp")) {
+            throw new InvalidParameterValueException(
+                    "Only TCP protocol is supported because HAProxy can only do TCP.");
+        }
         try {
             final LoadBalancer result =
                     _lbService.createPublicLoadBalancerRule(getXid(), getName(), getDescription(), getSourcePortStart(), getSourcePortEnd(), getDefaultPortStart(),


### PR DESCRIPTION
This fixes #110 

Will produce these messages:

```
(local) 🐵 > create loadbalancerrule name=remi privateport=53 publicport=53 protocol=udp algorithm=source networkid=bcf1b120-5fb6-4db3-b0d5-d05e5dc81c43 publicipid=7a4ed608-1292-4fc2-a15d-ecf249396cd1
Error 431: Only TCP protocol is supported because HAProxy can only do TCP.
```

TCP still works:
```

(local) 🐵 > create loadbalancerrule name=remi privateport=53 publicport=53 protocol=TCP algorithm=source networkid=bcf1b120-5fb6-4db3-b0d5-d05e5dc81c43 publicipid=7a4ed608-1292-4fc2-a15d-ecf249396cd1
 
accountid = 341ee1c4-bfe6-11e6-9f42-5254001daa61
cmd = com.cloud.api.command.user.loadbalancer.CreateLoadBalancerRuleCmd
created = 2016-12-12T09:22:44+0100
jobid = eb77fc63-68dd-432d-8042-b9d1f7145e64
jobinstanceid = 8f0fd6aa-895d-4ef4-a6a7-88dbbbb34aea
jobinstancetype = FirewallRule
jobprocstatus = 0
jobresult:
loadbalancer:
name = remi
id = 8f0fd6aa-895d-4ef4-a6a7-88dbbbb34aea
account = admin
algorithm = source
cidrlist = 
domain = ROOT
domainid = 341e5582-bfe6-11e6-9f42-5254001daa61
fordisplay = True
networkid = bcf1b120-5fb6-4db3-b0d5-d05e5dc81c43
privateport = 53
protocol = TCP
publicip = 192.168.23.5
publicipid = 7a4ed608-1292-4fc2-a15d-ecf249396cd1
publicport = 53
state = Add
tags:
zoneid = 1905698c-fe56-4120-a1d8-9df83950ab0b
jobresultcode = 0
jobresulttype = object
jobstatus = 1
userid = 341f7941-bfe6-11e6-9f42-5254001daa61
(local) 🐵 > 
(local) 🐵 > create loadbalancerrule name=remi privateport=53 publicport=53 protocol=TCPp algorithm=source networkid=bcf1b120-5fb6-4db3-b0d5-d05e5dc81c43 publicipid=7a4ed608-1292-4fc2-a15d-ecf249396cd1
```
