### PR TITLE
Allow projectId=-1 for root only, other users need to specify projectID

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -2503,10 +2503,10 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         if (projectId != null) {
             if (!forProjectInvitation) {
                 if (projectId.longValue() == -1) {
-                    if (caller.getType() == Account.ACCOUNT_TYPE_NORMAL) {
+                    if (caller.getType() == Account.ACCOUNT_TYPE_ADMIN) {
                         permittedAccounts.addAll(_projectMgr.listPermittedProjectAccounts(caller.getId()));
                     } else {
-                        domainIdRecursiveListProject.third(Project.ListProjectResourcesCriteria.ListProjectResourcesOnly);
+                        domainIdRecursiveListProject.third(Project.ListProjectResourcesCriteria.SkipProjectResources);
                     }
                 } else {
                     final Project project = _projectMgr.getProject(projectId);


### PR DESCRIPTION
When non-root user specifies projectId=-1 it effectively gets ignored and returns nothing any more.

```
list virtualmachines projectid=-1 listall=true
(domain2) 🐵 >
```

If they specify a projectId to which they have no access:
```
(domain2) 🐵 > list virtualmachines projectid=078650a8-4a43-4be9-9871-373f7885bcaf listall=true                                                                                                                                        
Error 531: Acct[b0971d90-2a49-4527-b57e-5a646f0a5e72-domain2] does not have permission to operate within domain id=b3f4c1e3-35d3-4d82-9a18-cca5edab1f39
cserrorcode = 4365
errorcode = 531
errortext = Acct[b0971d90-2a49-4527-b57e-5a646f0a5e72-domain2] does not have permission to operate within domain id=b3f4c1e3-35d3-4d82-9a18-cca5edab1f39
uuidList:
```

Root user can still do it:
```
(root) 🐵 > list virtualmachines projectid=-1 listall=true
count = 1
virtualmachine:
id = 2de99f63-7001-4f1f-bf8b-8c678d57f669
name = project1vm1
affinitygroup:
cpunumber = 1
<cut>
```

In short, this way the projects that an account does not have access to are no longer shown.