### PR TITLE
Remove deleted API cmds from commands.properties

### DIFF
--- a/cosmic-client/src/main/resources/commands.properties
+++ b/cosmic-client/src/main/resources/commands.properties
@@ -3,14 +3,6 @@
 ### CloudStack authentication commands
 login=15
 logout=15
-### SAML SSO/SLO commands
-samlSso=15
-samlSlo=15
-getSPMetadata=15
-listIdps=15
-authorizeSamlSso=7
-listSamlAuthorization=7
-listAndSwitchSamlAccount=15
 ### Account commands
 createAccount=7
 deleteAccount=7
@@ -257,10 +249,6 @@ findHostsForMigration=1
 addSecondaryStorage=1
 updateHostPassword=1
 releaseHostReservation=1
-#### VmWare DC
-addVmwareDc=1
-removeVmwareDc=1
-listVmwareDcs=1
 #### volume commands
 attachVolume=15
 uploadVolume=15
@@ -445,14 +433,6 @@ listVpnGateways=15
 listVpnConnections=15
 updateVpnConnection=15
 updateVpnGateway=15
-#### router commands
-createVirtualRouterElement=7
-configureVirtualRouterElement=7
-listVirtualRouterElements=7
-#### ovs commands
-createOvsElement=7
-configureOvsElement=7
-listOvsElements=7
 #### usage commands
 generateUsageRecords=1
 listUsageRecords=7
@@ -462,23 +442,6 @@ removeRawUsageRecords=1
 addTrafficMonitor=1
 deleteTrafficMonitor=1
 listTrafficMonitors=1
-#### Cisco Nexus 1000v Virtual Supervisor Module (VSM) commands
-deleteCiscoNexusVSM=1
-enableCiscoNexusVSM=1
-disableCiscoNexusVSM=1
-listCiscoNexusVSMs=1
-#### juniper srx firewall commands
-addSrxFirewall=1
-deleteSrxFirewall=1
-configureSrxFirewall=1
-listSrxFirewalls=1
-listSrxFirewallNetworks=1
-#### Palo Alto firewall commands
-addPaloAltoFirewall=1
-deletePaloAltoFirewall=1
-configurePaloAltoFirewall=1
-listPaloAltoFirewalls=1
-listPaloAltoFirewallNetworks=1
 #### nicira nvp commands
 addNiciraNvpDevice=1
 deleteNiciraNvpDevice=1
@@ -486,25 +449,11 @@ listNiciraNvpDevices=1
 listNiciraNvpDeviceNetworks=1
 # Not implemented (yet)
 #configureNiciraNvpDevice=1
-#### stratosphere ssp commands
-addStratosphereSsp=1
-deleteStratoshereSsp=1
-#### nuage vsp commands
-addNuageVspDevice=1
-updateNuageVspDevice=1
-deleteNuageVspDevice=1
-listNuageVspDevices=1
-issueNuageVspResourceRequest=15
 #### api discovery commands
 listApis=15
 #### API Rate Limit service command
 getApiLimit=15
 resetApiLimit=1
-#### API SolidFire Service Command
-getSolidFireAccountId=15
-getSolidFireVolumeSize=15
-getSolidFireVolumeAccessGroupId=15
-getSolidFireVolumeIscsiName=15
 #### Region commands
 addRegion=1
 updateRegion=1
@@ -537,14 +486,6 @@ deleteAffinityGroup=15
 listAffinityGroups=15
 updateVMAffinityGroup=15
 listAffinityGroupTypes=15
-#### Cisco Vnmc commands
-addCiscoVnmcResource=1
-deleteCiscoVnmcResource=1
-listCiscoVnmcResources=1
-#### Cisco Asa1000v commands
-addCiscoAsa1000vResource=1
-deleteCiscoAsa1000vResource=1
-listCiscoAsa1000vResources=1
 #### portable public IP commands
 createPortableIpRange=1
 deletePortableIpRange=1
@@ -576,19 +517,6 @@ listLdapUsers=3
 ldapCreateAccount=3
 importLdapUsers=3
 linkDomainToLdap=3
-#### juniper-contrail commands
-createServiceInstance=1
 ### volume/template post upload
 getUploadParamsForVolume=15
 getUploadParamsForTemplate=15
-### Quota Service
-quotaStatement=15
-quotaBalance=15
-quotaSummary=15
-quotaUpdate=1
-quotaTariffList=15
-quotaTariffUpdate=1
-quotaCredits=1
-quotaEmailTemplateList=1
-quotaEmailTemplateUpdate=1
-quotaIsEnabled=15


### PR DESCRIPTION
This removes several of these warnings:

```
Check, is this api part of another build profile? Null value for key: xxxxxxx
```

FYI The 3 deleted `router commands` were duplicates.