### PR TITLE
Add deviceId to Serial parameter of the LibVirt VM definition

### DIFF
--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1912,7 +1912,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
             if (data instanceof VolumeObjectTO) {
                 final VolumeObjectTO volumeObjectTo = (VolumeObjectTO) data;
-                disk.setSerial(diskUuidToSerial(volumeObjectTo.getUuid()));
+                disk.setSerial(volumeObjectTo.getDeviceId() + "-" + diskUuidToSerial(volumeObjectTo.getUuid()));
                 if (volumeObjectTo.getBytesReadRate() != null && volumeObjectTo.getBytesReadRate() > 0) {
                     disk.setBytesReadRate(volumeObjectTo.getBytesReadRate());
                 }

--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KvmStorageProcessor.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KvmStorageProcessor.java
@@ -829,7 +829,7 @@ public class KvmStorageProcessor implements StorageProcessor {
         final VolumeObjectTO vol = (VolumeObjectTO) disk.getData();
         final PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO) vol.getDataStore();
         final String vmName = cmd.getVmName();
-        final String serial = resource.diskUuidToSerial(vol.getUuid());
+        final String serial = disk.getDiskSeq() + "-" + resource.diskUuidToSerial(vol.getUuid());
         try {
             final Connect conn = LibvirtConnection.getConnectionByVmName(vmName);
 


### PR DESCRIPTION
This makes it possible to link the DeviceIds as you specify them on the Cosmic API to the devices in the OS. 

Example:
```
(local) 🐵 > list volumes virtualmachineid=7d66b036-270b-4ec8-9a75-99a7f8249446 filter=name,deviceid
count = 4
volume:
+----------------+----------+
|      name      | deviceid |
+----------------+----------+
|   ANOTHER-9    |    9     |
|     ROOT-5     |    0     |
|     DISK-5     |    5     |
| DISK-REMI-DATA |    8     |
+----------------+----------+
```

On the OS, Linux as example:

```
[root@vm-7d66b036-270b-4ec8-9a75-99a7f8249446 ~]# ls -l /dev/disk/by-id/
total 0
lrwxrwxrwx. 1 root root  9 Dec 29 16:38 ata-QEMU_DVD-ROM_QM00003 -> ../../sr0
lrwxrwxrwx. 1 root root  9 Dec 29 16:38 virtio-0-f043f3b303a84b8396 -> ../../vda
lrwxrwxrwx. 1 root root 10 Dec 29 16:38 virtio-0-f043f3b303a84b8396-part1 -> ../../vda1
lrwxrwxrwx. 1 root root  9 Dec 29 16:38 virtio-5-f26f05bc06cc474aa6 -> ../../vdb
lrwxrwxrwx. 1 root root  9 Dec 29 16:38 virtio-8-b9250669cc274f46a6 -> ../../vdc
lrwxrwxrwx. 1 root root  9 Dec 29 18:50 virtio-9-ea556a7ef3e341adac -> ../../vdd
```

It seems the max chars a VM will show is 20, even when you put more in the XML:

```
    <disk type='file' device='disk'>
      <driver name='qemu' type='qcow2' cache='none'/>
      <source file='/mnt/f9160a20-70c7-38f4-a980-29f0c16f010c/f043f3b3-03a8-4b83-969f-f8cf682975ae'/>
      <target dev='vda' bus='virtio'/>
      <serial>0-f043f3b303a84b83969f</serial>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
    </disk>
    <disk type='file' device='disk'>
      <driver name='qemu' type='qcow2' cache='none'/>
      <source file='/mnt/f9160a20-70c7-38f4-a980-29f0c16f010c/f26f05bc-06cc-474a-a6f7-f8fb5bc6a3dc'/>
      <target dev='vdf' bus='virtio'/>
      <serial>5-f26f05bc06cc474aa6f7</serial>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
    </disk>
    <disk type='file' device='disk'>
      <driver name='qemu' type='qcow2' cache='none'/>
      <source file='/mnt/f9160a20-70c7-38f4-a980-29f0c16f010c/b9250669-cc27-4f46-a666-7712680a67ef'/>
      <target dev='vdi' bus='virtio'/>
      <serial>8-b9250669cc274f46a666</serial>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
    </disk>
    <disk type='file' device='disk'>
      <driver name='qemu' type='qcow2' cache='none'/>
      <source file='/mnt/f9160a20-70c7-38f4-a980-29f0c16f010c/ea556a7e-f3e3-41ad-ac25-12744b1228d8'/>
      <target dev='vdj' bus='virtio'/>
      <serial>9-ea556a7ef3e341adac25</serial>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x0c' function='0x0'/>
    </disk>
    <disk type='file' device='cdrom'>
      <driver name='qemu' type='raw' cache='none'/>
      <target dev='hdc' bus='ide'/>
      <readonly/>
      <address type='drive' controller='0' bus='1' target='0' unit='0'/>
    </disk>
```

So `<serial>5-f26f05bc06cc474aa6f7</serial>` becomes `virtio-5-f26f05bc06cc474aa6`. This used to be `virtio-f26f05bc06cc474aa6f7`. As discussed, this is what we want now.
