### PR TITLE
Make global setting snapshot.backup.rightafter work

### DIFF
--- a/cosmic-core/engine/storage/snapshot/src/main/java/com/cloud/storage/snapshot/SnapshotStateMachineManagerImpl.java
+++ b/cosmic-core/engine/storage/snapshot/src/main/java/com/cloud/storage/snapshot/SnapshotStateMachineManagerImpl.java
@@ -30,6 +30,7 @@ public class SnapshotStateMachineManagerImpl implements SnapshotStateMachineMana
         stateMachine.addTransition(Snapshot.State.BackingUp, Event.OperationFailed, Snapshot.State.Error);
         stateMachine.addTransition(Snapshot.State.BackedUp, Event.DestroyRequested, Snapshot.State.Destroying);
         stateMachine.addTransition(Snapshot.State.BackedUp, Event.CopyingRequested, Snapshot.State.Copying);
+        stateMachine.addTransition(Snapshot.State.BackedUp, Event.BackupToSecondary, Snapshot.State.BackingUp);
         stateMachine.addTransition(Snapshot.State.Copying, Event.OperationSucceeded, Snapshot.State.BackedUp);
         stateMachine.addTransition(Snapshot.State.Copying, Event.OperationFailed, Snapshot.State.BackedUp);
         stateMachine.addTransition(Snapshot.State.Destroying, Event.OperationSucceeded, Snapshot.State.Destroyed);

--- a/cosmic-core/server/src/main/java/com/cloud/configuration/Config.java
+++ b/cosmic-core/server/src/main/java/com/cloud/configuration/Config.java
@@ -488,7 +488,7 @@ public enum Config {
             null),
     SnapshotDeltaMax("Snapshots", SnapshotManager.class, Integer.class, "snapshot.delta.max", "16", "max delta snapshots between two full snapshots.", null),
     BackupSnapshotAfterTakingSnapshot(
-            "Hidden",
+            "Snapshots",
             SnapshotManager.class,
             Boolean.class,
             "snapshot.backup.rightafter",

--- a/cosmic-core/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
@@ -1102,7 +1102,14 @@ public class SnapshotManagerImpl extends ManagerBase implements SnapshotManager,
 
             try {
                 postCreateSnapshot(volume.getId(), snapshotId, payload.getSnapshotPolicyId());
-                final SnapshotDataStoreVO snapshotStoreRef = _snapshotStoreDao.findBySnapshot(snapshotId, DataStoreRole.Image);
+                SnapshotDataStoreVO snapshotStoreRef = _snapshotStoreDao.findBySnapshot(snapshotId, DataStoreRole.Image);
+                if (snapshotStoreRef == null) {
+                    // The snapshot was not backed up to secondary.  Find the snap on primary
+                    snapshotStoreRef = _snapshotStoreDao.findBySnapshot(snapshotId, DataStoreRole.Primary);
+                    if (snapshotStoreRef == null) {
+                        throw new CloudRuntimeException("Could not find snapshot");
+                    }
+                }
                 UsageEventUtils.publishUsageEvent(EventTypes.EVENT_SNAPSHOT_CREATE, snapshot.getAccountId(), snapshot.getDataCenterId(), snapshotId, snapshot.getName(),
                         null, null, snapshotStoreRef.getPhysicalSize(), volume.getSize(), snapshot.getClass().getName(), snapshot.getUuid());
                 // Correct the resource count of snapshot in case of delta snapshots.

--- a/cosmic-core/server/src/test/java/com/cloud/template/TemplateManagerImplTest.java
+++ b/cosmic-core/server/src/test/java/com/cloud/template/TemplateManagerImplTest.java
@@ -24,6 +24,7 @@ import com.cloud.engine.subsystem.api.storage.EndPointSelector;
 import com.cloud.engine.subsystem.api.storage.PrimaryDataStore;
 import com.cloud.engine.subsystem.api.storage.SnapshotDataFactory;
 import com.cloud.engine.subsystem.api.storage.StorageCacheManager;
+import com.cloud.engine.subsystem.api.storage.StorageStrategyFactory;
 import com.cloud.engine.subsystem.api.storage.TemplateDataFactory;
 import com.cloud.engine.subsystem.api.storage.TemplateService;
 import com.cloud.engine.subsystem.api.storage.VolumeDataFactory;
@@ -144,6 +145,9 @@ public class TemplateManagerImplTest {
 
     @Inject
     SnapshotDao snapshotDao;
+
+    @Inject
+    StorageStrategyFactory storageStrategyFactory;
 
     @Before
     public void setUp() {
@@ -410,6 +414,11 @@ public class TemplateManagerImplTest {
         @Bean
         public VMTemplateDao vmTemplateDao() {
             return Mockito.mock(VMTemplateDao.class);
+        }
+
+        @Bean
+        public StorageStrategyFactory storageStrategyFactory() {
+            return Mockito.mock(StorageStrategyFactory.class);
         }
 
         @Bean


### PR DESCRIPTION
This allows turning off the snapshot backups to secondary storage.

```
2017-02-04 21:18:13.239 DEBUG [c.c.v.VmWorkJobDispatcher] (logid: fa15827b) (ctx: 564b7bef) (job: 295/job: 296) Run VM work job: com.cloud.vm.VmWorkTakeVolumeSnapshot for VM 33, job origin: 295
2017-02-04 21:18:13.239 DEBUG [c.c.v.VmWorkJobHandlerProxy] (logid: fa15827b) (ctx: e9e92094) (job: 295/job: 296) Execute VM work job: com.cloud.vm.VmWorkTakeVolumeSnapshot{"volumeId":31,"policyId":0,"snapshotId":4,"quiesceVm":false,"userI
d":2,"accountId":2,"vmId":33,"handlerName":"VolumeApiServiceImpl"}
2017-02-04 21:18:13.263 DEBUG [c.c.h.XenServerGuru] (logid: fa15827b) (ctx: e9e92094) (job: 295/job: 296) getCommandHostDelegation: class com.cloud.storage.command.CreateObjectCommand
2017-02-04 21:18:13.734 DEBUG [c.c.s.s.XenserverSnapshotStrategy] (logid: fa15827b) (ctx: e9e92094) (job: 295/job: 296) skipping backup of snapshot due to configuration snapshot.backup.rightafter
2017-02-04 21:18:13.745 DEBUG [c.c.v.VmWorkJobHandlerProxy] (logid: fa15827b) (ctx: e9e92094) (job: 295/job: 296) Done executing VM work job: com.cloud.vm.VmWorkTakeVolumeSnapshot{"volumeId":31,"policyId":0,"snapshotId":4,"quiesceVm":false
,"userId":2,"accountId":2,"vmId":33,"handlerName":"VolumeApiServiceImpl"}
2017-02-04 21:18:13.745 DEBUG [c.c.f.j.i.AsyncJobManagerImpl] (logid: fa15827b) (ctx: e9e92094) (job: 295/job: 296) Complete async job-296, jobStatus: SUCCEEDED, resultCode: 0, result: rO0ABXNyAA5qYXZhLmxhbmcuTG9uZzuL5JDMjyPfAgABSgAFdmFsdW
V4cgAQamF2YS5sYW5nLk51bWJlcoaslR0LlOCLAgAAeHAAAAAAAAAABA

```
I tested it with KVM and it didn't copy to secondary storage as soon as I set the setting to false. However, it's confusing that `XenserverSnapshotStrategy` class (strickly speaking even the Guru) is actually also being used for KVM snapshots. We may want to tackle that in a separate PR, if we want.

Backport of ACS PR 1697