### PR TITLE
Add debug info that prints the contents of the json commands

### DIFF
--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/AbstractConfigItemFacade.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/AbstractConfigItemFacade.java
@@ -99,7 +99,10 @@ public abstract class AbstractConfigItemFacade {
         final String remoteFilename = appendUuidToJsonFiles(destinationFile);
         s_logger.debug("Transformed filename " + destinationFile + " to " + remoteFilename);
 
-        final ConfigItem configFile = new FileConfigItem(VRScripts.CONFIG_PERSIST_LOCATION, remoteFilename, gson.toJson(configuration));
+        final String jsonConfigCommand = gson.toJson(configuration);
+        s_logger.debug("Contents of jsonConfigCommand " + remoteFilename + " is: " + jsonConfigCommand);
+
+        final ConfigItem configFile = new FileConfigItem(VRScripts.CONFIG_PERSIST_LOCATION, remoteFilename, jsonConfigCommand);
         cfg.add(configFile);
 
         final ConfigItem updateCommand = new ScriptConfigItem(VRScripts.UPDATE_CONFIG, remoteFilename);


### PR DESCRIPTION
When the router is being provisioned and something goes wrong (hits an exit 1) it gets destroyed after which it's hard to understand what command was sent. Added the exact json command to the debug logging.

Example:
```
2017-02-04 19:34:48.163 DEBUG (logid: 438d46a2) 2628 --- [agentRequest-Handler-4] c.c.a.r.v.VirtualRoutingResource         : Transforming com.cloud.agent.api.routing.SetFirewallRulesCommand to ConfigItems
2017-02-04 19:34:48.163 DEBUG (logid: 438d46a2) 2628 --- [agentRequest-Handler-4] c.c.a.r.v.f.AbstractConfigItemFacade     : Transformed filename firewall_rules.json to firewall_rules.json.6f383dd5-1f1a-4673-a6ff-6bce7d9e6cf9
2017-02-04 19:34:48.163 DEBUG (logid: 438d46a2) 2628 --- [agentRequest-Handler-4] c.c.a.r.v.f.AbstractConfigItemFacade     : Contents of jsonConfigCommand firewall_rules.json.6f383dd5-1f1a-4673-a6ff-6bce7d9e6cf9 is: {"rules":[{"id":0,"src_
ip":"","protocol":"all","revoked":false,"already_added":false,"source_cidr_list":[],"purpose":"Firewall","traffic_type":"Egress","default_egress_policy":false}],"type":"firewallrules"}
2017-02-04 19:34:48.163 DEBUG (logid: 438d46a2) 2628 --- [agentRequest-Handler-4] c.c.h.k.r.LibvirtComputingResource       : Creating file in VR VR-2a8777c0-0553-438f-8df4-a207ed275bdc.cfg
```

That JSON part can you then simply copy/paste either to a router to replay it or to a JSON tool to easily view it.