### PR TITLE
Configure SSH.PublicKey for VMs on restart+cleanup

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -639,7 +639,8 @@ public class CommandSetupHelper {
                 final NicVO nic = _nicDao.findByNtwkIdAndInstanceId(guestNetworkId, vm.getId());
                 if (nic != null) {
                     s_logger.debug("Creating user data entry for vm " + vm + " on domR " + router);
-                    createVmDataCommand(router, vm, nic, null, cmds);
+                    _userVmDao.loadDetails(vm);
+                    createVmDataCommand(router, vm, nic, vm.getDetail("SSH.PublicKey"), cmds);
                 }
             }
         }


### PR DESCRIPTION
Before it was explicitly set to null, so after restart+cleanup any VM that reboots and relies on metadata for its SSH key cannot be logged into any more as the SSH key got lost in the config on the router.

Detail on the parameter changed:
![screen shot 2017-02-03 at 08 28 08](https://cloud.githubusercontent.com/assets/1630096/22583053/d2c59740-e9ea-11e6-9a38-3a0d994d7dd5.png)

Backport of ACS PR 1919