### PR TITLE
Explicitly set nwType for IpAssociation command

### DIFF
--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/IpAssociationConfigItem.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/IpAssociationConfigItem.java
@@ -22,7 +22,7 @@ public class IpAssociationConfigItem extends AbstractConfigItemFacade {
 
         for (final IpAddressTO ip : command.getIpAddresses()) {
             final IpAddress ipAddress = new IpAddress(ip.getPublicIp(), ip.isSourceNat(), ip.isAdd(), ip.isOneToOneNat(), ip.isFirstIP(), ip.getVlanGateway(), ip.getVlanNetmask(),
-                    ip.getVifMacAddress(), ip.getNicDevId(), ip.isNewNic());
+                    ip.getVifMacAddress(), ip.getNicDevId(), ip.isNewNic(), ip.getTrafficType().toString());
             ips.add(ipAddress);
         }
 

--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/model/IpAddress.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/model/IpAddress.java
@@ -11,14 +11,14 @@ public class IpAddress {
     private String vifMacAddress;
     private Integer nicDevId;
     private boolean newNic;
+    private String nwType;
 
     public IpAddress() {
         // Empty constructor for (de)serialization
     }
 
-    public IpAddress(final String publicIp, final boolean sourceNat, final boolean add, final boolean oneToOneNat, final boolean firstIP, final String gateway, final String
-            netmask, final String vifMacAddress,
-                     final Integer nicDevId, final boolean newNic) {
+    public IpAddress(final String publicIp, final boolean sourceNat, final boolean add, final boolean oneToOneNat, final boolean firstIP, final String gateway,
+                     final String netmask, final String vifMacAddress, final Integer nicDevId, final boolean newNic, final String nwType) {
         super();
         this.publicIp = publicIp;
         this.sourceNat = sourceNat;
@@ -30,6 +30,7 @@ public class IpAddress {
         this.vifMacAddress = vifMacAddress;
         this.nicDevId = nicDevId;
         this.newNic = newNic;
+        this.nwType = nwType;
     }
 
     public String getPublicIp() {
@@ -110,5 +111,13 @@ public class IpAddress {
 
     public void setNewNic(final boolean newNic) {
         this.newNic = newNic;
+    }
+
+    public String getNwType() {
+        return nwType;
+    }
+
+    public void setNwType(final String nwType) {
+        this.nwType = nwType;
     }
 }

--- a/cosmic-core/nucleo/src/test/java/com/cloud/agent/resource/virtualnetwork/ConfigHelperTest.java
+++ b/cosmic-core/nucleo/src/test/java/com/cloud/agent/resource/virtualnetwork/ConfigHelperTest.java
@@ -27,6 +27,7 @@ import com.cloud.agent.resource.virtualnetwork.model.IpAliases;
 import com.cloud.agent.resource.virtualnetwork.model.IpAssociation;
 import com.cloud.agent.resource.virtualnetwork.model.LoadBalancerRule;
 import com.cloud.agent.resource.virtualnetwork.model.LoadBalancerRules;
+import com.cloud.network.Networks.TrafficType;
 import com.cloud.network.lb.LoadBalancingRule.LbDestination;
 
 import java.util.ArrayList;
@@ -169,9 +170,16 @@ public class ConfigHelperTest {
 
     protected IpAssocVpcCommand generateIpAssocVpcCommand() {
         final List<IpAddressTO> ips = new ArrayList<>();
-        ips.add(new IpAddressTO(1, "64.1.1.10", true, true, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false));
-        ips.add(new IpAddressTO(2, "64.1.1.11", false, false, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false));
-        ips.add(new IpAddressTO(3, "65.1.1.11", true, false, false, "vlan://65", "65.1.1.1", "255.255.255.0", "11:23:45:67:89:AB", 1000, false));
+
+        final IpAddressTO ip1 = new IpAddressTO(1, "64.1.1.10", true, true, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false);
+        final IpAddressTO ip2 = new IpAddressTO(2, "64.1.1.11", false, false, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false);
+        final IpAddressTO ip3 = new IpAddressTO(3, "65.1.1.11", true, false, false, "vlan://65", "65.1.1.1", "255.255.255.0", "11:23:45:67:89:AB", 1000, false);
+        ip1.setTrafficType(TrafficType.Public);
+        ip2.setTrafficType(TrafficType.Public);
+        ip3.setTrafficType(TrafficType.Public);
+        ips.add(ip1);
+        ips.add(ip2);
+        ips.add(ip3);
 
         final IpAddressTO[] ipArray = ips.toArray(new IpAddressTO[ips.size()]);
         final IpAssocVpcCommand cmd = new IpAssocVpcCommand(ipArray);

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py
@@ -19,6 +19,8 @@ def merge(dbag, ip):
     ip['network'] = str(ipo.network) + '/' + str(ipo.prefixlen)
     if 'nw_type' not in ip.keys():
         ip['nw_type'] = 'public'
+    else:
+        ip['nw_type'] = ip['nw_type'].lower()
     if ip['nw_type'] == 'control':
         dbag['eth' + str(ip['nic_dev_id'])] = [ip]
     else:


### PR DESCRIPTION
It is now implicitly set to 'public' when it is not there (cs_ip.py).

Backport of ACS PR 1659 (partly).