### PR TITLE
Make preshared key work after disable/enable VPN

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -619,6 +619,7 @@ class CsRemoteAccessVpn(CsDataBag):
         file.commit()
 
         secret = CsFile(vpnsecretfilte)
+        secret.empty()
         secret.addeq(": PSK \"%s\"" % psk)
         secret.commit()
 


### PR DESCRIPTION
Backport of ACS PR 1890