### PR TITLE
Add permission check on the provided VPC when adding private gateway

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -1361,6 +1361,11 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             throw ex;
         }
 
+        // permission check on the VPC
+        final CallContext ctx = CallContext.current();
+        final Account caller = ctx.getCallingAccount();
+        _accountMgr.checkAccess(caller, null, false, vpc);
+
         if (gateway != null || netmask != null) {
             throw new InvalidParameterValueException("Gateway/netmask fields are not supported anymore");
         }


### PR DESCRIPTION
This means that root user can still operate on any VPC, and other domain admins can only provide their own VPCs.

Next to that, there seems to be another check that makes sure that only the owner of the private network can plug on it. So, root user cannot plug VPCs to a private network owned by another lower domain.

Before this, one domain could create a private network and as its owner plug any VPC onto it. Example a private network owned by domain `IaaS`, could plug a VPC owned by domain `Remi`:

The VPC:
```
(local) 🐵 > list vpcs id=2778e403-7dfc-42f8-bedd-d6485b35de64 filter=name,domain listall=true
count = 1
vpc:
+--------+------+
| domain | name |
+--------+------+
|  remi  | vpc3 |
+--------+------+
```

Plugging the private gateway:

```
(local_iaas) 🐵 > create privategateway networkid=2776c9d4-bbce-4242-b5b6-d836e64287a1 ipaddress=10.10.10.101 vpcid=2778e403-7dfc-42f8-bedd-d6485b35de64
 
accountid = f8f9375b-3dc4-4a54-8492-d70fdf5fef3d
cmd = com.cloud.api.command.admin.vpc.CreatePrivateGatewayCmd
created = 2017-01-21T14:18:21+0100
jobid = 9eb40b10-0a2d-4299-a92d-dac077d22d62
jobinstanceid = 47b3dc16-467b-4240-a8d2-051540f1e932
jobinstancetype = PrivateGateway
jobprocstatus = 0
jobresult:
privategateway:
id = 47b3dc16-467b-4240-a8d2-051540f1e932
account = remi
aclid = abd94ec4-dbeb-11e6-8d45-5254001daa61
cidr = 10.10.10.0/24
domain = remi
domainid = 743591fc-0363-4c85-8bce-85b23d637c37
ipaddress = 10.10.10.101
networkid = 2776c9d4-bbce-4242-b5b6-d836e64287a1
networkname = iaas-owned-private-net
sourcenatsupported = False
state = Ready
vpcid = 2778e403-7dfc-42f8-bedd-d6485b35de64
zoneid = caf8f2bd-a1af-4365-b3e0-6266c76677c9
zonename = MCCT-SHARED-1
jobresultcode = 0
jobresulttype = object
jobstatus = 1
userid = 8e179d79-45e5-44c1-9496-d2b38c7cec71
```

The private gateway would be owned by the same owner as the VPC, but was created by the owner of the private network.

This PR disallows this behaviour:
```
(local_iaas) 🐵 > create privategateway networkid=2776c9d4-bbce-4242-b5b6-d836e64287a1 ipaddress=10.10.10.101 vpcid=2778e403-7dfc-42f8-bedd-d6485b35de64
Error 531: Acct[8bf3136f-5b2b-4c14-9a9f-d87395eea543-iaas] does not have permission to operate within domain id=743591fc-0363-4c85-8bce-85b23d637c37
cserrorcode = 4365
errorcode = 531
errortext = Acct[8bf3136f-5b2b-4c14-9a9f-d87395eea543-iaas] does not have permission to operate within domain id=743591fc-0363-4c85-8bce-85b23d637c37
uuidList:
(local_iaas) 🐵 > 
```