### PR TITLE
Allow private gateway creation by domain admins

### DIFF
--- a/cosmic-client/src/main/resources/commands.properties
+++ b/cosmic-client/src/main/resources/commands.properties
@@ -371,7 +371,7 @@ listHypervisorCapabilities=1
 #### Physical Network commands
 createPhysicalNetwork=1
 deletePhysicalNetwork=1
-listPhysicalNetworks=1
+listPhysicalNetworks=7
 updatePhysicalNetwork=1
 #### Physical Network Service Provider commands
 listSupportedNetworkServices=1
@@ -406,9 +406,9 @@ updateVPCOffering=1
 deleteVPCOffering=1
 listVPCOfferings=15
 #### Private gateway commands
-createPrivateGateway=1
+createPrivateGateway=7
 listPrivateGateways=15
-deletePrivateGateway=1
+deletePrivateGateway=7
 #### Network ACL commands
 createNetworkACL=15
 updateNetworkACLItem=15

--- a/cosmic-client/src/main/webapp/scripts/vpc.js
+++ b/cosmic-client/src/main/webapp/scripts/vpc.js
@@ -1832,7 +1832,7 @@
 
             add: {
                 preCheck: function (args) {
-                    if (isAdmin()) { //root-admin
+                    if (isAdmin() || isDomainAdmin()) { //root or domain-admin
                         var items;
                         $.ajax({
                             url: createURL('listPrivateGateways'),
@@ -1875,6 +1875,34 @@
                                     },
                                     success: function (json) {
                                         var objs = json.listphysicalnetworksresponse.physicalnetwork;
+                                        var items = [];
+                                        $(objs).each(function () {
+                                            items.push({
+                                                id: this.id,
+                                                description: this.name
+                                            });
+                                        });
+                                        args.response.success({
+                                            data: items
+                                        });
+                                    }
+                                });
+                            }
+                        },
+                        networkofferingid: {
+                            docID: 'helpGuestNetworkNetworkOffering',
+                            label: 'label.network.offering',
+                            select: function (args) {
+                                $.ajax({
+                                    url: createURL("listNetworkOfferings"),
+                                    data: {
+                                        zoneid: args.context.vpc[0].zoneid,
+                                        traffictype: "Guest",
+                                        specifyvlan: "true",
+                                        keyword: "private"
+                                    },
+                                    success: function (json) {
+                                        var objs = json.listnetworkofferingsresponse.networkoffering;
                                         var items = [];
                                         $(objs).each(function () {
                                             items.push({
@@ -1970,6 +1998,7 @@
                         url: createURL('createPrivateGateway' + array1.join("")),
                         data: {
                             physicalnetworkid: args.data.physicalnetworkid,
+                            networkofferingid: args.data.networkofferingid,
                             vpcid: args.context.vpc[0].id,
                             ipaddress: args.data.ipaddress,
                             gateway: args.data.gateway,
@@ -2053,6 +2082,34 @@
                                                     },
                                                     success: function (json) {
                                                         var objs = json.listphysicalnetworksresponse.physicalnetwork;
+                                                        var items = [];
+                                                        $(objs).each(function () {
+                                                            items.push({
+                                                                id: this.id,
+                                                                description: this.name
+                                                            });
+                                                        });
+                                                        args.response.success({
+                                                            data: items
+                                                        });
+                                                    }
+                                                });
+                                            }
+                                        },
+                                        networkofferingid: {
+                                            docID: 'helpGuestNetworkNetworkOffering',
+                                            label: 'label.network.offering',
+                                            select: function (args) {
+                                                $.ajax({
+                                                    url: createURL("listNetworkOfferings"),
+                                                    data: {
+                                                        zoneid: args.context.vpc[0].zoneid,
+                                                        traffictype: "Guest",
+                                                        specifyvlan: "true",
+                                                        keyword: "private"
+                                                    },
+                                                    success: function (json) {
+                                                        var objs = json.listnetworkofferingsresponse.networkoffering;
                                                         var items = [];
                                                         $(objs).each(function () {
                                                             items.push({
@@ -2153,6 +2210,7 @@
                                         url: createURL('createPrivateGateway' + array1.join("")),
                                         data: {
                                             physicalnetworkid: args.data.physicalnetworkid,
+                                            networkofferingid: args.data.networkofferingid,
                                             vpcid: args.context.vpc[0].id,
                                             ipaddress: args.data.ipaddress,
                                             gateway: args.data.gateway,

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/CreatePrivateGatewayCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/CreatePrivateGatewayCmd.java
@@ -13,6 +13,7 @@ import com.cloud.api.response.NetworkOfferingResponse;
 import com.cloud.api.response.PhysicalNetworkResponse;
 import com.cloud.api.response.PrivateGatewayResponse;
 import com.cloud.api.response.VpcResponse;
+import com.cloud.context.CallContext;
 import com.cloud.event.EventTypes;
 import com.cloud.exception.ConcurrentOperationException;
 import com.cloud.exception.InsufficientCapacityException;
@@ -164,7 +165,7 @@ public class CreatePrivateGatewayCmd extends BaseAsyncCreateCmd {
 
     @Override
     public long getEntityOwnerId() {
-        return Account.ACCOUNT_ID_SYSTEM;
+        return CallContext.current().getCallingAccount().getId();
     }
 
     @Override

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/DeletePrivateGatewayCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/DeletePrivateGatewayCmd.java
@@ -92,6 +92,6 @@ public class DeletePrivateGatewayCmd extends BaseAsyncCmd {
 
     @Override
     public long getEntityOwnerId() {
-        return Account.ACCOUNT_ID_SYSTEM;
+        return CallContext.current().getCallingAccount().getId();
     }
 }

--- a/cosmic-core/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -3053,8 +3053,10 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             }
         }
 
-        // Don't return system network offerings to the user
-        sc.addAnd("systemOnly", SearchCriteria.Op.EQ, false);
+        // Don't return system network offerings to the user except for private gateway offerings
+        if (keyword == null || ! keyword.equals("private")) {
+            sc.addAnd("systemOnly", SearchCriteria.Op.EQ, false);
+        }
 
         // if networkId is specified, list offerings available for upgrade only
         // (for this network)


### PR DESCRIPTION
Next to `root admins`, also allow `domain admins` to create and delete private gateways for their VPCs.

This is a private gw I created as domain admin "remi" between two VPCs:

```
5: eth3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 06:d9:6a:00:00:4a brd ff:ff:ff:ff:ff:ff
    inet 172.17.0.2/24 brd 172.17.0.255 scope global eth3
       valid_lft forever preferred_lft forever
root@r-7-VM:~# ping 172.17.0.1
PING 172.17.0.1 (172.17.0.1): 48 data bytes
56 bytes from 172.17.0.1: icmp_seq=0 ttl=64 time=2.756 ms
56 bytes from 172.17.0.1: icmp_seq=1 ttl=64 time=0.868 ms
^C--- 172.17.0.1 ping statistics ---
2 packets transmitted, 2 packets received, 0% packet loss
round-trip min/avg/max/stddev = 0.868/1.812/2.756/0.944 ms
root@r-7-VM:~# 
```