### PR TITLE
Use routing table for each public network cidr on the VR

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -841,6 +841,11 @@ class CsForwardingRules(CsDataBag):
         device = self.getDeviceByIp(rule["public_ip"])
         if device is None:
             raise Exception("Ip address %s has no device in the ips databag" % rule["public_ip"])
+
+        self.fw.append(["mangle", "",
+                        "-A PREROUTING -s %s/32 -m state --state NEW -j MARK --set-xmark 0x%s/0xffffffff" % (rule["internal_ip"], device[len("eth"):])])
+        self.fw.append(["mangle", "",
+                        "-A PREROUTING -s %s/32 -m state --state NEW -j CONNMARK --save-mark --nfmask 0xffffffff --ctmask 0xffffffff" % rule["internal_ip"]])
         self.fw.append(["nat", "front",
                         "-A PREROUTING -d %s/32 -j DNAT --to-destination %s" % (rule["public_ip"], rule["internal_ip"])])
         self.fw.append(["nat", "front",

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -273,10 +273,10 @@ class CsIP:
                 CsHelper.execute(cmd)
             except Exception as e:
                 logging.info("Exception occurred ==> %s" % e)
+            self.post_configure(address)
 
         else:
             self.delete(self.ip())
-        self.post_configure(address)
 
     def post_configure(self, address):
         """ The steps that must be done after a device is configured """
@@ -289,7 +289,11 @@ class CsIP:
             interfaces = [CsInterface(address, self.config)]
             CsHelper.reconfigure_interfaces(self.cl, interfaces)
 
-            self.set_mark()
+            if not self.config.is_vpc() and (self.get_type() in ['public']):
+                self.set_mark()
+            if self.config.is_vpc() and (self.get_type() in ['public']):
+                self.set_mark()
+
             if 'gateway' in self.address:
                 self.arpPing()
 
@@ -380,6 +384,10 @@ class CsIP:
                             "-j CONNMARK --set-xmark %s/0xffffffff" % self.dnum])
             self.fw.append(
                 ["mangle", "", "-A FIREWALL_%s -j DROP" % self.address['public_ip']])
+            self.fw.append(["filter", "",
+                            "-A FORWARD -i %s -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT" % self.dev])
+            self.fw.append(["filter", "",
+                                      "-A FORWARD -i eth0 -o %s -j FW_OUTBOUND" % self.dev])
 
         self.fw.append(["filter", "", "-A INPUT -d 224.0.0.18/32 -j ACCEPT"])
         self.fw.append(["filter", "", "-A INPUT -d 224.0.0.22/32 -j ACCEPT"])
@@ -408,14 +416,7 @@ class CsIP:
             self.fw.append(
                 ["filter", "", "-A FORWARD -i %s -o %s -m state --state NEW -j ACCEPT" % (self.dev, self.dev)])
             self.fw.append(
-                ["filter", "", "-A FORWARD -i eth2 -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT"])
-            self.fw.append(
                 ["filter", "", "-A FORWARD -i eth0 -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT"])
-            self.fw.append(
-                ["filter", "", "-A FORWARD -i eth0 -o eth2 -j FW_OUTBOUND"])
-            self.fw.append(["mangle", "",
-                            "-A PREROUTING -i %s -m state --state NEW " % self.dev +
-                            "-j CONNMARK --set-xmark %s/0xffffffff" % self.dnum])
 
         self.fw.append(['', 'front', '-A FORWARD -j NETWORK_STATS'])
         self.fw.append(['', 'front', '-A INPUT -j NETWORK_STATS'])
@@ -429,10 +430,6 @@ class CsIP:
         if not self.config.is_vpc():
             return
 
-        self.fw.append(["mangle", "front", "-A PREROUTING " +
-                        "-m state --state RELATED,ESTABLISHED " +
-                        "-j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff"])
-
         self.fw.append(["", "front", "-A FORWARD -j NETWORK_STATS"])
         self.fw.append(["", "front", "-A INPUT -j NETWORK_STATS"])
         self.fw.append(["", "front", "-A OUTPUT -j NETWORK_STATS"])
@@ -444,6 +441,10 @@ class CsIP:
                         "-p udp -m udp --dport 68 -j CHECKSUM --checksum-fill"])
 
         if self.get_type() in ["guest"]:
+            self.fw.append(["mangle", "front", "-A PREROUTING " +
+                            " -i %s -m state --state RELATED,ESTABLISHED "  % self.dev +
+                            "-j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff"])
+
             guestNetworkCidr = self.address['network']
             # jump to egress chain
             self.fw.append(["mangle", "", "-A PREROUTING -m state --state NEW -i %s ! -d %s -j ACL_OUTBOUND_%s" %
@@ -512,11 +513,38 @@ class CsIP:
 
     def post_config_change(self, method):
         route = CsRoute()
+        tableName = "Table_" + self.dev
+
         if method == "add":
-            route.add_table(self.dev)
-            route.add_route(self.dev, str(self.address["network"]))
+            if not self.config.is_vpc():
+                # treat the first IP on a interface as special case to set up the routing rules
+                if self.get_type() in ["public"] and (len(self.iplist) == 1):
+                    CsHelper.execute("sudo ip route add throw " + self.config.address().dbag['eth0'][0]['network'] + " table " + tableName + " proto static")
+                    CsHelper.execute("sudo ip route add throw " + self.config.address().dbag['eth1'][0]['network'] + " table " + tableName + " proto static")
+
+                # add 'default via gateway' rule in the device specific routing table
+                if "gateway" in self.address and self.address["gateway"] != "None":
+                    route.add_route(self.dev, self.address["gateway"])
+                route.add_network_route(self.dev, str(self.address["network"]))
+
+                if self.get_type() in ["public"]:
+                    CsRule(self.dev).addRule("from " + str(self.address["network"]))
+
+                if self.config.is_vpc():
+                    if self.get_type() in ["public"] and "gateway" in self.address and self.address["gateway"] != "None":
+                        route.add_route(self.dev, self.address["gateway"])
+                    route.add_network_route(self.dev, str(self.address["network"]))
+
+                CsHelper.execute("sudo ip route flush cache")
+
         elif method == "delete":
-            logging.warn("delete route not implemented")
+
+            # treat the last IP to be dis-associated with interface as special case to clean up the routing rules
+            if self.get_type() in ["public"] and (not self.config.is_vpc()) and (len(self.iplist) == 0):
+                CsHelper.execute("sudo ip rule delete table " + tableName)
+                CsHelper.execute("sudo ip route flush table " + tableName)
+                CsHelper.execute("sudo ip route flush cache")
+                CsRule(self.dev).delMark()
 
         self.fw_router()
         self.fw_vpcrouter()

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRoute.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRoute.py
@@ -21,13 +21,27 @@ class CsRoute:
         filename = "/etc/iproute2/rt_tables"
         logging.info(
             "Adding route table: " + str + " to " + filename + " if not present ")
-        CsHelper.addifmissing(filename, str)
+        if not CsHelper.definedinfile(filename, str):
+            CsHelper.execute("sudo echo " + str + " >> /etc/iproute2/rt_tables")
+        # remove "from all table tablename" if exists, else it will interfere with
+        # routing of unintended traffic
+        if self.findRule("from all lookup " + tablename):
+            CsHelper.execute("sudo ip rule delete from all table " + tablename)
 
     def flush_table(self, tablename):
         CsHelper.execute("ip route flush table %s" % (tablename))
         CsHelper.execute("ip route flush cache")
 
     def add_route(self, dev, address):
+        """ Wrapper method that adds table name and device to route statement """
+        # ip route add dev eth1 table Table_eth1 10.0.2.0/24
+        table = self.get_tablename(dev)
+        logging.info("Adding route: dev " + dev + " table: " +
+                     table + " network: " + address + " if not present")
+        cmd = "default via %s table %s proto static" % (address, table)
+        self.set_route(cmd)
+
+    def add_network_route(self, dev, address):
         """ Wrapper method that adds table name and device to route statement """
         # ip route add dev eth1 table Table_eth1 10.0.2.0/24
         table = self.get_tablename(dev)
@@ -80,3 +94,9 @@ class CsRoute:
         else:
             logging.warn("No default route found!")
             return False
+
+    def findRule(self, rule):
+        for i in CsHelper.execute("ip rule show"):
+            if rule in i.strip():
+                return True
+        return False

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRule.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRule.py
@@ -16,11 +16,29 @@ class CsRule:
         self.tableNo = int(dev[3:])
         self.table = "Table_%s" % (dev)
 
+    def addRule(self, rule):
+        if not self.findRule(rule + " lookup " + self.table):
+            cmd = "ip rule add " + rule + " table " + self.table
+            CsHelper.execute(cmd)
+            logging.info("Added rule %s for %s" % (cmd, self.table))
+
+    def findRule(self, rule):
+        for i in CsHelper.execute("ip rule show"):
+            if rule in i.strip():
+                return True
+        return False
+
     def addMark(self):
         if not self.findMark():
             cmd = "ip rule add fwmark %s table %s" % (self.tableNo, self.table)
             CsHelper.execute(cmd)
             logging.info("Added fwmark rule for %s" % (self.table))
+
+    def delMark(self):
+        if self.findMark():
+            cmd = "ip rule delete fwmark %s table %s" % (self.tableNo, self.table)
+            CsHelper.execute(cmd)
+            logging.info("Deleting fwmark rule for %s" % (self.table))
 
     def findMark(self):
         srch = "from all fwmark %s lookup %s" % (hex(self.tableNo), self.table)

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py
@@ -4,15 +4,20 @@ from netaddr import *
 
 
 def merge(dbag, ip):
+    nic_dev_id = None
     for dev in dbag:
         if dev == "id":
             continue
         for address in dbag[dev]:
             if address['public_ip'] == ip['public_ip']:
+                if 'nic_dev_id' in address:
+                    nic_dev_id = address['nic_dev_id']
                 dbag[dev].remove(address)
 
     ipo = IPNetwork(ip['public_ip'] + '/' + ip['netmask'])
-    ip['device'] = 'eth' + str(ip['nic_dev_id'])
+    if 'nic_dev_id' in ip:
+        nic_dev_id = ip['nic_dev_id']
+    ip['device'] = 'eth' + str(nic_dev_id)
     ip['broadcast'] = str(ipo.broadcast)
     ip['cidr'] = str(ipo.ip) + '/' + str(ipo.prefixlen)
     ip['size'] = str(ipo.prefixlen)
@@ -22,8 +27,8 @@ def merge(dbag, ip):
     else:
         ip['nw_type'] = ip['nw_type'].lower()
     if ip['nw_type'] == 'control':
-        dbag['eth' + str(ip['nic_dev_id'])] = [ip]
+        dbag['eth' + str(nic_dev_id)] = [ip]
     else:
-        dbag.setdefault('eth' + str(ip['nic_dev_id']), []).append(ip)
+        dbag.setdefault('eth' + str(nic_dev_id), []).append(ip)
 
     return dbag


### PR DESCRIPTION
Backport of ACS PR 1659 (and follow-up fix in 1929). Left out the part that is tested in #251.