### PR TITLE
Ignore empty vmSecondaryIp parameter

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/CreatePortForwardingRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/CreatePortForwardingRuleCmd.java
@@ -381,7 +381,7 @@ public class CreatePortForwardingRuleCmd extends BaseAsyncCreateCmd implements P
     }
 
     public Ip getVmSecondaryIp() {
-        if (vmSecondaryIp == null) {
+        if (vmSecondaryIp == null || vmSecondaryIp.isEmpty() ) {
             return null;
         }
         return new Ip(vmSecondaryIp);


### PR DESCRIPTION
When an empty parameter for ip address is passed, it should ignore that. Terraform sends this empty parameter, which results in an error:

```
(local) 🐵 > create portforwardingrule virtualmachineid=6cd98aa9-337b-4957-b4e0-f11c582bef70 publicport=2222 privateport=22 ipaddressid=b246098c-c145-4036-be90-21475c500ac0 vmguestip= protocol=tcp
Error 530: Incorrect number
```

This PR ignores the empty ("") parameter:
```
(local) 🐵 > create portforwardingrule virtualmachineid=6cd98aa9-337b-4957-b4e0-f11c582bef70 publicport=2222 privateport=22 ipaddressid=b246098c-c145-4036-be90-21475c500ac0 vmguestip= protocol=tcp
 
accountid = 77d40ad3-dbeb-11e6-8d45-5254001daa61
cmd = com.cloud.api.command.user.firewall.CreatePortForwardingRuleCmd
created = 2017-01-20T15:08:42+0100
jobid = 30100af1-ee16-401a-b5b0-f4dbdeb0a942
jobinstanceid = 9186bf87-c7ed-456e-bc5b-36cb4c0588ef
jobinstancetype = FirewallRule
jobprocstatus = 0
jobresult:
portforwardingrule:
id = 9186bf87-c7ed-456e-bc5b-36cb4c0588ef
cidrlist = 
fordisplay = True
ipaddress = 192.168.23.7
ipaddressid = b246098c-c145-4036-be90-21475c500ac0
networkid = c1a02d61-8da1-4947-8068-21a6056438ba
privateendport = 22
privateport = 22
protocol = tcp
publicendport = 2222
publicport = 2222
state = Active
tags:
virtualmachinedisplayname = vm6
virtualmachineid = 6cd98aa9-337b-4957-b4e0-f11c582bef70
virtualmachinename = vm6
vmguestip = 10.1.1.181
jobresultcode = 0
jobresulttype = object
jobstatus = 1
userid = 77d42452-dbeb-11e6-8d45-5254001daa61
```

Still think it'd be good not to send empty parameters?
Ping @ddegoede as requested ;-)
