### PR TITLE
Detect pre-5.3 Private Gateway interfaces

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -184,6 +184,11 @@ class CsInterface:
     def is_privategateway(self):
         if "nw_type" in self.address and self.address['nw_type'] in ['privategateway']:
             return True
+        # Backwards compatibility with pre-5.3
+        # Interfaces with nw_type=public other than eth1, are private gateways
+        if "nw_type" in self.address and self.address['nw_type'] in ['public'] \
+                and "nic_dev_id" in self.address and self.address['nic_dev_id'] != "1":
+            return True
         return False
 
     def is_added(self):


### PR DESCRIPTION
Mainly to make sure that routers keep working OK, while they get the new scripts but haven't got new json config