### PR TITLE
Make resource limits on public ips by VPC effective

### DIFF
--- a/cosmic-core/engine/schema/src/main/java/com/cloud/network/dao/IPAddressDaoImpl.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/network/dao/IPAddressDaoImpl.java
@@ -119,7 +119,9 @@ public class IPAddressDaoImpl extends GenericDaoBase<IPAddressVO, Long> implemen
         AllocatedIpCountForAccount.select(null, Func.COUNT, AllocatedIpCountForAccount.entity().getAddress());
         AllocatedIpCountForAccount.and("account", AllocatedIpCountForAccount.entity().getAllocatedToAccountId(), Op.EQ);
         AllocatedIpCountForAccount.and("allocated", AllocatedIpCountForAccount.entity().getAllocatedTime(), Op.NNULL);
-        AllocatedIpCountForAccount.and("network", AllocatedIpCountForAccount.entity().getAssociatedWithNetworkId(), Op.NNULL);
+        AllocatedIpCountForAccount.and().op("network", AllocatedIpCountForAccount.entity().getAssociatedWithNetworkId(), Op.NNULL);
+        AllocatedIpCountForAccount.or("vpc", AllocatedIpCountForAccount.entity().getVpcId(), Op.NNULL);
+        AllocatedIpCountForAccount.cp();
         AllocatedIpCountForAccount.done();
 
         CountFreePublicIps = createSearchBuilder(Long.class);


### PR DESCRIPTION
Update resource count command recalculates the resource count. While computing public IP we are not considering the ips allocated to VPC.

Backport of ACS PR 1850