### PR TITLE
Get gateway from CIDR for network creation

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -2039,7 +2039,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         final String cidrnew = NetUtils.getCidrFromGatewayAndNetmask(newVlanGateway, newVlanNetmask);
         final String existing_cidr = NetUtils.getCidrFromGatewayAndNetmask(vlan.getVlanGateway(), vlan.getVlanNetmask());
 
-        return NetUtils.isNetowrkASubsetOrSupersetOfNetworkB(cidrnew, existing_cidr);
+        return NetUtils.isNetworkASubsetOrSupersetOfNetworkB(cidrnew, existing_cidr);
     }
 
     private void checkPublicIpRangeErrors(final long zoneId, final String vlanId, final String vlanGateway, final String vlanNetmask, final String startIP, final String endIP) {

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -677,7 +677,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
         final Long vpcId = cmd.getVpcId();
         final String startIPv6 = cmd.getStartIpv6();
         String endIPv6 = cmd.getEndIpv6();
-        final String ip6Gateway = cmd.getIp6Gateway();
+        String ip6Gateway = cmd.getIp6Gateway();
         final String ip6Cidr = cmd.getIp6Cidr();
         Boolean displayNetwork = cmd.getDisplayNetwork();
         final Long aclId = cmd.getAclId();
@@ -901,7 +901,6 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
         if (ipv4) {
             // For non-root admins check cidr limit - if it's allowed by global config value
             if (!_accountMgr.isRootAdmin(caller.getId()) && cidr != null) {
-
                 final String[] cidrPair = cidr.split("\\/");
                 final int cidrSize = Integer.parseInt(cidrPair[1]);
 
@@ -955,6 +954,10 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
 
         if (ntwkOff.getGuestType() != GuestType.Private && gateway == null && cidr != null) {
             gateway = NetUtils.getCidrHostAddress(cidr);
+        }
+
+        if (ntwkOff.getGuestType() != GuestType.Private && ip6Gateway == null && ip6Cidr != null) {
+            ip6Gateway = NetUtils.getCidrHostAddress6(ip6Cidr);
         }
 
         Network network = commitNetwork(networkOfferingId, gateway, startIP, endIP, netmask, networkDomain, vlanId, name, displayText, caller, physicalNetworkId, zoneId, domainId,

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -659,7 +659,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
     @ActionEvent(eventType = EventTypes.EVENT_NETWORK_CREATE, eventDescription = "creating network")
     public Network createGuestNetwork(final CreateNetworkCmd cmd) throws InsufficientCapacityException, ConcurrentOperationException, ResourceAllocationException {
         final Long networkOfferingId = cmd.getNetworkOfferingId();
-        final String gateway = cmd.getGateway();
+        String gateway = cmd.getGateway();
         final String startIP = cmd.getStartIp();
         String endIP = cmd.getEndIp();
         final String netmask = cmd.getNetmask();
@@ -818,7 +818,12 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
         }
 
         String cidr = cmd.getCidr();
+
         if (ipv4) {
+            // validate the CIDR
+            if (cidr != null && !NetUtils.isValidCIDR(cidr)) {
+                throw new InvalidParameterValueException("Invalid format for the CIDR parameter");
+            }
             // if end ip is not specified, default it to startIp
             if (startIP != null) {
                 if (!NetUtils.isValidIp(startIP)) {
@@ -857,6 +862,11 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
         }
 
         if (ipv6) {
+            // validate the ipv6 CIDR
+            if (ip6Cidr != null && !NetUtils.isValidCIDR(ip6Cidr)) {
+                throw new InvalidParameterValueException("Invalid format for the CIDR parameter");
+            }
+
             if (endIPv6 == null) {
                 endIPv6 = startIPv6;
             }
@@ -943,8 +953,8 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
             throw ex;
         }
 
-        if (ntwkOff.getGuestType() != GuestType.Private && gateway == null && netmask == null && cidr != null) {
-            gateway, netmask = NetUtils.getCidrSubNet(cidr)
+        if (ntwkOff.getGuestType() != GuestType.Private && gateway == null && cidr != null) {
+            gateway = NetUtils.getCidrHostAddress(cidr);
         }
 
         Network network = commitNetwork(networkOfferingId, gateway, startIP, endIP, netmask, networkDomain, vlanId, name, displayText, caller, physicalNetworkId, zoneId, domainId,

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -943,6 +943,10 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
             throw ex;
         }
 
+        if (ntwkOff.getGuestType() != GuestType.Private && gateway == null && netmask == null && cidr != null) {
+            gateway, netmask = NetUtils.getCidrSubNet(cidr)
+        }
+
         Network network = commitNetwork(networkOfferingId, gateway, startIP, endIP, netmask, networkDomain, vlanId, name, displayText, caller, physicalNetworkId, zoneId, domainId,
                 isDomainSpecific, subdomainAccess, vpcId, startIPv6, endIPv6, ip6Gateway, ip6Cidr, displayNetwork, aclId, isolatedPvlan, ntwkOff, pNtwk, aclType, owner, cidr,
                 createVlan);

--- a/cosmic-core/server/src/main/java/com/cloud/network/guru/DirectNetworkGuru.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/guru/DirectNetworkGuru.java
@@ -106,12 +106,12 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
 
         if (userSpecified != null) {
             if ((userSpecified.getCidr() == null && userSpecified.getGateway() != null) || (userSpecified.getCidr() != null && userSpecified.getGateway() == null)) {
-                throw new InvalidParameterValueException("cidr and gateway must be specified together.");
+                throw new InvalidParameterValueException("CIDR and gateway must be specified together or the CIDR must represents the gateway.");
             }
 
             if ((userSpecified.getIp6Cidr() == null && userSpecified.getIp6Gateway() != null) ||
                     (userSpecified.getIp6Cidr() != null && userSpecified.getIp6Gateway() == null)) {
-                throw new InvalidParameterValueException("cidrv6 and gatewayv6 must be specified together.");
+                throw new InvalidParameterValueException("CIDRv6 and gatewayv6 must be specified together or the CIDRv6 must represents the gateway.");
             }
 
             if (userSpecified.getCidr() != null) {

--- a/cosmic-core/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
@@ -165,7 +165,7 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
         if (userSpecified != null) {
             if (!Network.GuestType.Private.equals(offering.getGuestType()) &&
                     ((userSpecified.getCidr() == null && userSpecified.getGateway() != null) || (userSpecified.getCidr() != null && userSpecified.getGateway() == null))) {
-                throw new InvalidParameterValueException("cidr and gateway must be specified together.");
+                throw new InvalidParameterValueException("CIDR and gateway must be specified together or the CIDR must represents the gateway.");
             }
 
             if (userSpecified.getCidr() != null) {

--- a/cosmic-core/server/src/main/java/com/cloud/network/guru/PrivateNetworkGuru.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/guru/PrivateNetworkGuru.java
@@ -97,7 +97,7 @@ public class PrivateNetworkGuru extends AdapterBase implements NetworkGuru {
         if (userSpecified != null) {
             if (!GuestType.Private.equals(offering.getGuestType()) &&
                     ((userSpecified.getCidr() == null && userSpecified.getGateway() != null) || (userSpecified.getCidr() != null && userSpecified.getGateway() == null))) {
-                throw new InvalidParameterValueException("cidr and gateway must be specified together.");
+                throw new InvalidParameterValueException("CIDR and gateway must be specified together or the CIDR must represents the gateway.");
             }
 
             if (userSpecified.getCidr() != null) {

--- a/cosmic-core/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/cosmic-core/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -664,7 +664,7 @@ public class NetUtils {
         return new Pair<>(tokens[0], Integer.parseInt(tokens[1]));
     }
 
-    public static SupersetOrSubset isNetowrkASubsetOrSupersetOfNetworkB(final String cidrA, final String cidrB) {
+    public static SupersetOrSubset isNetworkASubsetOrSupersetOfNetworkB(final String cidrA, final String cidrB) {
         if (!areCidrsNotEmpty(cidrA, cidrB)) {
             return SupersetOrSubset.errorInCidrFormat;
         }
@@ -759,6 +759,19 @@ public class NetUtils {
         final String[] cidrPair = cidr.split("\\/");
         final long guestCidrSize = Long.parseLong(cidrPair[1]);
         return getCidrNetmask(guestCidrSize);
+    }
+
+    public static String getCidrHostAddress(final String cidr) {
+        final String[] cidrPair = cidr.split("\\/");
+        final String address = cidrPair[0];
+        final SubnetUtils subnetUtils = new SubnetUtils(cidr);
+        subnetUtils.setInclusiveHostCount(false);
+
+        if (isValidIp(address) && subnetUtils.getInfo().isInRange(address)) {
+            return address;
+        }
+
+        return null;
     }
 
     public static String cidr2Netmask(final String cidr) {

--- a/cosmic-core/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/cosmic-core/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -774,6 +774,17 @@ public class NetUtils {
         return null;
     }
 
+    public static String getCidrHostAddress6(final String cidrv6) {
+        final String[] cidrPair = cidrv6.split("\\/");
+        final String address = cidrPair[0];
+
+        if (isValidIpv6(address) && isIp6InNetwork(address, cidrv6, false)) {
+            return address;
+        }
+
+        return null;
+    }
+
     public static String cidr2Netmask(final String cidr) {
         final String[] tokens = cidr.split("\\/");
         return getCidrNetmask(Integer.parseInt(tokens[1]));
@@ -1224,6 +1235,21 @@ public class NetUtils {
         }
         final IPv6Address ip = IPv6Address.fromString(ip6);
         return network.contains(ip);
+    }
+
+    public static boolean isIp6InNetwork(final String ip6, final String ip6Cidr, final Boolean inclusiveHostCount) {
+        IPv6Network network = null;
+        try {
+            network = IPv6Network.fromString(ip6Cidr);
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+        final IPv6Address ip = IPv6Address.fromString(ip6);
+        if (inclusiveHostCount) {
+            return network.contains(ip);
+        } else {
+            return ((network.getFirst().compareTo(ip) < 0) && (network.getLast().compareTo(ip) > 0));
+        }
     }
 
     public static boolean isIp6RangeOverlap(final String ipRange1, final String ipRange2) {

--- a/cosmic-core/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
+++ b/cosmic-core/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
@@ -414,6 +414,27 @@ public class NetUtilsTest {
     }
 
     @Test
+    public void testGetCidrHostAddress() {
+        final String cidr = "10.10.0.1/24";
+        final String address = NetUtils.getCidrHostAddress(cidr);
+        assertTrue(cidr + " does not generate valid network address: ", NetUtils.isValidIp(address));
+    }
+
+    @Test
+    public void testGetCidrHostAddressNetworkAddress() {
+        final String cidr = "10.10.0.0/24";
+        final String address = NetUtils.getCidrHostAddress(cidr);
+        assertFalse(address + " is a not the network address of CIDR:" + cidr, NetUtils.isValidIp(address));
+    }
+
+    @Test
+    public void testGetCidrHostAddressBroadcastAddress() {
+        final String cidr = "10.10.0.255/24";
+        final String address = NetUtils.getCidrHostAddress(cidr);
+        assertFalse(address + " is a not the broadcast address of CIDR:" + cidr, NetUtils.isValidIp(address));
+    }
+
+    @Test
     public void testGetCidrSubNet() {
         final String cidr = "10.10.0.0/16";
         final String subnet = NetUtils.getCidrSubNet("10.10.10.10/16");
@@ -481,7 +502,7 @@ public class NetUtilsTest {
 
     @Test
     public void testIsNetowrkASubsetOrSupersetOfNetworkBWithEmptyValues() {
-        assertEquals(SupersetOrSubset.errorInCidrFormat, NetUtils.isNetowrkASubsetOrSupersetOfNetworkB("", null));
+        assertEquals(SupersetOrSubset.errorInCidrFormat, NetUtils.isNetworkASubsetOrSupersetOfNetworkB("", null));
     }
 
     @Test

--- a/cosmic-core/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
+++ b/cosmic-core/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
@@ -417,7 +417,7 @@ public class NetUtilsTest {
     public void testGetCidrHostAddress() {
         final String cidr = "10.10.0.1/24";
         final String address = NetUtils.getCidrHostAddress(cidr);
-        assertTrue(cidr + " does not generate valid network address: ", NetUtils.isValidIp(address));
+        assertTrue(cidr + " does not generate valid gateway address.", NetUtils.isValidIp(address));
     }
 
     @Test
@@ -432,6 +432,27 @@ public class NetUtilsTest {
         final String cidr = "10.10.0.255/24";
         final String address = NetUtils.getCidrHostAddress(cidr);
         assertFalse(address + " is a not the broadcast address of CIDR:" + cidr, NetUtils.isValidIp(address));
+    }
+
+    @Test
+    public void testGetCidrHostAddressIPv6() {
+        final String cidr = "2a00:16:a::1/64";
+        final String address = NetUtils.getCidrHostAddress6(cidr);
+        assertTrue(cidr + " does not generate valid gateway address.", NetUtils.isValidIpv6(address));
+    }
+
+    @Test
+    public void testGetCidrHostAddressNetworkAddressIPv6() {
+        final String cidr = "2a00:16:a::/64";
+        final String address = NetUtils.getCidrHostAddress6(cidr);
+        assertFalse(address + " is a not the network address of CIDR:" + cidr, NetUtils.isValidIpv6(address));
+    }
+
+    @Test
+    public void testGetCidrHostAddressBroadcastAddressIPv6() {
+        final String cidr = "2a00:16:a::ffff:ffff:ffff:ffff/64";
+        final String address = NetUtils.getCidrHostAddress6(cidr);
+        assertFalse(address + " is a not the broadcast address of CIDR:" + cidr, NetUtils.isValidIpv6(address));
     }
 
     @Test


### PR DESCRIPTION
This allows the creation of network with only providing the CIDR, where the address part of the CIDR represents the gateway address