### PR TITLE
Including VMs with the state 'Starting' into the mix

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/deploy/DeploymentPlanner.java
+++ b/cosmic-core/api/src/main/java/com/cloud/deploy/DeploymentPlanner.java
@@ -16,8 +16,6 @@ import java.util.Collection;
 import java.util.Set;
 import java.util.TreeSet;
 
-/**
- */
 public interface DeploymentPlanner extends Adapter {
 
     /**

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDao.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDao.java
@@ -102,7 +102,7 @@ public interface VMInstanceDao extends GenericDao<VMInstanceVO, Long>, StateDao<
 
     List<Long> listHostIdsByVmCount(long dcId, Long podId, Long clusterId, long accountId);
 
-    Long countRunningByAccount(long accountId);
+    Long countStartingOrRunningByAccount(long accountId);
 
     List<VMInstanceVO> listNonRemovedVmsByTypeAndNetwork(long networkId, VirtualMachine.Type... types);
 

--- a/cosmic-core/plugins/deployment-planners/user-dispersing/src/main/java/com/cloud/deploy/UserDispersingPlanner.java
+++ b/cosmic-core/plugins/deployment-planners/user-dispersing/src/main/java/com/cloud/deploy/UserDispersingPlanner.java
@@ -19,7 +19,8 @@ import org.slf4j.LoggerFactory;
 public class UserDispersingPlanner extends FirstFitPlanner implements DeploymentClusterPlanner {
 
     private static final Logger s_logger = LoggerFactory.getLogger(UserDispersingPlanner.class);
-    float _userDispersionWeight;
+
+    private float _userDispersionWeight;
 
     /**
      * This method should reorder the given list of Cluster Ids by applying any necessary heuristic
@@ -83,7 +84,7 @@ public class UserDispersingPlanner extends FirstFitPlanner implements Deployment
 
     protected Pair<List<Long>, Map<Long, Double>> listPodsByUserDispersion(final long dataCenterId, final long accountId) {
         if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Applying Userdispersion heuristic to pods for account: " + accountId);
+            s_logger.debug("Applying user dispersion heuristic to pods for account: " + accountId);
         }
         final Pair<List<Long>, Map<Long, Double>> podIdsVmCountInfo = vmInstanceDao.listPodIdsInZoneByVmCount(dataCenterId, accountId);
         if (s_logger.isTraceEnabled()) {
@@ -105,7 +106,7 @@ public class UserDispersingPlanner extends FirstFitPlanner implements Deployment
 
     protected Pair<List<Long>, Map<Long, Double>> listClustersByUserDispersion(final long id, final boolean isZone, final long accountId) {
         if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Applying Userdispersion heuristic to clusters for account: " + accountId);
+            s_logger.debug("Applying user dispersion heuristic to clusters for account: " + accountId);
         }
         final Pair<List<Long>, Map<Long, Double>> clusterIdsVmCountInfo;
         if (isZone) {
@@ -141,7 +142,7 @@ public class UserDispersingPlanner extends FirstFitPlanner implements Deployment
         //normalize the vmCountMap
         final LinkedHashMap<Long, Double> normalisedVmCountIdMap = new LinkedHashMap<>();
 
-        final Long totalVmsOfAccount = vmInstanceDao.countRunningByAccount(accountId);
+        final Long totalVmsOfAccount = vmInstanceDao.countStartingOrRunningByAccount(accountId);
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("Total VMs for account: " + totalVmsOfAccount);
         }

--- a/cosmic-core/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
+++ b/cosmic-core/server/src/main/java/com/cloud/deploy/FirstFitPlanner.java
@@ -189,17 +189,14 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
             uniqueTags = (long) 0;
             final List<Long> hostList = capacityDao.listHostsWithEnoughCapacity(requiredCpu, requiredRam, clusterId, Host.Type.Routing.toString());
             if (!hostList.isEmpty() && implicitHostTags.length > 0) {
-                uniqueTags = new Long(hostTagsDao.getDistinctImplicitHostTags(hostList, implicitHostTags).size());
+                uniqueTags = (long) hostTagsDao.getDistinctImplicitHostTags(hostList, implicitHostTags).size();
             }
             UniqueTagsInClusterMap.put(clusterId, uniqueTags);
         }
-        Collections.sort(clusterList, new Comparator<Long>() {
-            @Override
-            public int compare(final Long o1, final Long o2) {
-                final Long t1 = UniqueTagsInClusterMap.get(o1);
-                final Long t2 = UniqueTagsInClusterMap.get(o2);
-                return t1.compareTo(t2);
-            }
+        clusterList.sort((o1, o2) -> {
+            final Long t1 = UniqueTagsInClusterMap.get(o1);
+            final Long t2 = UniqueTagsInClusterMap.get(o2);
+            return t1.compareTo(t2);
         });
     }
 
@@ -375,8 +372,7 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
             return null;
         }
         if (!prioritizedClusterIds.isEmpty()) {
-            final List<Long> clusterList = reorderClusters(id, isZone, clusterCapacityInfo, vmProfile, plan);
-            return clusterList; //return checkClustersforDestination(clusterList, vmProfile, plan, avoid, dc);
+            return reorderClusters(id, isZone, clusterCapacityInfo, vmProfile, plan); //return checkClustersforDestination(clusterList, vmProfile, plan, avoid, dc);
         } else {
             if (s_logger.isDebugEnabled()) {
                 s_logger.debug("No clusters found after removing disabled clusters and clusters in avoid list, returning.");
@@ -395,8 +391,7 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
      */
     protected List<Long> reorderClusters(final long id, final boolean isZone, final Pair<List<Long>, Map<Long, Double>> clusterCapacityInfo, final VirtualMachineProfile vmProfile,
                                          final DeploymentPlan plan) {
-        final List<Long> reordersClusterIds = clusterCapacityInfo.first();
-        return reordersClusterIds;
+        return clusterCapacityInfo.first();
     }
 
     /**
@@ -408,8 +403,7 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
      * @return List<Long> ordered list of Pod Ids
      */
     protected List<Long> reorderPods(final Pair<List<Long>, Map<Long, Double>> podCapacityInfo, final VirtualMachineProfile vmProfile, final DeploymentPlan plan) {
-        final List<Long> podIdsByCapacity = podCapacityInfo.first();
-        return podIdsByCapacity;
+        return podCapacityInfo.first();
     }
 
     private List<Long> listDisabledClusters(final long zoneId, final Long podId) {
@@ -423,8 +417,7 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
     }
 
     private List<Long> listDisabledPods(final long zoneId) {
-        final List<Long> disabledPods = podDao.listDisabledPods(zoneId);
-        return disabledPods;
+        return podDao.listDisabledPods(zoneId);
     }
 
     protected Pair<List<Long>, Map<Long, Double>> listClustersByCapacity(final long id, final int requiredCpu, final long requiredRam, final ExcludeList avoid, final boolean
@@ -496,14 +489,7 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
     }
 
     private boolean isRootAdmin(final VirtualMachineProfile vmProfile) {
-        if (vmProfile != null) {
-            if (vmProfile.getOwner() != null) {
-                return accountMgr.isRootAdmin(vmProfile.getOwner().getId());
-            } else {
-                return false;
-            }
-        }
-        return false;
+        return vmProfile != null && vmProfile.getOwner() != null && accountMgr.isRootAdmin(vmProfile.getOwner().getId());
     }
 
     @Override


### PR DESCRIPTION
When VMs are created with automated tools like Terraform, they are created too fast and they all end up in the same hypervisor. Their state are still in "Starting" when the next one is created and the `UserDispersingPlanner` does not consider/count them. This pull request makes the `UserDispersingPlanner` capable of seeing them.