### PR TITLE
Private Network enhancements for Domain Admins

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/network.js
+++ b/cosmic-client/src/main/webapp/scripts/network.js
@@ -1857,6 +1857,7 @@
                             var hasNetworkACL = false;
                             var hasSRXFirewall = false;
                             var isVPC = false;
+                            var isPrivateNet = false;
                             var isAdvancedSGZone = false;
                             var hiddenTabs = [];
                             var isSharedNetwork;
@@ -1867,6 +1868,9 @@
                             }
                             if (thisNetwork.type == 'Shared') {
                                 isSharedNetwork = true;
+                            }
+                            if (thisNetwork.type == 'Private') {
+                                isPrivateNet = true;
                             }
 
                             $(thisNetwork.service).each(function () {
@@ -1909,7 +1913,7 @@
                                 }
                             });
 
-                            if (isVPC || isAdvancedSGZone || isSharedNetwork) {
+                            if (isVPC || isAdvancedSGZone || isSharedNetwork || isPrivateNet) {
                                 hiddenTabs.push('egressRules');
                             }
 

--- a/cosmic-client/src/main/webapp/scripts/sharedFunctions.js
+++ b/cosmic-client/src/main/webapp/scripts/sharedFunctions.js
@@ -227,6 +227,9 @@ var addPrivateNetworkDialog = {
                         required: true
                     }
                 },
+                vlanId: {
+                    label: 'label.vlan',
+                },
                 zoneId: {
                     label: 'label.zone',
                     validation: {
@@ -385,6 +388,10 @@ var addPrivateNetworkDialog = {
             array1.push("&networkOfferingId=" + args.data.networkOfferingId);
             array1.push("&name=" + todb(args.data.name));
             array1.push("&displayText=" + todb(args.data.name));
+
+            if (($form.find('.form-item[rel=vlanId]').css("display") != "none")
+                && (args.data.vlanId != null && args.data.vlanId.length > 0))
+                array1.push("&vlan=" + todb(args.data.vlanId));
 
             if (args.data.ip4cidr != null && args.data.ip4cidr.length > 0)
                 array1.push("&cidr=" + args.data.ip4cidr);

--- a/cosmic-client/src/main/webapp/scripts/system.js
+++ b/cosmic-client/src/main/webapp/scripts/system.js
@@ -1539,6 +1539,9 @@
                                                         }
                                                     }
                                                 }
+                                                if (selectedGuestNetworkObj.type == "Private") {
+                                                    return false;
+                                                }
                                                 return true;
                                             }
                                         },

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/CreateNetworkCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/CreateNetworkCmdByAdmin.java
@@ -21,16 +21,9 @@ import org.slf4j.LoggerFactory;
 public class CreateNetworkCmdByAdmin extends CreateNetworkCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateNetworkCmdByAdmin.class.getName());
 
-    @Parameter(name = ApiConstants.VLAN, type = CommandType.STRING, description = "the ID or VID of the network")
-    private String vlan;
-
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
-
-    public String getVlan() {
-        return vlan;
-    }
 
     /////////////////////////////////////////////////////
     /////////////// API Implementation///////////////////

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/CreateNetworkCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/CreateNetworkCmd.java
@@ -130,6 +130,9 @@ public class CreateNetworkCmd extends BaseCmd {
     @Parameter(name = ApiConstants.ACL_ID, type = CommandType.UUID, entityType = NetworkACLResponse.class, description = "Network ACL ID associated for the network")
     private Long aclId;
 
+    @Parameter(name = ApiConstants.VLAN, type = CommandType.STRING, description = "The VLAN of the network")
+    private String vlan;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -261,6 +264,10 @@ public class CreateNetworkCmd extends BaseCmd {
 
     public Long getAclId() {
         return aclId;
+    }
+
+    public String getVlan() {
+        return vlan;
     }
 
     @Override

--- a/cosmic-core/api/src/main/java/com/cloud/offering/NetworkOffering.java
+++ b/cosmic-core/api/src/main/java/com/cloud/offering/NetworkOffering.java
@@ -16,6 +16,7 @@ public interface NetworkOffering extends InfrastructureEntity, InternalIdentity,
     public final static String SystemManagementNetwork = "System-Management-Network";
     public final static String SystemStorageNetwork = "System-Storage-Network";
     public final static String DefaultPrivateGatewayNetworkOffering = "DefaultPrivateGatewayNetworkOffering";
+    public final static String DefaultPrivateGatewayNetworkOfferingSpecifyVlan = "DefaultPrivateGatewayNetworkOfferingSpecifyVlan";
     public final static String DefaultSharedNetworkOfferingWithSGService = "DefaultSharedNetworkOfferingWithSGService";
     public final static String DefaultIsolatedNetworkOfferingWithSourceNatService = "DefaultIsolatedNetworkOfferingWithSourceNatService";
     public final static String DefaultSharedNetworkOffering = "DefaultSharedNetworkOffering";

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/offerings/NetworkOfferingVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/offerings/NetworkOfferingVO.java
@@ -180,12 +180,12 @@ public class NetworkOfferingVO implements NetworkOffering {
         this.state = State.Enabled;
     }
 
-    public NetworkOfferingVO(final String name, final Network.GuestType guestType) {
+    public NetworkOfferingVO(final String name, final Network.GuestType guestType, final boolean specifyVlan) {
         this(name,
                 "System Offering for " + name,
                 TrafficType.Guest,
                 false,
-                false,
+                specifyVlan,
                 0,
                 0,
                 true,

--- a/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -1973,8 +1973,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         }
         response.setReservedIpRange(reservation);
 
-        // return vlan information only to Root admin
-        if (network.getBroadcastUri() != null && view == ResponseView.Full) {
+        if (network.getBroadcastUri() != null) {
             final String broadcastUri = network.getBroadcastUri().toString();
             response.setBroadcastUri(broadcastUri);
             String vlan = "N/A";
@@ -1984,7 +1983,6 @@ public class ApiResponseHelper implements ResponseGenerator {
                     vlan = BroadcastDomainType.getValue(network.getBroadcastUri());
                     break;
             }
-            // return vlan information only to Root admin
             response.setVlan(vlan);
         }
 

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -322,7 +322,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
         NetworkOfferingVO storageNetworkOffering = new NetworkOfferingVO(NetworkOffering.SystemStorageNetwork, TrafficType.Storage, true);
         storageNetworkOffering = _networkOfferingDao.persistDefaultNetworkOffering(storageNetworkOffering);
         _systemNetworks.put(NetworkOffering.SystemStorageNetwork, storageNetworkOffering);
-        NetworkOfferingVO privateGatewayNetworkOffering = new NetworkOfferingVO(NetworkOffering.DefaultPrivateGatewayNetworkOffering, GuestType.Private);
+        NetworkOfferingVO privateGatewayNetworkOffering = new NetworkOfferingVO(NetworkOffering.DefaultPrivateGatewayNetworkOffering, GuestType.Private, false);
         privateGatewayNetworkOffering = _networkOfferingDao.persistDefaultNetworkOffering(privateGatewayNetworkOffering);
         _systemNetworks.put(NetworkOffering.DefaultPrivateGatewayNetworkOffering, privateGatewayNetworkOffering);
         s_privateOfferingId = privateGatewayNetworkOffering.getId();

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -664,10 +664,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
         String endIP = cmd.getEndIp();
         final String netmask = cmd.getNetmask();
         final String networkDomain = cmd.getNetworkDomain();
-        String vlanId = null;
-        if (cmd instanceof CreateNetworkCmdByAdmin) {
-            vlanId = ((CreateNetworkCmdByAdmin) cmd).getVlan();
-        }
+        String vlanId = cmd.getVlan();
         final String name = cmd.getNetworkName();
         final String displayText = cmd.getDisplayText();
         final Account caller = CallContext.current().getCallingAccount();

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -886,9 +886,9 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
                     + " and network type " + Network.GuestType.Isolated + " with a service " + Service.SourceNat.getName() + " enabled");
         }
 
-        // Don't allow to specify vlan if the caller is not ROOT admin
-        if (!_accountMgr.isRootAdmin(caller.getId()) && (ntwkOff.getSpecifyVlan() || vlanId != null)) {
-            throw new InvalidParameterValueException("Only ROOT admin is allowed to specify vlanId");
+        // Don't allow to specify vlan if the caller is a normal user
+        if (_accountMgr.isNormalUser(caller.getId()) && (ntwkOff.getSpecifyVlan() || vlanId != null)) {
+            throw new InvalidParameterValueException("Only ROOT admin and domain admins are allowed to specify vlanId");
         }
 
         if (ipv4) {

--- a/cosmic-core/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
@@ -454,8 +454,10 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         _networkOfferingDao.persistDefaultNetworkOffering(controlNetworkOffering);
         NetworkOfferingVO storageNetworkOffering = new NetworkOfferingVO(NetworkOffering.SystemStorageNetwork, TrafficType.Storage, true);
         _networkOfferingDao.persistDefaultNetworkOffering(storageNetworkOffering);
-        NetworkOfferingVO privateGatewayNetworkOffering = new NetworkOfferingVO(NetworkOffering.DefaultPrivateGatewayNetworkOffering, GuestType.Private);
+        NetworkOfferingVO privateGatewayNetworkOffering = new NetworkOfferingVO(NetworkOffering.DefaultPrivateGatewayNetworkOffering, GuestType.Private, false);
         _networkOfferingDao.persistDefaultNetworkOffering(privateGatewayNetworkOffering);
+        NetworkOfferingVO privateGatewayNetworkOfferingSpecifyVlan = new NetworkOfferingVO(NetworkOffering.DefaultPrivateGatewayNetworkOfferingSpecifyVlan, GuestType.Private, true);
+        _networkOfferingDao.persistDefaultNetworkOffering(privateGatewayNetworkOfferingSpecifyVlan);
 
         //populate providers
         final Map<Network.Service, Network.Provider> defaultSharedNetworkOfferingProviders = new HashMap<>();


### PR DESCRIPTION
This should remove most reasons for a root account:

- Add default Private Gateway offering with specifyVlan=true to be used in cases where a specific vlan/lswitch is required rather than an auto-provisioned one
- UI: When private Gateway offering has specifyVlan=true, then show vlan field
- Display the vlan/lswitch field to Domain Admins
- UI: Hide the Egress tab for private networks (as it used ACL's)

Private Gateway (specifyVlan=false):
![screen shot 2017-01-16 at 14 24 34](https://cloud.githubusercontent.com/assets/1630096/21985009/24e4f9b2-dbf9-11e6-83d3-b87ba0e7dbff.png)

Private Gateway (specifyVlan=true):
![screen shot 2017-01-16 at 14 24 22](https://cloud.githubusercontent.com/assets/1630096/21985043/39dfb618-dbf9-11e6-8489-26fc60e059c9.png)

Overview of networks for Domain Admin:
![screen shot 2017-01-16 at 14 33 21](https://cloud.githubusercontent.com/assets/1630096/21985047/43e29cc0-dbf9-11e6-82cd-7c30b0cd3331.png)

