### PR TITLE
Fix NPE when restart+cleanup a VPC with private gw powered by NSX

### DIFF
--- a/cosmic-core/engine/schema/src/main/java/com/cloud/network/vpc/dao/PrivateIpDao.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/network/vpc/dao/PrivateIpDao.java
@@ -13,7 +13,7 @@ public interface PrivateIpDao extends GenericDao<PrivateIpVO, Long> {
      * @param requestedIp TODO
      * @return
      */
-    PrivateIpVO allocateIpAddress(long dcId, long networkId, String requestedIp);
+    PrivateIpVO allocateIpAddress(long dcId, long networkId, Long vpcId, String requestedIp);
 
     /**
      * @param ipAddress

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/network/vpc/dao/PrivateIpDaoImpl.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/network/vpc/dao/PrivateIpDaoImpl.java
@@ -50,10 +50,13 @@ public class PrivateIpDaoImpl extends GenericDaoBase<PrivateIpVO, Long> implemen
     }
 
     @Override
-    public PrivateIpVO allocateIpAddress(final long dcId, final long networkId, final String requestedIp) {
+    public PrivateIpVO allocateIpAddress(final long dcId, final long networkId, final Long vpcId, final String requestedIp) {
         final SearchCriteria<PrivateIpVO> sc = AllFieldsSearch.create();
         sc.setParameters("networkId", networkId);
-        sc.setParameters("taken", (Date) null);
+
+        if (vpcId != null) {
+            sc.setParameters("vpc_id", vpcId);
+        }
 
         if (requestedIp != null) {
             sc.setParameters("ipAddress", requestedIp);

--- a/cosmic-core/server/src/main/java/com/cloud/network/guru/PrivateNetworkGuru.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/guru/PrivateNetworkGuru.java
@@ -138,7 +138,7 @@ public class PrivateNetworkGuru extends AdapterBase implements NetworkGuru {
     protected void getIp(final NicProfile nic, final DataCenter dc, final Network network) throws InsufficientVirtualNetworkCapacityException,
             InsufficientAddressCapacityException {
         if (nic.getIPv4Address() == null) {
-            final PrivateIpVO ipVO = _privateIpDao.allocateIpAddress(network.getDataCenterId(), network.getId(), null);
+            final PrivateIpVO ipVO = _privateIpDao.allocateIpAddress(network.getDataCenterId(), network.getId(), network.getVpcId(), null);
             final String vlanTag = BroadcastDomainType.getValue(network.getBroadcastUri());
             final String netmask = NetUtils.getCidrNetmask(network.getCidr());
             final PrivateIpAddress ip =

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/NicProfileHelperImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/NicProfileHelperImpl.java
@@ -44,10 +44,11 @@ public class NicProfileHelperImpl implements NicProfileHelper {
     public NicProfile createPrivateNicProfileForGateway(final VpcGateway privateGateway, final VirtualRouter router) {
         final Network privateNetwork = _networkModel.getNetwork(privateGateway.getNetworkId());
 
-        PrivateIpVO ipVO = _privateIpDao.allocateIpAddress(privateNetwork.getDataCenterId(), privateNetwork.getId(), privateGateway.getIp4Address());
-
         final Long vpcId = privateGateway.getVpcId();
         final Vpc activeVpc = _vpcMgr.getActiveVpc(vpcId);
+
+        PrivateIpVO ipVO = _privateIpDao.allocateIpAddress(privateNetwork.getDataCenterId(), privateNetwork.getId(), vpcId, privateGateway.getIp4Address());
+
         if (activeVpc.isRedundant() && ipVO == null) {
             ipVO = _privateIpDao.findByIpAndVpcId(vpcId, privateGateway.getIp4Address());
         }


### PR DESCRIPTION
Basically changed to lookup `private gw ip` by `networkId`, `VpcId` and `RequestedIp`. Before the `taken` field needed to be `null` as it'd look for all available IPs in `private_ip_address` table. But private gateways are statically defined and do not grab a random ip from the pool. The 'pool' is just one ip you specify at creation time.
Since `taken` has a date after initial deployment, no ip could be grabbed later on, so `ipVO` was `null` resulting in `NPE` later on. 
Instead, now we select the right ip from the db by looking at the `networkId` (private gw network), `vpcId` and the private gateway's `Ipaddress`. That's a reliable combination that always gives the desired result.

With this PR, combined with https://github.com/MissionCriticalCloud/bubble-toolkit/pull/181 and https://github.com/MissionCriticalCloud/bubble-toolkit/pull/182 I could deploy a NSX based cloud and create, delete and restart+cleanup without any issues.

Also tested multiple private gateways per VPC and that also worked great.

```
vm1 -- vpc1 --- pgw --- vpc2 -- pgw -- vpc3 -- vm3
```

Traffic then flows from `vm1` to `vpc1`, via the first `pgw` arriving on `vpc2`, then via its second `pgw` towards `vpc3` finally reaching `vm3`.

```
[root@Macchinina ~]# traceroute 10.1.0.122
traceroute to 10.1.0.122 (10.1.0.122), 30 hops max, 46 byte packets
 1  10.3.0.1 (10.3.0.1)  1.309 ms  0.660 ms  0.547 ms
 2  172.16.2.2 (172.16.2.2)  1.248 ms  0.994 ms  0.886 ms
 3  172.16.1.1 (172.16.1.1)  1.661 ms  1.170 ms  1.169 ms
 4  10.1.0.122 (10.1.0.122)  2.634 ms  1.824 ms  1.820 ms
[root@Macchinina ~]# 
```

Hopefully the problems with the cleanups are now over for good ;-)