### PR TITLE
When hostid is specified in API call then only deploy to this host

### DIFF
--- a/cosmic-core/engine/api/src/main/java/com/cloud/engine/cloud/entity/api/VirtualMachineEntity.java
+++ b/cosmic-core/engine/api/src/main/java/com/cloud/engine/cloud/entity/api/VirtualMachineEntity.java
@@ -59,7 +59,8 @@ public interface VirtualMachineEntity extends CloudStackEntity {
      *
      * @param reservationId reservation id from reserve call.
      */
-    void deploy(String reservationId, String caller, Map<VirtualMachineProfile.Param, Object> params) throws InsufficientCapacityException, ResourceUnavailableException;
+    void deploy(String reservationId, String caller, Map<VirtualMachineProfile.Param, Object> params, boolean deployOnGivenHost)
+            throws InsufficientCapacityException, ResourceUnavailableException;
 
     /**
      * Stop the virtual machine

--- a/cosmic-core/engine/orchestration/src/main/java/com/cloud/engine/cloud/entity/api/VMEntityManager.java
+++ b/cosmic-core/engine/orchestration/src/main/java/com/cloud/engine/cloud/entity/api/VMEntityManager.java
@@ -22,7 +22,7 @@ public interface VMEntityManager {
     String reserveVirtualMachine(VMEntityVO vmEntityVO, DeploymentPlanner plannerToUse, DeploymentPlan plan, ExcludeList exclude) throws InsufficientCapacityException,
             ResourceUnavailableException;
 
-    void deployVirtualMachine(String reservationId, VMEntityVO vmEntityVO, String caller, Map<VirtualMachineProfile.Param, Object> params)
+    void deployVirtualMachine(String reservationId, VMEntityVO vmEntityVO, String caller, Map<VirtualMachineProfile.Param, Object> params, boolean deployOnGivenHost)
             throws InsufficientCapacityException, ResourceUnavailableException;
 
     boolean stopvirtualmachine(VMEntityVO vmEntityVO, String caller) throws ResourceUnavailableException;

--- a/cosmic-core/engine/orchestration/src/main/java/com/cloud/engine/cloud/entity/api/VirtualMachineEntityImpl.java
+++ b/cosmic-core/engine/orchestration/src/main/java/com/cloud/engine/cloud/entity/api/VirtualMachineEntityImpl.java
@@ -124,9 +124,9 @@ public class VirtualMachineEntityImpl implements VirtualMachineEntity {
     }
 
     @Override
-    public void deploy(final String reservationId, final String caller, final Map<VirtualMachineProfile.Param, Object> params) throws InsufficientCapacityException,
-            ResourceUnavailableException {
-        manager.deployVirtualMachine(reservationId, this.vmEntityVO, caller, params);
+    public void deploy(final String reservationId, final String caller, final Map<VirtualMachineProfile.Param, Object> params, final boolean deployOnGivenHost) throws
+            InsufficientCapacityException, ResourceUnavailableException {
+        manager.deployVirtualMachine(reservationId, this.vmEntityVO, caller, params, deployOnGivenHost);
     }
 
     @Override

--- a/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -801,9 +801,11 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
 
         DataCenterDeployment plan = null;
+        boolean deployOnGivenHost = false;
         if (destinationHost != null) {
             s_logger.debug("Destination Host to deploy the VM is specified, specifying a deployment plan to deploy the VM");
             plan = new DataCenterDeployment(vm.getDataCenterId(), destinationHost.getPodId(), destinationHost.getClusterId(), destinationHost.getId(), null, null);
+            deployOnGivenHost = true;
         }
 
         // Set parameters
@@ -851,7 +853,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
 
         final String reservationId = vmEntity.reserve(planner, plan, new ExcludeList(), Long.toString(callerUser.getId()));
-        vmEntity.deploy(reservationId, Long.toString(callerUser.getId()), params);
+        vmEntity.deploy(reservationId, Long.toString(callerUser.getId()), params, deployOnGivenHost);
 
         final Pair<UserVmVO, Map<VirtualMachineProfile.Param, Object>> vmParamPair = new Pair(vm, params);
         if (vm != null && vm.isUpdateParameters()) {


### PR DESCRIPTION
When deploying a vm with hostid=someid, and this fails for example due to capacity, other hosts were tried to deploy. Now we return an error so the user knows that deploying to the hostid specified failed.

Backport of ACS PR 1868