### PR TITLE
Wait a bit before retry when there is a failure in Qemu Guest Agent

### DIFF
--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1374,6 +1374,12 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 logger.debug("Giving up on cmdline passing after 100 times, aborting.");
                 return false;
             }
+            // Give it some time to get ready
+            try {
+                Thread.sleep(15000);
+            } catch (final InterruptedException e) {
+                logger.debug("Interrupted while awaiting next try: ", e);
+            }
         }
         return true;
     }


### PR DESCRIPTION
Since CentOS 7.3/Qemu2 the qga timeout immediately instead of after 10 seconds. Therefore we go through the 100 retries very fast and so the systemvms get killed and stuff won't work.