### PR TITLE
Make use of the gateway service in the offering

### DIFF
--- a/cosmic-agent/src/main/java/com/cloud/agent/service/Agent.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/service/Agent.java
@@ -463,7 +463,7 @@ public class Agent implements HandlerFactory, IAgentControl {
 
         final ReadyCommand ready = (ReadyCommand) cmd;
 
-        logger.info("Proccess agent ready command, agent id = " + ready.getHostId());
+        logger.info("Process agent ready command, agent id = " + ready.getHostId());
         if (ready.getHostId() != null) {
             setId(ready.getHostId());
         }
@@ -509,7 +509,7 @@ public class Agent implements HandlerFactory, IAgentControl {
             return;
         }
 
-        logger.info("Proccess agent startup answer, agent id = " + startup.getHostId());
+        logger.info("Process agent startup answer, agent id = " + startup.getHostId());
 
         setId(startup.getHostId());
         _pingInterval = (long) startup.getPingInterval() * 1000; // change to ms.
@@ -806,7 +806,7 @@ public class Agent implements HandlerFactory, IAgentControl {
             try {
                 _link.send(request.toBytes());
             } catch (final ClosedChannelException e) {
-                logger.warn("Unable to post agent control reques: " + request.toString());
+                logger.warn("Unable to post agent control request: " + request.toString());
                 throw new AgentControlChannelException("Unable to post agent control request due to " + e.getMessage());
             }
         } else {

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/NicProfileHelperImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/NicProfileHelperImpl.java
@@ -98,8 +98,8 @@ public class NicProfileHelperImpl implements NicProfileHelper {
         final NicProfile guestNic = new NicProfile();
 
         // Redundant VPCs should not acquire the gateway ip because that is the VIP between the two routers to which guest VMs connect
-        // VPCs without sourcenat service also should not acquire the gateway ip because it is in use by an external device on the network
-        if (vpcRouterDeploymentDefinition.isRedundant() || !vpcRouterDeploymentDefinition.hasSourceNatService()) {
+        // VPCs without gateway service also should not acquire the gateway ip because it is in use by an external device on the network
+        if (vpcRouterDeploymentDefinition.isRedundant() || !vpcRouterDeploymentDefinition.hasGatewayService()) {
             guestNic.setIPv4Address(_ipAddrMgr.acquireGuestIpAddressForRouter(guestNetwork, null));
         } else {
             guestNic.setIPv4Address(guestNetwork.getGateway());

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/deployment/RouterDeploymentDefinition.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/deployment/RouterDeploymentDefinition.java
@@ -88,6 +88,7 @@ public class RouterDeploymentDefinition {
     protected Long serviceOfferingId;
     protected Long tableLockId;
     protected boolean isPublicNetwork;
+    protected boolean isGateway = true;
     protected PublicIp sourceNatIp;
 
     protected RouterDeploymentDefinition(final Network guestNetwork, final DeployDestination dest, final Account owner, final Map<Param, Object> params) {
@@ -167,6 +168,10 @@ public class RouterDeploymentDefinition {
 
     public boolean hasSourceNatService() {
         return isPublicNetwork;
+    }
+
+    public boolean hasGatewayService() {
+        return isGateway;
     }
 
     protected void generateDeploymentPlan() {

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/deployment/VpcRouterDeploymentDefinition.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/deployment/VpcRouterDeploymentDefinition.java
@@ -126,6 +126,10 @@ public class VpcRouterDeploymentDefinition extends RouterDeploymentDefinition {
         return hasService(Network.Service.SourceNat);
     }
 
+    public boolean hasGatewayService() {
+        return hasService(Network.Service.Gateway);
+    }
+
     private boolean hasService(final Network.Service service) {
         final Map<Network.Service, Set<Network.Provider>> vpcOffSvcProvidersMap = vpcMgr.getVpcOffSvcProvidersMap(vpc.getVpcOfferingId());
         try {

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -451,7 +451,9 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             svcProviderMap.put(Service.NetworkACL, defaultProviders);
         }
 
-        svcProviderMap.put(Service.Gateway, defaultProviders);
+        // we should make the gateway service addition explicit
+        // will probably break the tests!
+        //svcProviderMap.put(Service.Gateway, defaultProviders);
 
         if (serviceProviders != null) {
             for (final Entry<String, List<String>> serviceEntry : serviceProviders.entrySet()) {

--- a/cosmic-core/test/integration/smoke/test_password_server.py
+++ b/cosmic-core/test/integration/smoke/test_password_server.py
@@ -82,8 +82,9 @@ class Services:
             "redundant_vpc_offering": {
                 "name": 'Redundant VPC off',
                 "displaytext": 'Redundant VPC off',
-                "supportedservices": 'Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat',
+                "supportedservices": 'Gateway,Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat',
                 "serviceProviderList": {
+                    "Gateway": 'VpcVirtualRouter',
                     "Vpn": 'VpcVirtualRouter',
                     "Dhcp": 'VpcVirtualRouter',
                     "Dns": 'VpcVirtualRouter',
@@ -124,7 +125,7 @@ class Services:
                 "name": "VPC off",
                 "displaytext": "VPC off",
                 "supportedservices":
-                    "Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat,NetworkACL"
+                    "Gateway,Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat,NetworkACL"
             },
             "vpc": {
                 "name": "TestVPC",

--- a/cosmic-core/test/integration/smoke/test_privategw_acl.py
+++ b/cosmic-core/test/integration/smoke/test_privategw_acl.py
@@ -82,8 +82,9 @@ class Services:
             "redundant_vpc_offering": {
                 "name": 'Redundant VPC off',
                 "displaytext": 'Redundant VPC off',
-                "supportedservices": 'Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat',
+                "supportedservices": 'Gateway,Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat',
                 "serviceProviderList": {
+                    "Gateway": 'VpcVirtualRouter',
                     "Vpn": 'VpcVirtualRouter',
                     "Dhcp": 'VpcVirtualRouter',
                     "Dns": 'VpcVirtualRouter',
@@ -104,7 +105,7 @@ class Services:
                 "name": "VPC off",
                 "displaytext": "VPC off",
                 "supportedservices":
-                    "Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat,NetworkACL"
+                    "Gateway,Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat,NetworkACL"
             },
             "vpc": {
                 "name": "TestVPC",

--- a/cosmic-core/test/integration/smoke/test_vpc_router_nics.py
+++ b/cosmic-core/test/integration/smoke/test_vpc_router_nics.py
@@ -89,7 +89,7 @@ class Services:
             "vpc_offering": {
                 "name": 'VPC off',
                 "displaytext": 'VPC off',
-                "supportedservices": 'Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat',
+                "supportedservices": 'Gateway,Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat',
             },
             "vpc": {
                 "name": "TestVPC",

--- a/cosmic-core/test/integration/smoke/test_vpc_vpn.py
+++ b/cosmic-core/test/integration/smoke/test_vpc_vpn.py
@@ -106,13 +106,14 @@ class Services:
             "vpc_offering": {
                 "name": 'VPC off',
                 "displaytext": 'VPC off',
-                "supportedservices": 'Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat',
+                "supportedservices": 'Gateway,Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat',
             },
             "redundant_vpc_offering": {
                 "name": 'Redundant VPC off',
                 "displaytext": 'Redundant VPC off',
-                "supportedservices": 'Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat',
+                "supportedservices": 'Gateway,Dhcp,Dns,SourceNat,PortForwarding,Vpn,Lb,UserData,StaticNat',
                 "serviceProviderList": {
+                    "Gateway": 'VpcVirtualRouter',
                     "Vpn": 'VpcVirtualRouter',
                     "Dhcp": 'VpcVirtualRouter',
                     "Dns": 'VpcVirtualRouter',


### PR DESCRIPTION
The method `VpcRouterDeploymentDefinition.hasService(...)` remains on `VpcRouterDeploymentDefinition` as its implementation heavily relies on VPC's services and providers.