### PR TITLE
Revert "Allow projectId=-1 for root only, other users need to specify projectID"

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -2503,10 +2503,10 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         if (projectId != null) {
             if (!forProjectInvitation) {
                 if (projectId.longValue() == -1) {
-                    if (caller.getType() == Account.ACCOUNT_TYPE_ADMIN) {
+                    if (caller.getType() == Account.ACCOUNT_TYPE_NORMAL) {
                         permittedAccounts.addAll(_projectMgr.listPermittedProjectAccounts(caller.getId()));
                     } else {
-                        domainIdRecursiveListProject.third(Project.ListProjectResourcesCriteria.SkipProjectResources);
+                        domainIdRecursiveListProject.third(Project.ListProjectResourcesCriteria.ListProjectResourcesOnly);
                     }
                 } else {
                     final Project project = _projectMgr.getProject(projectId);


### PR DESCRIPTION
Reverts MissionCriticalCloud/cosmic#227

This is not completely fixed. As a root user I now see sometimes VMs twice. Needs more investigation.