### PR TITLE
Increase URL fields to 2048 charachters to match the VO

### DIFF
--- a/cosmic-core/db-scripts/src/main/resources/db/schema-530to531.sql
+++ b/cosmic-core/db-scripts/src/main/resources/db/schema-530to531.sql
@@ -1,3 +1,11 @@
 --;
 -- Schema upgrade from 5.3.0 to 5.3.1;
 --;
+
+-- Increase URL fields to 2048 charachters to match the VO
+ALTER TABLE `cloud`.`volume_host_ref` MODIFY COLUMN `url` varchar(2048);
+ALTER TABLE `cloud`.`object_datastore_ref` MODIFY COLUMN `url` varchar(2048);
+ALTER TABLE `cloud`.`image_store` MODIFY COLUMN `url` varchar(2048);
+ALTER TABLE `cloud`.`template_store_ref` MODIFY COLUMN `url` varchar(2048);
+ALTER TABLE `cloud`.`volume_store_ref` MODIFY COLUMN `url` varchar(2048);
+ALTER TABLE `cloud`.`volume_store_ref` MODIFY COLUMN `download_url` varchar(2048);


### PR DESCRIPTION
The `VO`s have a length of 2048 defined, and somehow the DB only 255. So I enlarged the fields in the DB to 2048 too.
