### PR TITLE
Add dns1 and dns2 parameters to createNetwork API

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/UpdateNetworkCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/UpdateNetworkCmdByAdmin.java
@@ -31,8 +31,9 @@ public class UpdateNetworkCmdByAdmin extends UpdateNetworkCmd {
             throw new InvalidParameterValueException("Couldn't find network by id");
         }
 
-        final Network result = _networkService.updateGuestNetwork(getId(), getNetworkName(), getDisplayText(), callerAccount,
-                callerUser, getNetworkDomain(), getNetworkOfferingId(), getChangeCidr(), getGuestVmCidr(), getDisplayNetwork(), getCustomId());
+        final Network result =
+                _networkService.updateGuestNetwork(getId(), getNetworkName(), getDisplayText(), callerAccount, callerUser, getNetworkDomain(), getNetworkOfferingId(),
+                        getChangeCidr(), getGuestVmCidr(), getDisplayNetwork(), getCustomId(), getDns1(), getDns2());
 
         if (result != null) {
             final NetworkResponse response = _responseGenerator.createNetworkResponse(ResponseView.Full, result);

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/CreateNetworkCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/CreateNetworkCmd.java
@@ -133,6 +133,12 @@ public class CreateNetworkCmd extends BaseCmd {
     @Parameter(name = ApiConstants.VLAN, type = CommandType.STRING, description = "The VLAN of the network")
     private String vlan;
 
+    @Parameter(name = ApiConstants.DNS1, type = CommandType.STRING, description = "The first DNS server of the network")
+    private String dns1;
+
+    @Parameter(name = ApiConstants.DNS2, type = CommandType.STRING, description = "The second DNS server of the network")
+    private String dns2;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -268,6 +274,14 @@ public class CreateNetworkCmd extends BaseCmd {
 
     public String getVlan() {
         return vlan;
+    }
+
+    public String getDns1() {
+        return dns1;
+    }
+
+    public String getDns2() {
+        return dns2;
     }
 
     @Override

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/UpdateNetworkCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/UpdateNetworkCmd.java
@@ -64,6 +64,12 @@ public class UpdateNetworkCmd extends BaseAsyncCustomIdCmd {
             description = "an optional field, whether to the display the network to the end user or not.", authorized = {RoleType.Admin})
     private Boolean displayNetwork;
 
+    @Parameter(name = ApiConstants.DNS1, type = CommandType.STRING, description = "The first DNS server of the network")
+    private String dns1;
+
+    @Parameter(name = ApiConstants.DNS2, type = CommandType.STRING, description = "The second DNS server of the network")
+    private String dns2;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -79,7 +85,7 @@ public class UpdateNetworkCmd extends BaseAsyncCustomIdCmd {
 
         final Network result =
                 _networkService.updateGuestNetwork(getId(), getNetworkName(), getDisplayText(), callerAccount, callerUser, getNetworkDomain(), getNetworkOfferingId(),
-                        getChangeCidr(), getGuestVmCidr(), getDisplayNetwork(), getCustomId());
+                        getChangeCidr(), getGuestVmCidr(), getDisplayNetwork(), getCustomId(), getDns1(), getDns2());
 
         if (result != null) {
             final NetworkResponse response = _responseGenerator.createNetworkResponse(ResponseView.Restricted, result);
@@ -108,6 +114,14 @@ public class UpdateNetworkCmd extends BaseAsyncCustomIdCmd {
 
     public Long getNetworkOfferingId() {
         return networkOfferingId;
+    }
+
+    public String getDns1() {
+        return dns1;
+    }
+
+    public String getDns2() {
+        return dns2;
     }
 
     public Boolean getChangeCidr() {

--- a/cosmic-core/api/src/main/java/com/cloud/network/Network.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/Network.java
@@ -47,6 +47,10 @@ public interface Network extends ControlledEntity, StateObject<Network.State>, I
 
     String getIp6Cidr();
 
+    String getDns1();
+
+    String getDns2();
+
     long getDataCenterId();
 
     long getNetworkOfferingId();

--- a/cosmic-core/api/src/main/java/com/cloud/network/NetworkService.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/NetworkService.java
@@ -59,7 +59,7 @@ public interface NetworkService {
     IpAddress getIp(long id);
 
     Network updateGuestNetwork(long networkId, String name, String displayText, Account callerAccount, User callerUser, String domainSuffix, Long networkOfferingId,
-                               Boolean changeCidr, String guestVmCidr, Boolean displayNetwork, String newUUID);
+                               Boolean changeCidr, String guestVmCidr, Boolean displayNetwork, String newUUID, String dns1, String dns2);
 
     PhysicalNetwork createPhysicalNetwork(Long zoneId, String vnetRange, String networkSpeed, List<String> isolationMethods, String broadcastDomainRange, Long domainId,
                                           List<String> tags, String name);

--- a/cosmic-core/engine/api/src/main/java/com/cloud/engine/orchestration/service/NetworkOrchestrationService.java
+++ b/cosmic-core/engine/api/src/main/java/com/cloud/engine/orchestration/service/NetworkOrchestrationService.java
@@ -73,7 +73,7 @@ public interface NetworkOrchestrationService {
     List<? extends Network> setupNetwork(Account owner, NetworkOffering offering, Network predefined, DeploymentPlan plan,
                                          String name, String displayText,
                                          boolean errorIfAlreadySetup, Long domainId, ACLType aclType, Boolean subdomainAccess, Long vpcId,
-                                         Boolean isDisplayNetworkEnabled)
+                                         Boolean isDisplayNetworkEnabled, String dns1, String dns2)
             throws ConcurrentOperationException;
 
     void allocate(VirtualMachineProfile vm, LinkedHashMap<? extends Network, List<? extends NicProfile>> networks)
@@ -132,10 +132,9 @@ public interface NetworkOrchestrationService {
     boolean destroyNetwork(long networkId, ReservationContext context, boolean forced);
 
     Network createGuestNetwork(long networkOfferingId, String name, String displayText, String gateway, String cidr,
-                               String vlanId, String networkDomain, Account owner,
-                               Long domainId, PhysicalNetwork physicalNetwork, long zoneId, ACLType aclType, Boolean subdomainAccess, Long vpcId,
-                               String ip6Gateway, String ip6Cidr,
-                               Boolean displayNetworkEnabled, String isolatedPvlan)
+                               String vlanId, String networkDomain, Account owner, Long domainId, PhysicalNetwork physicalNetwork,
+                               long zoneId, ACLType aclType, Boolean subdomainAccess, Long vpcId, String ip6Gateway, String ip6Cidr,
+                               Boolean displayNetworkEnabled, String isolatedPvlan, String dns1, String dns2)
             throws ConcurrentOperationException, InsufficientCapacityException, ResourceAllocationException;
 
     UserDataServiceProvider getPasswordResetProvider(Network network);

--- a/cosmic-core/engine/components-api/src/main/java/com/cloud/network/vpc/VpcManager.java
+++ b/cosmic-core/engine/components-api/src/main/java/com/cloud/network/vpc/VpcManager.java
@@ -92,7 +92,7 @@ public interface VpcManager {
     Network
     createVpcGuestNetwork(long ntwkOffId, String name, String displayText, String gateway, String cidr, String vlanId, String networkDomain, Account owner,
                           Long domainId, PhysicalNetwork pNtwk, long zoneId, ACLType aclType, Boolean subdomainAccess, long vpcId, Long aclId, Account caller,
-                          Boolean displayNetworkEnabled)
+                          Boolean displayNetworkEnabled, String dns1, String dns2)
 
             throws ConcurrentOperationException, InsufficientCapacityException, ResourceAllocationException;
 

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
@@ -122,9 +122,9 @@ public class NetworkVO implements Network {
 
     public NetworkVO(final long id, final Network that, final long offeringId, final String guruName, final long domainId, final long accountId, final long related,
                      final String name, final String displayText, final String networkDomain, final GuestType guestType, final long dcId, final Long physicalNetworkId,
-                     final ACLType aclType, final boolean specifyIpRanges, final Long vpcId, final boolean isRedundant) {
+                     final ACLType aclType, final boolean specifyIpRanges, final Long vpcId, final boolean isRedundant, final String dns1, final String dns2) {
         this(id, that.getTrafficType(), that.getMode(), that.getBroadcastDomainType(), offeringId, domainId, accountId, related, name, displayText, networkDomain, guestType,
-                dcId, physicalNetworkId, aclType, specifyIpRanges, vpcId, isRedundant);
+                dcId, physicalNetworkId, aclType, specifyIpRanges, vpcId, isRedundant, dns1, dns2);
         gateway = that.getGateway();
         cidr = that.getCidr();
         networkCidr = that.getNetworkCidr();
@@ -161,7 +161,7 @@ public class NetworkVO implements Network {
     public NetworkVO(final long id, final TrafficType trafficType, final Mode mode, final BroadcastDomainType broadcastDomainType, final long networkOfferingId,
                      final long domainId, final long accountId, final long related, final String name, final String displayText, final String networkDomain,
                      final GuestType guestType, final long dcId, final Long physicalNetworkId, final ACLType aclType, final boolean specifyIpRanges, final Long vpcId,
-                     final boolean isRedundant) {
+                     final boolean isRedundant, final String dns1, final String dns2) {
         this(trafficType, mode, broadcastDomainType, networkOfferingId, State.Allocated, dcId, physicalNetworkId, isRedundant);
         this.domainId = domainId;
         this.accountId = accountId;
@@ -175,6 +175,8 @@ public class NetworkVO implements Network {
         this.guestType = guestType;
         this.specifyIpRanges = specifyIpRanges;
         this.vpcId = vpcId;
+        this.dns1 = dns1;
+        this.dns2 = dns2;
     }
 
     /**

--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/api/SetupGuestNetworkCommand.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/api/SetupGuestNetworkCommand.java
@@ -6,8 +6,8 @@ import com.cloud.agent.api.to.NicTO;
 public class SetupGuestNetworkCommand extends NetworkElementCommand {
     String dhcpRange;
     String networkDomain;
-    String defaultDns1 = null;
-    String defaultDns2 = null;
+    String networkDns1 = null;
+    String networkDns2 = null;
     boolean isRedundant = false;
     boolean add = true;
     NicTO nic;
@@ -15,13 +15,13 @@ public class SetupGuestNetworkCommand extends NetworkElementCommand {
     protected SetupGuestNetworkCommand() {
     }
 
-    public SetupGuestNetworkCommand(final String dhcpRange, final String networkDomain, final boolean isRedundant, final String defaultDns1, final String defaultDns2, final
+    public SetupGuestNetworkCommand(final String dhcpRange, final String networkDomain, final boolean isRedundant, final String networkDns1, final String networkDns2, final
     boolean add,
                                     final NicTO nic) {
         this.dhcpRange = dhcpRange;
         this.networkDomain = networkDomain;
-        this.defaultDns1 = defaultDns1;
-        this.defaultDns2 = defaultDns2;
+        this.networkDns1 = networkDns1;
+        this.networkDns2 = networkDns2;
         this.isRedundant = isRedundant;
         this.add = add;
         this.nic = nic;
@@ -31,12 +31,12 @@ public class SetupGuestNetworkCommand extends NetworkElementCommand {
         return nic;
     }
 
-    public String getDefaultDns1() {
-        return defaultDns1;
+    public String getNetworkDns1() {
+        return networkDns1;
     }
 
-    public String getDefaultDns2() {
-        return defaultDns2;
+    public String getNetworkDns2() {
+        return networkDns2;
     }
 
     public String getNetworkDomain() {

--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/SetGuestNetworkConfigItem.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/SetGuestNetworkConfigItem.java
@@ -23,12 +23,12 @@ public class SetGuestNetworkConfigItem extends AbstractConfigItemFacade {
         final String cidr = Long.toString(NetUtils.getCidrSize(nic.getNetmask()));
         final String netmask = nic.getNetmask();
         final String domainName = command.getNetworkDomain();
-        String dns = command.getDefaultDns1();
+        String dns = command.getNetworkDns1();
 
         if (dns == null || dns.isEmpty()) {
-            dns = command.getDefaultDns2();
+            dns = command.getNetworkDns2();
         } else {
-            final String dns2 = command.getDefaultDns2();
+            final String dns2 = command.getNetworkDns2();
             if (dns2 != null && !dns2.isEmpty()) {
                 dns += "," + dns2;
             }

--- a/cosmic-core/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -3047,7 +3047,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         }
 
         // Don't return system network offerings to the user except for private gateway offerings
-        if (keyword == null || ! keyword.equals("private")) {
+        if (keyword == null || !keyword.equals("private")) {
             sc.addAnd("systemOnly", SearchCriteria.Op.EQ, false);
         }
 
@@ -4157,7 +4157,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
                 userNetwork.setBroadcastDomainType(broadcastDomainType);
                 userNetwork.setNetworkDomain(networkDomain);
-                _networkMgr.setupNetwork(systemAccount, offering, userNetwork, plan, null, null, false, Domain.ROOT_DOMAIN, null, null, null, true);
+                _networkMgr.setupNetwork(systemAccount, offering, userNetwork, plan, null, null, false, Domain.ROOT_DOMAIN, null, null, null, true, null, null);
             }
         }
     }

--- a/cosmic-core/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
@@ -1544,7 +1544,8 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
                             s_logger.debug("Creating network for account " + owner + " from the network offering id=" + requiredOfferings.get(0).getId()
                                     + " as a part of createVlanIpRange process");
                             guestNetwork = _networkMgr.createGuestNetwork(requiredOfferings.get(0).getId(), owner.getAccountName() + "-network", owner.getAccountName()
-                                    + "-network", null, null, null, null, owner, null, physicalNetwork, zoneId, ACLType.Account, null, null, null, null, true, null);
+                                            + "-network", null, null, null, null, owner, null, physicalNetwork, zoneId, ACLType.Account,
+                                    null, null, null, null, true, null, null, null);
                             if (guestNetwork == null) {
                                 s_logger.warn("Failed to create default Virtual network for the account " + accountId + "in zone " + zoneId);
                                 throw new CloudRuntimeException("Failed to create a Guest Isolated Networks with SourceNAT "

--- a/cosmic-core/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
@@ -168,6 +168,14 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
                 throw new InvalidParameterValueException("CIDR and gateway must be specified together or the CIDR must represents the gateway.");
             }
 
+            if (userSpecified.getDns1() != null) {
+                network.setDns1(userSpecified.getDns1());
+            }
+
+            if (userSpecified.getDns2() != null) {
+                network.setDns2(userSpecified.getDns2());
+            }
+
             if (userSpecified.getCidr() != null) {
                 network.setCidr(userSpecified.getCidr());
                 network.setGateway(userSpecified.getGateway());
@@ -308,8 +316,17 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
                 nic.setIPv4Address(guestIp);
                 nic.setIPv4Netmask(NetUtils.cidr2Netmask(network.getCidr()));
 
-                nic.setIPv4Dns1(dc.getDns1());
-                nic.setIPv4Dns2(dc.getDns2());
+                if (network.getDns1() != null && network.getDns1().equals("")) {
+                    nic.setIPv4Dns1(dc.getDns1());
+                } else {
+                    nic.setIPv4Dns1(network.getDns1());
+                }
+                if (network.getDns2() != null && network.getDns2().equals("")) {
+                    nic.setIPv4Dns2(dc.getDns2());
+                } else {
+                    nic.setIPv4Dns2(network.getDns2());
+                }
+
                 nic.setFormat(AddressFormat.Ip4);
             }
         }
@@ -398,8 +415,12 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
     @Override
     public void updateNetworkProfile(final NetworkProfile networkProfile) {
         final DataCenter dc = _dcDao.findById(networkProfile.getDataCenterId());
-        networkProfile.setDns1(dc.getDns1());
-        networkProfile.setDns2(dc.getDns2());
+        if (networkProfile.getDns1() != null && networkProfile.getDns1().equals("")) {
+            networkProfile.setDns1(dc.getDns1());
+        }
+        if (networkProfile.getDns2() != null && networkProfile.getDns2().equals("")) {
+            networkProfile.setDns2(dc.getDns2());
+        }
     }
 
     @Override

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -992,8 +992,8 @@ public class CommandSetupHelper {
     public SetupGuestNetworkCommand createSetupGuestNetworkCommand(final DomainRouterVO router, final boolean add, final NicProfile guestNic) {
         final Network network = _networkModel.getNetwork(guestNic.getNetworkId());
 
-        String defaultDns1 = null;
-        String defaultDns2 = null;
+        String networkDns1 = null;
+        String networkDns2 = null;
 
         final boolean dnsProvided = _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.Dns, Provider.VPCVirtualRouter);
         final boolean dhcpProvided = _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.Dhcp, Provider.VPCVirtualRouter);
@@ -1001,8 +1001,8 @@ public class CommandSetupHelper {
         final boolean setupDns = dnsProvided || dhcpProvided;
 
         if (setupDns) {
-            defaultDns1 = guestNic.getIPv4Dns1();
-            defaultDns2 = guestNic.getIPv4Dns2();
+            networkDns1 = network.getDns1();
+            networkDns2 = network.getDns2();
         }
 
         final Nic nic = _nicDao.findByNtwkIdAndInstanceId(network.getId(), router.getId());
@@ -1011,9 +1011,8 @@ public class CommandSetupHelper {
 
         final NicProfile nicProfile = _networkModel.getNicProfile(router, nic.getNetworkId(), null);
 
-        final SetupGuestNetworkCommand setupCmd = new SetupGuestNetworkCommand(dhcpRange, networkDomain, router.getIsRedundantRouter(), defaultDns1, defaultDns2, add, _itMgr
-                .toNicTO(nicProfile,
-                        router.getHypervisorType()));
+        final SetupGuestNetworkCommand setupCmd = new SetupGuestNetworkCommand(dhcpRange, networkDomain, router.getIsRedundantRouter(), networkDns1, networkDns2, add, _itMgr
+                .toNicTO(nicProfile, router.getHypervisorType()));
 
         final String brd = NetUtils.long2Ip(NetUtils.ip2Long(guestNic.getIPv4Address()) | ~NetUtils.ip2Long(guestNic.getIPv4Netmask()));
         setupCmd.setAccessDetail(NetworkElementCommand.ROUTER_IP, _routerControlHelper.getRouterControlIp(router.getId()));

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -37,8 +37,6 @@ import com.cloud.network.Network.Provider;
 import com.cloud.network.Network.Service;
 import com.cloud.network.NetworkModel;
 import com.cloud.network.NetworkService;
-import com.cloud.network.Networks.BroadcastDomainType;
-import com.cloud.network.Networks.TrafficType;
 import com.cloud.network.PhysicalNetwork;
 import com.cloud.network.addr.PublicIp;
 import com.cloud.network.dao.FirewallRulesDao;
@@ -285,7 +283,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         return true;
     }
 
-    private Map<Service, Set<Provider>> getServiceSetMap(List<Service> serviceToAdd) {
+    private Map<Service, Set<Provider>> getServiceSetMap(final List<Service> serviceToAdd) {
         final Map<Service, Set<Provider>> svcProviderMap = new HashMap<>();
         final Set<Provider> defaultProviders = new HashSet<>();
         defaultProviders.add(Provider.VPCVirtualRouter);
@@ -351,10 +349,10 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
     @DB
     private VpcOffering createVpcOffering(final String name, final String displayText,
-                                            final Map<Network.Service, Set<Network.Provider>> svcProviderMap,
-                                            final boolean isDefault, final State state, final Long serviceOfferingId, final boolean supportsDistributedRouter,
-                                            final boolean offersRegionLevelVPC,
-                                            final boolean redundantRouter) {
+                                          final Map<Network.Service, Set<Network.Provider>> svcProviderMap,
+                                          final boolean isDefault, final State state, final Long serviceOfferingId, final boolean supportsDistributedRouter,
+                                          final boolean offersRegionLevelVPC,
+                                          final boolean redundantRouter) {
 
         return Transaction.execute(new TransactionCallback<VpcOffering>() {
             @Override
@@ -1370,7 +1368,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             throw new InvalidParameterValueException("Gateway/netmask fields are not supported anymore");
         }
 
-        Network privateNtwk = _ntwkDao.findByIdAndDomainId(networkId, gatewayDomainId);
+        final Network privateNtwk = _ntwkDao.findByIdAndDomainId(networkId, gatewayDomainId);
         if (privateNtwk == null) {
             throw new InvalidParameterValueException("Unable to find private network based on the network ID");
         }
@@ -1381,7 +1379,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                             " should be outside of the VPC super CIDR " + vpc.getCidr());
         }
 
-        if (! NetUtils.isIpWithtInCidrRange(ipAddress, privateNtwk.getCidr())) {
+        if (!NetUtils.isIpWithtInCidrRange(ipAddress, privateNtwk.getCidr())) {
             throw new InvalidParameterValueException(
                     "The specified ip address for the private network " + ipAddress +
                             " should be within the CIDR of the private network " + privateNtwk.getCidr());
@@ -1395,7 +1393,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                         "VPC with uuid " + vpc.getUuid() + " is already connected to network '"
                                 + privateNtwk.getName() + "'");
             }
-         }
+        }
 
         final VpcGatewayVO gatewayVO;
         try {
@@ -1973,7 +1971,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
     @DB
     private void validateNewVpcGuestNetwork(final String cidr, final String gateway, final Account networkOwner,
-                                              final Vpc vpc, final String networkDomain) {
+                                            final Vpc vpc, final String networkDomain) {
 
         Transaction.execute(new TransactionCallbackNoReturn() {
             @Override
@@ -2067,7 +2065,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     }
 
     private List<IPAddressVO> listPublicIpsAssignedToVpc(final long accountId, final Boolean sourceNat,
-                                                           final long vpcId) {
+                                                         final long vpcId) {
         final SearchCriteria<IPAddressVO> sc = IpAddressSearch.create();
         sc.setParameters("accountId", accountId);
         sc.setParameters("vpcId", vpcId);
@@ -2394,11 +2392,10 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
     @DB
     @Override
-    public Network createVpcGuestNetwork(final long ntwkOffId, final String name, final String displayText,
-                                         final String gateway, final String cidr, final String vlanId,
-                                         String networkDomain, final Account owner, final Long domainId, final PhysicalNetwork pNtwk, final long zoneId,
-                                         final ACLType aclType, final Boolean subdomainAccess,
-                                         final long vpcId, final Long aclId, final Account caller, final Boolean isDisplayNetworkEnabled)
+    public Network createVpcGuestNetwork(final long ntwkOffId, final String name, final String displayText, final String gateway, final String cidr, final String vlanId,
+                                         String networkDomain, final Account owner, final Long domainId, final PhysicalNetwork pNtwk, final long zoneId, final ACLType aclType,
+                                         final Boolean subdomainAccess, final long vpcId, final Long aclId, final Account caller, final Boolean isDisplayNetworkEnabled,
+                                         final String dns1, final String dns2)
             throws ConcurrentOperationException, InsufficientCapacityException,
             ResourceAllocationException {
 
@@ -2424,8 +2421,8 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
         // 2) Create network
         final Network guestNetwork = _ntwkMgr.createGuestNetwork(ntwkOffId, name, displayText, gateway, cidr, vlanId,
-                networkDomain, owner, domainId, pNtwk, zoneId, aclType,
-                subdomainAccess, vpcId, null, null, isDisplayNetworkEnabled, null);
+                networkDomain, owner, domainId, pNtwk, zoneId, aclType, subdomainAccess, vpcId, null, null,
+                isDisplayNetworkEnabled, null, dns1, dns2);
 
         if (guestNetwork != null) {
             guestNetwork.setNetworkACLId(aclId);

--- a/cosmic-core/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
@@ -446,17 +446,18 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
     @DB
     protected void createDefaultNetworkOfferings() {
 
-        NetworkOfferingVO publicNetworkOffering = new NetworkOfferingVO(NetworkOffering.SystemPublicNetwork, TrafficType.Public, true);
+        final NetworkOfferingVO publicNetworkOffering = new NetworkOfferingVO(NetworkOffering.SystemPublicNetwork, TrafficType.Public, true);
         _networkOfferingDao.persistDefaultNetworkOffering(publicNetworkOffering);
-        NetworkOfferingVO managementNetworkOffering = new NetworkOfferingVO(NetworkOffering.SystemManagementNetwork, TrafficType.Management, false);
+        final NetworkOfferingVO managementNetworkOffering = new NetworkOfferingVO(NetworkOffering.SystemManagementNetwork, TrafficType.Management, false);
         _networkOfferingDao.persistDefaultNetworkOffering(managementNetworkOffering);
-        NetworkOfferingVO controlNetworkOffering = new NetworkOfferingVO(NetworkOffering.SystemControlNetwork, TrafficType.Control, false);
+        final NetworkOfferingVO controlNetworkOffering = new NetworkOfferingVO(NetworkOffering.SystemControlNetwork, TrafficType.Control, false);
         _networkOfferingDao.persistDefaultNetworkOffering(controlNetworkOffering);
-        NetworkOfferingVO storageNetworkOffering = new NetworkOfferingVO(NetworkOffering.SystemStorageNetwork, TrafficType.Storage, true);
+        final NetworkOfferingVO storageNetworkOffering = new NetworkOfferingVO(NetworkOffering.SystemStorageNetwork, TrafficType.Storage, true);
         _networkOfferingDao.persistDefaultNetworkOffering(storageNetworkOffering);
-        NetworkOfferingVO privateGatewayNetworkOffering = new NetworkOfferingVO(NetworkOffering.DefaultPrivateGatewayNetworkOffering, GuestType.Private, false);
+        final NetworkOfferingVO privateGatewayNetworkOffering = new NetworkOfferingVO(NetworkOffering.DefaultPrivateGatewayNetworkOffering, GuestType.Private, false);
         _networkOfferingDao.persistDefaultNetworkOffering(privateGatewayNetworkOffering);
-        NetworkOfferingVO privateGatewayNetworkOfferingSpecifyVlan = new NetworkOfferingVO(NetworkOffering.DefaultPrivateGatewayNetworkOfferingSpecifyVlan, GuestType.Private, true);
+        final NetworkOfferingVO privateGatewayNetworkOfferingSpecifyVlan =
+                new NetworkOfferingVO(NetworkOffering.DefaultPrivateGatewayNetworkOfferingSpecifyVlan, GuestType.Private, true);
         _networkOfferingDao.persistDefaultNetworkOffering(privateGatewayNetworkOfferingSpecifyVlan);
 
         //populate providers
@@ -687,10 +688,9 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                     if (broadcastDomainType != null) {
                         final NetworkVO network =
                                 new NetworkVO(id, trafficType, mode, broadcastDomainType, networkOfferingId, domainId, accountId, related, null, null, networkDomain,
-                                        Network.GuestType.Shared, zoneId, null, null, specifyIpRanges, null, offering.getRedundantRouter());
+                                        Network.GuestType.Shared, zoneId, null, null, specifyIpRanges, null, offering.getRedundantRouter(),
+                                        zone.getDns1(), zone.getDns2());
                         network.setGuruName(guruNames.get(network.getTrafficType()));
-                        network.setDns1(zone.getDns1());
-                        network.setDns2(zone.getDns2());
                         network.setState(State.Implemented);
                         _networkDao.persist(network, false, getServicesAndProvidersForNetwork(networkOfferingId));
                         id++;

--- a/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -2593,7 +2593,8 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                             "process");
                     final Network newNetwork = _networkMgr.createGuestNetwork(requiredOfferings.get(0).getId(), owner.getAccountName() + "-network", owner.getAccountName() +
                                     "-network",
-                            null, null, null, null, owner, null, physicalNetwork, zone.getId(), ACLType.Account, null, null, null, null, true, null);
+                            null, null, null, null, owner, null, physicalNetwork, zone.getId(), ACLType.Account,
+                            null, null, null, null, true, null, null, null);
                     if (newNetwork != null) {
                         defaultNetwork = _networkDao.findById(newNetwork.getId());
                     }
@@ -3582,7 +3583,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                                     + " as a part of deployVM process");
                             Network newNetwork = _networkMgr.createGuestNetwork(requiredOfferings.get(0).getId(), newAccount.getAccountName() + "-network",
                                     newAccount.getAccountName() + "-network", null, null, null, null, newAccount, null, physicalNetwork, zone.getId(), ACLType.Account, null, null,
-                                    null, null, true, null);
+                                    null, null, true, null, null, null);
                             // if the network offering has persistent set to true, implement the network
                             if (requiredOfferings.get(0).getIsPersistent()) {
                                 final DeployDestination dest = new DeployDestination(zone, null, null, null);

--- a/cosmic-core/server/src/test/java/com/cloud/network/CreatePrivateNetworkTest.java
+++ b/cosmic-core/server/src/test/java/com/cloud/network/CreatePrivateNetworkTest.java
@@ -94,18 +94,18 @@ public class CreatePrivateNetworkTest {
         final PhysicalNetworkVO physicalNetwork = new PhysicalNetworkVO(1L, 1L, "2-5", "200", 1L, null, "testphysicalnetwork");
         when(networkService._physicalNetworkDao.findById(anyLong())).thenReturn(physicalNetwork);
 
-        final DataCenterVO dc = new DataCenterVO(1L, "hut", "op de hei", null, null, null, null, "10.1.1.0/24", "unreal.net", 1L, NetworkType.Advanced, null, null);
+        final DataCenterVO dc = new DataCenterVO(1L, "DC", "Datacenter", "1.2.3.4", null, null, null, "10.1.1.0/24", "unreal.net", 1L, NetworkType.Advanced, null, null);
         when(networkService._dcDao.lockRow(anyLong(), anyBoolean())).thenReturn(dc);
 
         when(networkService._networksDao.getPrivateNetwork(anyString(), anyString(), eq(1L), eq(1L), anyLong())).thenReturn(null);
 
         final Network net =
                 new NetworkVO(1L, TrafficType.Guest, Mode.None, BroadcastDomainType.Vlan, 1L, 1L, 1L, 1L, "bla", "fake", "eet.net", GuestType.Isolated, 1L, 1L,
-                        ACLType.Account, false, 1L, false);
+                        ACLType.Account, false, 1L, false, "1.2.3.4", null);
         when(
                 networkService._networkMgr.createGuestNetwork(eq(ntwkOff.getId()), eq("bla"), eq("fake"), eq("10.1.1.1"), eq("10.1.1.0/24"), anyString(), anyString(),
                         eq(account), anyLong(), eq(physicalNetwork), eq(physicalNetwork.getDataCenterId()), eq(ACLType.Account), anyBoolean(), eq(1L), anyString(), anyString(),
-                        anyBoolean(), anyString())).thenReturn(net);
+                        anyBoolean(), anyString(), eq("1.2.3.4"), eq(null))).thenReturn(net);
 
         when(networkService._privateIpDao.findByIpAndSourceNetworkId(net.getId(), "10.1.1.2")).thenReturn(null);
         when(networkService._privateIpDao.findByIpAndSourceNetworkIdAndVpcId(eq(1L), anyString(), eq(1L))).thenReturn(null);

--- a/cosmic-core/server/src/test/java/com/cloud/vpc/MockNetworkManagerImpl.java
+++ b/cosmic-core/server/src/test/java/com/cloud/vpc/MockNetworkManagerImpl.java
@@ -240,8 +240,8 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
      */
     @Override
     public Network updateGuestNetwork(final long networkId, final String name, final String displayText, final Account callerAccount, final User callerUser, final String
-            domainSuffix,
-                                      final Long networkOfferingId, final Boolean changeCidr, final String guestVmCidr, final Boolean displayNetwork, final String newUUID) {
+            domainSuffix, final Long networkOfferingId, final Boolean changeCidr, final String guestVmCidr, final Boolean displayNetwork, final String newUUID, final String
+                                              dns1, final String dns2) {
         // TODO Auto-generated method stub
         return null;
     }
@@ -546,10 +546,9 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
      * .DeploymentPlan, java.lang.String, java.lang.String, boolean, java.lang.Long, ControlledEntity.ACLType, java.lang.Boolean, java.lang.Long)
      */
     @Override
-    public List<NetworkVO> setupNetwork(final Account owner, final NetworkOffering offering, final Network predefined, final DeploymentPlan plan, final String name, final String
-            displayText,
-                                        final boolean errorIfAlreadySetup, final Long domainId, final ACLType aclType, final Boolean subdomainAccess, final Long vpcId, final
-                                        Boolean isNetworkDisplayEnabled)
+    public List<NetworkVO> setupNetwork(final Account owner, final NetworkOffering offering, final Network predefined, final DeploymentPlan plan, final String name,
+                                        final String displayText, final boolean errorIfAlreadySetup, final Long domainId, final ACLType aclType, final Boolean subdomainAccess,
+                                        final Long vpcId, final Boolean isNetworkDisplayEnabled, final String dns1, final String dns2)
             throws ConcurrentOperationException {
         // TODO Auto-generated method stub
         return null;
@@ -662,10 +661,10 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
      */
     @Override
     public Network createGuestNetwork(final long networkOfferingId, final String name, final String displayText, final String gateway, final String cidr, final String vlanId,
-                                      final String networkDomain,
-                                      final Account owner, final Long domainId, final PhysicalNetwork physicalNetwork, final long zoneId, final ACLType aclType, final Boolean
-                                              subdomainAccess, final Long vpcId, final String gatewayv6,
-                                      final String cidrv6, final Boolean displayNetworkEnabled, final String isolatedPvlan) throws ConcurrentOperationException,
+                                      final String networkDomain, final Account owner, final Long domainId, final PhysicalNetwork physicalNetwork, final long zoneId,
+                                      final ACLType aclType, final Boolean subdomainAccess, final Long vpcId, final String gatewayv6, final String cidrv6,
+                                      final Boolean displayNetworkEnabled, final String isolatedPvlan, final String dns1, final String dns2) throws
+            ConcurrentOperationException,
             InsufficientCapacityException,
             ResourceAllocationException {
         // TODO Auto-generated method stub

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsGuestNetwork.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsGuestNetwork.py
@@ -23,11 +23,14 @@ class CsGuestNetwork:
             return self.config.get_dns()
 
         dns = []
-        if not self.config.use_extdns() and 'router_guest_gateway' in self.data:
-            dns.append(self.data['router_guest_gateway'])
-
+        # If the guestnetwork has a DNS parameter, then use it (and only this)
         if 'dns' in self.data:
             dns.extend(self.data['dns'].split(','))
+            return dns
+
+        # Use the router vm as DNS server
+        if not self.config.use_extdns() and 'router_guest_gateway' in self.data:
+            dns.append(self.data['router_guest_gateway'])
 
         return dns or ['']
 

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/merge.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/merge.py
@@ -137,6 +137,8 @@ class updateDataBag:
         dp['nic_dev_id'] = d['device'][3]
         dp['nw_type'] = 'guest'
         dp['vif_mac_address'] = d['mac_address']
+        if 'dns' in d:
+            dp['dns'] = d['dns']
         qf = QueueFile()
         qf.load({ 'ip_address': [dp], 'type': 'ips' })
         if 'domain_name' not in d.keys() or d['domain_name'] == '':


### PR DESCRIPTION
Requirement: specify DNS servers per tier

Create network with DNS servers:
```
(local) 🐵 > create network name=tierDNS displaytext=tierDNS zoneid=30a95621-8ce9-4ddd-98d2-bc42976e0f06 networkofferingid=5fc47118-b534-40a3-93c2-ba92d4ba6a8b vpcid=7b441d81-e732-4558-ae09-2f30de82009d ga
teway=10.3.2.2 netmask=255.255.255.0 dns1=10.3.2.221 dns2=10.3.2.222                                                                                                                                        
network:
id = 444a5546-4a14-408f-b5e1-c0721b3bb0b7
name = tierDNS
account = admin
acltype = Account
broadcastdomaintype = Lswitch
canusefordeploy = True
cidr = 10.3.2.0/24
displaynetwork = True
displaytext = tierDNS
dns1 = 10.3.2.221
dns2 = 10.3.2.222
```

Or without:
```
(local) 🐵 > create network name=tierNoDNS displaytext=NotierDNS zoneid=30a95621-8ce9-4ddd-98d2-bc42976e0f06 networkofferingid=5fc47118-b534-40a3-93c2-ba92d4ba6a8b vpcid=7b441d81-e732-4558-ae09-2f30de82009d gateway=10.3.3.1 netmask=255.255.255.0 
network:
id = 3a06d179-ed66-4523-b33d-73ab31c582a4
name = tierNoDNS
account = admin
acltype = Account
broadcastdomaintype = Lswitch
canusefordeploy = True
cidr = 10.3.3.0/24
displaynetwork = True
displaytext = NotierDNS
domain = ROOT
```

Result on router:
```
root@r-22-VM:~# cat /etc/dnsmasq.d/cloud.conf 
dhcp-hostsfile=/etc/dhcphosts.txt
dhcp-optsfile=/etc/dhcpopts.txt
log-dhcp
dhcp-range=interface:eth3,set:interface-eth3-1,10.3.2.2,static
dhcp-option=tag:interface-eth3-1,15,cs2cloud
dhcp-option=tag:interface-eth3-1,6,10.3.2.221,10.3.2.222
dhcp-option=tag:interface-eth3-1,3,10.3.2.2
dhcp-option=tag:interface-eth3-1,1,255.255.255.0
dhcp-range=interface:eth4,set:interface-eth4-2,10.3.3.1,static
dhcp-option=tag:interface-eth4-2,15,cs2cloud
dhcp-option=tag:interface-eth4-2,6,10.3.3.1
dhcp-option=tag:interface-eth4-2,3,10.3.3.1
dhcp-option=tag:interface-eth4-2,1,255.255.255.0
```

Network `eth3` has its own DNS servers (from the API call), network `eth2` uses the virtual router for DNS.
