### PR TITLE
cloud-engine-network was already removed, though not from cosmic-client/pom.xml

### DIFF
--- a/cosmic-client/pom.xml
+++ b/cosmic-client/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cloud-client-ui</artifactId>
     <name>Cosmic Client UI</name>
@@ -179,11 +180,6 @@
             <groupId>cloud.cosmic</groupId>
             <artifactId>cloud-engine-components-api</artifactId>
             <version>5.2.0.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>cloud.cosmic</groupId>
-            <artifactId>cloud-engine-network</artifactId>
-            <version>5.1.1.9-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>cloud.cosmic</groupId>


### PR DESCRIPTION
Fix for broken master build @bheuvel @remibergsma @eliasgomes 