### PR TITLE
Fix for classic RVR and passwd server

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -126,7 +126,7 @@ class CsInterface:
         return self.get_attr("netmask")
 
     def get_gateway(self):
-        if self.config.is_vpc() or self.config.cmdline().is_redundant():
+        if self.config.is_vpc() or not self.is_guest():
             return self.get_attr("gateway")
         else:
             return self.config.cmdline().get_guest_gw()


### PR DESCRIPTION
Backport of ACS PR 1871

Not entirely sure about this one. Can it influence private gateways for example? Let's see what Jenkins thinks of it ;-)

