### PR TITLE
Handle non-root volumes only in storage cleanup thread

### DIFF
--- a/cosmic-core/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDao.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDao.java
@@ -64,7 +64,7 @@ public interface VolumeDao extends GenericDao<VolumeVO, Long>, StateDao<Volume.S
 
     List<VolumeVO> listVolumesToBeDestroyed();
 
-    List<VolumeVO> listVolumesToBeDestroyed(Date date);
+    List<VolumeVO> listNonRootVolumesToBeDestroyed(Date date);
 
     ImageFormat getImageFormat(Long volumeId);
 

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDaoImpl.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDaoImpl.java
@@ -78,6 +78,7 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
         AllFieldsSearch.and("deviceId", AllFieldsSearch.entity().getDeviceId(), Op.EQ);
         AllFieldsSearch.and("poolId", AllFieldsSearch.entity().getPoolId(), Op.EQ);
         AllFieldsSearch.and("vType", AllFieldsSearch.entity().getVolumeType(), Op.EQ);
+        AllFieldsSearch.and("notVolumeType", AllFieldsSearch.entity().getVolumeType(), Op.NEQ);
         AllFieldsSearch.and("id", AllFieldsSearch.entity().getId(), Op.EQ);
         AllFieldsSearch.and("destroyed", AllFieldsSearch.entity().getState(), Op.EQ);
         AllFieldsSearch.and("notDestroyed", AllFieldsSearch.entity().getState(), Op.NEQ);
@@ -424,9 +425,10 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
     }
 
     @Override
-    public List<VolumeVO> listVolumesToBeDestroyed(final Date date) {
+    public List<VolumeVO> listNonRootVolumesToBeDestroyed(final Date date) {
         final SearchCriteria<VolumeVO> sc = AllFieldsSearch.create();
         sc.setParameters("state", Volume.State.Destroy);
+        sc.setParameters("notVolumeType", Volume.Type.ROOT.toString());
         sc.setParameters("updateTime", date);
 
         return listBy(sc);

--- a/cosmic-core/engine/storage/volume/src/main/java/com/cloud/storage/volume/VolumeObject.java
+++ b/cosmic-core/engine/storage/volume/src/main/java/com/cloud/storage/volume/VolumeObject.java
@@ -381,9 +381,9 @@ public class VolumeObject implements VolumeInfo {
             s_logger.debug("Failed to update state", e);
             throw new CloudRuntimeException("Failed to update state:" + e.toString());
         } finally {
-            // in case of OperationFailed, expunge the entry
+            // state transit call reloads the volume from DB and so check for null as well
             if (event == ObjectInDataStoreStateMachine.Event.OperationFailed &&
-                    (volumeVO.getState() != Volume.State.Copying && volumeVO.getState() != Volume.State.Uploaded && volumeVO.getState() != Volume.State.UploadError)) {
+                    (volumeVO != null && volumeVO.getState() != Volume.State.Copying && volumeVO.getState() != Volume.State.Uploaded && volumeVO.getState() != Volume.State.UploadError)) {
                 objectInStoreMgr.deleteIfNotReady(this);
             }
         }

--- a/cosmic-core/engine/storage/volume/src/main/java/com/cloud/storage/volume/VolumeServiceImpl.java
+++ b/cosmic-core/engine/storage/volume/src/main/java/com/cloud/storage/volume/VolumeServiceImpl.java
@@ -571,6 +571,12 @@ public class VolumeServiceImpl implements VolumeService {
 
         final VolumeVO vol = volDao.findById(volume.getId());
 
+        if (vol == null) {
+            s_logger.debug("Volume " + volume.getId() + " is not found");
+            future.complete(result);
+            return future;
+        }
+
         final String volumePath = vol.getPath();
         final Long poolId = vol.getPoolId();
         if (poolId == null || volumePath == null || volumePath.trim().isEmpty()) {

--- a/cosmic-core/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -501,10 +501,15 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
 
                     cleanupSecondaryStorage(recurring);
 
-                    final List<VolumeVO> vols = _volsDao.listVolumesToBeDestroyed(new Date(System.currentTimeMillis() - ((long) StorageCleanupDelay.value() << 10)));
+                    final List<VolumeVO> vols = _volsDao.listNonRootVolumesToBeDestroyed(new Date(System.currentTimeMillis() - ((long) StorageCleanupDelay.value() << 10)));
                     for (final VolumeVO vol : vols) {
                         try {
-                            volService.expungeVolumeAsync(volFactory.getVolume(vol.getId()));
+                            VolumeInfo volumeInfo = volFactory.getVolume(vol.getId());
+                            if (volumeInfo != null) {
+                                volService.expungeVolumeAsync(volumeInfo);
+                            } else {
+                                s_logger.debug("Volume " + vol.getUuid() + " is already destroyed");
+                            }
                         } catch (final Exception e) {
                             s_logger.warn("Unable to destroy volume " + vol.getUuid(), e);
                         }


### PR DESCRIPTION
Root volumes are handled as part of VM destroy.

This prevents NPE when massively destroying instances (by Terraform & friends for example)

Backport of ACS PR 1825