### PR TITLE
When configuring interfaces lookup the deviceName based on mac address

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/agent/api/to/IpAddressTO.java
+++ b/cosmic-core/api/src/main/java/com/cloud/agent/api/to/IpAddressTO.java
@@ -14,15 +14,17 @@ public class IpAddressTO {
     private String vlanGateway;
     private String vlanNetmask;
     private String vifMacAddress;
+    private String deviceMacAddress;
     private Integer networkRate;
     private TrafficType trafficType;
     private String networkName;
     private Integer nicDevId;
     private boolean newNic;
 
-    public IpAddressTO(final long accountId, final String ipAddress, final boolean add, final boolean firstIP, final boolean sourceNat, final String broadcastUri, final String
-            vlanGateway, final String vlanNetmask,
-                       final String vifMacAddress, final Integer networkRate, final boolean isOneToOneNat) {
+    public IpAddressTO(final long accountId, final String ipAddress, final boolean add, final boolean firstIP,
+                       final boolean sourceNat, final String broadcastUri, final String vlanGateway,
+                       final String vlanNetmask, final String vifMacAddress, final String deviceMacAddress,
+                       final Integer networkRate, final boolean isOneToOneNat) {
         this.accountId = accountId;
         this.publicIp = ipAddress;
         this.add = add;
@@ -32,6 +34,7 @@ public class IpAddressTO {
         this.vlanGateway = vlanGateway;
         this.vlanNetmask = vlanNetmask;
         this.vifMacAddress = vifMacAddress;
+        this.deviceMacAddress = deviceMacAddress;
         this.networkRate = networkRate;
         this.oneToOneNat = isOneToOneNat;
     }
@@ -118,4 +121,13 @@ public class IpAddressTO {
     public void setNewNic(final boolean newNic) {
         this.newNic = newNic;
     }
+
+    public String getDeviceMacAddress() {
+        return deviceMacAddress;
+    }
+
+    public void setDeviceMacAddress(String deviceMacAddress) {
+        this.deviceMacAddress = deviceMacAddress;
+    }
+
 }

--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/IpAssociationConfigItem.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/IpAssociationConfigItem.java
@@ -21,8 +21,9 @@ public class IpAssociationConfigItem extends AbstractConfigItemFacade {
         final List<IpAddress> ips = new LinkedList<>();
 
         for (final IpAddressTO ip : command.getIpAddresses()) {
-            final IpAddress ipAddress = new IpAddress(ip.getPublicIp(), ip.isSourceNat(), ip.isAdd(), ip.isOneToOneNat(), ip.isFirstIP(), ip.getVlanGateway(), ip.getVlanNetmask(),
-                    ip.getVifMacAddress(), ip.getNicDevId(), ip.isNewNic(), ip.getTrafficType().toString().toLowerCase());
+            final IpAddress ipAddress = new IpAddress(ip.getPublicIp(), ip.isSourceNat(), ip.isAdd(),
+                    ip.isOneToOneNat(), ip.isFirstIP(), ip.getVlanGateway(), ip.getVlanNetmask(), ip.getVifMacAddress(),
+                    ip.getDeviceMacAddress(), ip.getNicDevId(), ip.isNewNic(), ip.getTrafficType().toString().toLowerCase());
             ips.add(ipAddress);
         }
 

--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/model/IpAddress.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/model/IpAddress.java
@@ -9,6 +9,7 @@ public class IpAddress {
     private String gateway;
     private String netmask;
     private String vifMacAddress;
+    private String deviceMacAddress;
     private Integer nicDevId;
     private boolean newNic;
     private String nwType;
@@ -17,8 +18,9 @@ public class IpAddress {
         // Empty constructor for (de)serialization
     }
 
-    public IpAddress(final String publicIp, final boolean sourceNat, final boolean add, final boolean oneToOneNat, final boolean firstIP, final String gateway,
-                     final String netmask, final String vifMacAddress, final Integer nicDevId, final boolean newNic, final String nwType) {
+    public IpAddress(final String publicIp, final boolean sourceNat, final boolean add, final boolean oneToOneNat,
+                     final boolean firstIP, final String gateway, final String netmask, final String vifMacAddress,
+                     final String deviceMacAddress, final Integer nicDevId, final boolean newNic, final String nwType) {
         super();
         this.publicIp = publicIp;
         this.sourceNat = sourceNat;
@@ -28,6 +30,7 @@ public class IpAddress {
         this.gateway = gateway;
         this.netmask = netmask;
         this.vifMacAddress = vifMacAddress;
+        this.deviceMacAddress = deviceMacAddress;
         this.nicDevId = nicDevId;
         this.newNic = newNic;
         this.nwType = nwType;
@@ -119,5 +122,13 @@ public class IpAddress {
 
     public void setNwType(final String nwType) {
         this.nwType = nwType;
+    }
+
+    public String getDeviceMacAddress() {
+        return deviceMacAddress;
+    }
+
+    public void setDeviceMacAddress(final String deviceMacAddress) {
+        this.deviceMacAddress = deviceMacAddress;
     }
 }

--- a/cosmic-core/nucleo/src/test/java/com/cloud/agent/resource/virtualnetwork/ConfigHelperTest.java
+++ b/cosmic-core/nucleo/src/test/java/com/cloud/agent/resource/virtualnetwork/ConfigHelperTest.java
@@ -171,9 +171,9 @@ public class ConfigHelperTest {
     protected IpAssocVpcCommand generateIpAssocVpcCommand() {
         final List<IpAddressTO> ips = new ArrayList<>();
 
-        final IpAddressTO ip1 = new IpAddressTO(1, "64.1.1.10", true, true, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false);
-        final IpAddressTO ip2 = new IpAddressTO(2, "64.1.1.11", false, false, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false);
-        final IpAddressTO ip3 = new IpAddressTO(3, "65.1.1.11", true, false, false, "vlan://65", "65.1.1.1", "255.255.255.0", "11:23:45:67:89:AB", 1000, false);
+        final IpAddressTO ip1 = new IpAddressTO(1, "64.1.1.10", true, true, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", "00:01:23:45:67:89", 1000, false);
+        final IpAddressTO ip2 = new IpAddressTO(2, "64.1.1.11", false, false, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", "00:01:23:45:67:89", 1000, false);
+        final IpAddressTO ip3 = new IpAddressTO(3, "65.1.1.11", true, false, false, "vlan://65", "65.1.1.1", "255.255.255.0", "11:23:45:67:89:AB", "00:01:23:45:67:89", 1000, false);
         ip1.setTrafficType(TrafficType.Public);
         ip2.setTrafficType(TrafficType.Public);
         ip3.setTrafficType(TrafficType.Public);

--- a/cosmic-core/nucleo/src/test/java/com/cloud/agent/resource/virtualnetwork/VirtualRoutingResourceTest.java
+++ b/cosmic-core/nucleo/src/test/java/com/cloud/agent/resource/virtualnetwork/VirtualRoutingResourceTest.java
@@ -440,9 +440,9 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
 
     protected IpAssocCommand generateIpAssocCommand() {
         final List<IpAddressTO> ips = new ArrayList<>();
-        ips.add(new IpAddressTO(1, "64.1.1.10", true, true, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false));
-        ips.add(new IpAddressTO(2, "64.1.1.11", false, false, false, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false));
-        ips.add(new IpAddressTO(3, "65.1.1.11", true, false, false, "vlan://65", "65.1.1.1", "255.255.255.0", "11:23:45:67:89:AB", 1000, false));
+        ips.add(new IpAddressTO(1, "64.1.1.10", true, true, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", "00:01:23:45:67:89", 1000, false));
+        ips.add(new IpAddressTO(2, "64.1.1.11", false, false, false, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", "00:01:23:45:67:89", 1000, false));
+        ips.add(new IpAddressTO(3, "65.1.1.11", true, false, false, "vlan://65", "65.1.1.1", "255.255.255.0", "11:23:45:67:89:AB", "00:01:23:45:67:89", 1000, false));
         final IpAddressTO[] ipArray = ips.toArray(new IpAddressTO[ips.size()]);
         final IpAssocCommand cmd = new IpAssocCommand(ipArray);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
@@ -464,9 +464,9 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
 
     protected IpAssocVpcCommand generateIpAssocVpcCommand() {
         final List<IpAddressTO> ips = new ArrayList<>();
-        ips.add(new IpAddressTO(1, "64.1.1.10", true, true, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false));
-        ips.add(new IpAddressTO(2, "64.1.1.11", false, false, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false));
-        ips.add(new IpAddressTO(3, "65.1.1.11", true, false, false, "vlan://65", "65.1.1.1", "255.255.255.0", "11:23:45:67:89:AB", 1000, false));
+        ips.add(new IpAddressTO(1, "64.1.1.10", true, true, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", "00:01:23:45:67:89", 1000, false));
+        ips.add(new IpAddressTO(2, "64.1.1.11", false, false, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", "00:01:23:45:67:89", 1000, false));
+        ips.add(new IpAddressTO(3, "65.1.1.11", true, false, false, "vlan://65", "65.1.1.1", "255.255.255.0", "11:23:45:67:89:AB", "00:01:23:45:67:89", 1000, false));
         final IpAddressTO[] ipArray = ips.toArray(new IpAddressTO[ips.size()]);
         final IpAssocVpcCommand cmd = new IpAssocVpcCommand(ipArray);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
@@ -483,7 +483,7 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
     }
 
     protected SetSourceNatCommand generateSetSourceNatCommand() {
-        final IpAddressTO ip = new IpAddressTO(1, "64.1.1.10", true, true, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false);
+        final IpAddressTO ip = new IpAddressTO(1, "64.1.1.10", true, true, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", "00:01:23:45:67:89", 1000, false);
         final SetSourceNatCommand cmd = new SetSourceNatCommand(ip, true);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         return cmd;

--- a/cosmic-core/server/src/main/java/com/cloud/network/ExternalLoadBalancerDeviceManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/ExternalLoadBalancerDeviceManagerImpl.java
@@ -1072,7 +1072,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
         // It's a hack, using isOneToOneNat field for indicate if it's inline or not
         final boolean inline = _networkMgr.isNetworkInlineMode(guestConfig);
         final IpAddressTO ip =
-                new IpAddressTO(guestConfig.getAccountId(), null, add, false, true, guestVlanTag, selfIp, guestVlanNetmask, null, networkRate, inline);
+                new IpAddressTO(guestConfig.getAccountId(), null, add, false, true, guestVlanTag, selfIp, guestVlanNetmask, null, null, networkRate, inline);
         final IpAddressTO[] ips = new IpAddressTO[1];
         ips[0] = ip;
         final IpAssocCommand cmd = new IpAssocCommand(ips);

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -18,7 +18,9 @@ class CsAddress(CsDataBag):
     def compare(self):
         for dev in CsDevice('', self.config).list():
             ip = CsIP(dev, self.config)
-            ip.compare(self.dbag)
+            # Process for all types, except the link local interface
+            if dev is not self.get_control_if():
+                ip.compare(self.dbag)
 
     def get_interfaces(self):
         interfaces = []
@@ -89,6 +91,33 @@ class CsAddress(CsDataBag):
             ip = CsIP(dev, self.config)
 
             for address in self.dbag[dev]:
+                # Double check interface name based on mac address. If it doesn't match, use discovered device name
+                if address['nw_type'] not in ["control"] and ('vif_mac_address' in address or 'device_mac_address' in address):
+                    if 'vif_mac_address' in address:
+                        mac_address_to_check = address['vif_mac_address']
+                    if 'device_mac_address' in address:
+                        mac_address_to_check = address['device_mac_address']
+
+                    found_device = CsHelper.get_device_from_mac_address(mac_address_to_check)
+                    if found_device is False:
+                        logging.warning("While setting up interface with macaddress %s, we couldn't find a "
+                                        "matching device at this time. Skipping setting up for now."
+                                        % mac_address_to_check)
+                        continue
+
+                    elif found_device != address['device']:
+                        logging.warning("The mgt server sends us device %s for macaddress %s but we just found it's "
+                                        "actually on device %s. Will used discovered info instead!" %
+                                        (address['device'], mac_address_to_check, found_device))
+                        address['device'] = found_device
+                        address['nic_dev_id'] = found_device.replace("eth", "")
+                    else:
+                        logging.info("The device using macaddress %s is indeed found to be at %s (%s equals %s)"
+                                     % (mac_address_to_check, found_device, found_device, address['device']))
+                else:
+                    logging.info("Skipping macaddress checks for device of type %s due to known issues. "
+                                 "We'll trust it to be on device %s. " % (address['nw_type'], address['device']))
+
                 ip.setAddress(address)
                 logging.info("Address found in DataBag ==> %s" % address)
 
@@ -617,12 +646,15 @@ class CsIP:
     # Delete any ips that are configured but not in the bag
     def compare(self, bag):
         if len(self.iplist) > 0 and (self.dev not in bag.keys() or len(bag[self.dev]) == 0):
-            # Remove all IPs on this device
-            logging.info(
-                "Will remove all configured addresses on device %s", self.dev)
-            self.delete("all")
-            app = CsApache(self)
-            app.remove()
+            # Handle all except control nics
+            if self.get_type() not in ["control"]:
+                # Remove all IPs on this device
+                logging.info("Will remove all configured addresses on device %s", self.dev)
+                self.delete("all")
+                app = CsApache(self)
+                app.remove()
+            else:
+                logging.info("Not removing interfaces of device %s, as it is control traffic", self.dev)
 
         # This condition should not really happen but did :)
         # It means an apache file got orphaned after a guest network address

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsConfig.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsConfig.py
@@ -17,6 +17,7 @@ class CsConfig(object):
     def __init__(self):
         self.fw = []
         self.ingress_rules = {}
+        self.ips = None
 
     def set_address(self):
         self.ips = CsAddress("ips", self)

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
@@ -39,6 +39,15 @@ def reconfigure_interfaces(router_config, interfaces):
                     execute(cmd)
 
 
+def get_device_from_mac_address(macaddress):
+    logging.info("Looking for interface with macaddress " + macaddress)
+    device = execute("find /sys/class/net/*/address | xargs grep %s | cut -d\/ -f5 " % macaddress)
+    if not device:
+        return False
+    logging.info("Looking for mac address " + macaddress + " we found matching interface => " + str(device))
+    return device[0]
+
+
 def is_mounted(name):
     for i in execute("mount"):
         vals = i.lstrip().split()

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs_guestnetwork.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs_guestnetwork.py
@@ -1,22 +1,12 @@
-keys = ['eth1', 'eth2', 'eth3', 'eth4', 'eth5', 'eth6', 'eth7', 'eth8', 'eth9']
 
+def merge(dbag, ip):
+    for dev in dbag:
+        if dev == "id":
+            continue
+        for address in dbag[dev]:
+            if address['router_guest_ip'] == ip['router_guest_ip']:
+                dbag[dev].remove(address)
 
-def merge(dbag, gn):
-    device = gn['device']
-
-    if not gn['add'] and device in dbag:
-
-        if dbag[device]:
-            device_to_die = dbag[device][0]
-            try:
-                dbag[device].remove(device_to_die)
-            except ValueError, e:
-                print "[WARN] cs_guestnetwork.py :: Error occurred removing item from databag. => %s" % device_to_die
-                del (dbag[device])
-        else:
-            del (dbag[device])
-
-    else:
-        dbag.setdefault(device, []).append(gn)
+    dbag.setdefault('eth' + str(ip['nic_dev_id']), []).append(ip)
 
     return dbag

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py
@@ -4,6 +4,11 @@ from netaddr import *
 
 
 def merge(dbag, ip):
+
+    # Private gateway ip address needs to be in ips.json too, but doesn't have 'public_ip' field
+    if 'public_ip' not in ip:
+        ip['public_ip'] = ip['ip_address']
+
     for dev in dbag:
         if dev == "id":
             continue

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/update_config.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/update_config.py
@@ -14,11 +14,12 @@ from merge import QueueFile
 
 OCCURRENCES = 1
 
-logging.basicConfig(filename='/var/log/cloud.log', level=logging.DEBUG, format='%(asctime)s  %(filename)s %(funcName)s:%(lineno)d %(message)s')
+logging.basicConfig(filename='/var/log/cloud.log', level=logging.DEBUG,
+                    format='%(asctime)s  %(filename)s %(funcName)s:%(lineno)d %(message)s')
 
 # first commandline argument should be the file to process
-if (len(sys.argv) != 2):
-    print "[ERROR]: Invalid usage"
+if len(sys.argv) != 2:
+    print("[ERROR]: Invalid usage")
     sys.exit(1)
 
 # FIXME we should get this location from a configuration class
@@ -34,7 +35,7 @@ def finish_config():
 
 
 def process(do_merge=True):
-    print "[INFO] Processing JSON file %s" % sys.argv[1]
+    print("[INFO] Processing JSON file %s" % sys.argv[1])
     qf = QueueFile()
     qf.setFile(sys.argv[1])
     qf.do_merge = do_merge
@@ -43,32 +44,32 @@ def process(do_merge=True):
 
 
 def process_file():
-    print "[INFO] process_file"
-    qf = process()
+    print("[INFO] process_file")
+    process()
     # Converge
     finish_config()
 
 
 def process_vmpasswd():
-    print "[INFO] process_vmpassword"
+    print("[INFO] process_vmpassword")
     qf = process(False)
-    print "[INFO] Sending password to password server"
+    print("[INFO] Sending password to password server")
     CsPassword(qf.getData())
 
 
-def is_guestnet_configured(guestnet_dict, keys):
+def is_guestnet_configured(guestnet_dict):
     existing_keys = []
-    new_eth_key = None
 
+    # Any interface is OK, except the control interface
     for k1, v1 in guestnet_dict.iteritems():
-        if k1 in keys and len(v1) > 0:
+        if k1 is not "eth0" and len(v1) > 0:
             existing_keys.append(k1)
 
     if not existing_keys:
         '''
         It seems all the interfaces have been removed. Let's allow a new configuration to come in.
         '''
-        print "[WARN] update_config.py :: Reconfiguring guest network..."
+        print("[WARN] update_config.py :: Reconfiguring guest network...")
         return False
 
     fn = min(glob.iglob(jsonCmdConfigPath + '*'), key=os.path.getctime)
@@ -79,7 +80,7 @@ def is_guestnet_configured(guestnet_dict, keys):
         '''
         Guest network has to be removed.
         '''
-        print "[INFO] update_config.py :: Removing guest network..."
+        print("[INFO] update_config.py :: Removing guest network...")
         return False
 
     '''
@@ -97,14 +98,15 @@ def is_guestnet_configured(guestnet_dict, keys):
 
     for key in existing_keys:
         for interface in guestnet_dict[key]:
-            new_mac = new_guestnet_dict["mac_address"].encode('utf-8')
-            old_mac = interface["mac_address"].encode('utf-8')
-            new_ip = new_guestnet_dict["router_guest_ip"].encode('utf-8')
-            old_ip = interface["router_guest_ip"].encode('utf-8')
+            if type(interface) is dict and type(new_guestnet_dict) is dict:
+                new_mac = new_guestnet_dict["mac_address"].encode('utf-8')
+                old_mac = interface["mac_address"].encode('utf-8')
+                new_ip = new_guestnet_dict["router_guest_ip"].encode('utf-8')
+                old_ip = interface["router_guest_ip"].encode('utf-8')
 
-            if (new_mac == old_mac) and (new_ip == old_ip):
-                exists = True
-                break
+                if (new_mac == old_mac) and (new_ip == old_ip):
+                    exists = True
+                    break
 
         if exists:
             break
@@ -114,28 +116,29 @@ def is_guestnet_configured(guestnet_dict, keys):
 
 filename = min(glob.iglob(jsonCmdConfigPath + '*'), key=os.path.getctime)
 if not (os.path.isfile(filename) and os.access(filename, os.R_OK)):
-    print "[ERROR] update_config.py :: You are telling me to process %s, but i can't access it" % jsonCmdConfigPath
+    print("[ERROR] update_config.py :: You are telling me to process %s, but i can't access it" % jsonCmdConfigPath)
     sys.exit(1)
 
-# If the guest network is already configured and have the same IP, do not try to configure it again otherwise it will break
+# If the guest network is already configured and have the same IP,
+# do not try to configure it again otherwise it will break
 if sys.argv[1] and sys.argv[1].count("guest_network.json") == OCCURRENCES:
     if os.path.isfile(currentGuestNetConfig):
         file = open(currentGuestNetConfig)
         guestnet_dict = json.load(file)
 
-        if not is_guestnet_configured(guestnet_dict, ['eth1', 'eth2', 'eth3', 'eth4', 'eth5', 'eth6', 'eth7', 'eth8', 'eth9']):
-            print "[INFO] update_config.py :: Processing Guest Network."
+        if not is_guestnet_configured(guestnet_dict):
+            print("[INFO] update_config.py :: Processing Guest Network.")
             process_file()
         else:
-            print "[INFO] update_config.py :: No need to process Guest Network."
+            print("[INFO] update_config.py :: No need to process Guest Network.")
             finish_config()
     else:
-        print "[INFO] update_config.py :: No GuestNetwork configured yet. Configuring first one now."
+        print("[INFO] update_config.py :: No GuestNetwork configured yet. Configuring first one now.")
         process_file()
 # Bypass saving passwords and running full config/convergence, just feed passwd to passwd server and stop
 elif sys.argv[1].startswith("vm_password.json"):
-    print "[INFO] update_config.py :: Processing incoming vm_passwd file => %s" % sys.argv[1]
+    print("[INFO] update_config.py :: Processing incoming vm_passwd file => %s" % sys.argv[1])
     process_vmpasswd()
 else:
-    print "[INFO] update_config.py :: Processing incoming file => %s" % sys.argv[1]
+    print("[INFO] update_config.py :: Processing incoming file => %s" % sys.argv[1])
     process_file()


### PR DESCRIPTION
The `management server` sends the `mac address` of the interface a given `ip address` is supposed to be configured on. This info was stored on the `virtual routers` but not used. This PR tries to find the `interface` a given `mac address` is  configured on, possibly overriding the `interface` name the `management server` sends. When no match is found, no configuration is done.

In case `device` names of IDs are mixed up, we should still have a working configuration based on the `mac address`.