### PR TITLE
Support for ROOT disk detach for KVM

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -746,8 +746,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
     }
 
     private void validateRootVolumeDetachAttach(final VolumeVO volume, final UserVmVO vm) {
-        if (!(vm.getHypervisorType() == HypervisorType.XenServer)) {
-            throw new InvalidParameterValueException("Root volume detach is allowed for hypervisor type " + HypervisorType.XenServer + " only");
+        if (!(vm.getHypervisorType() == HypervisorType.XenServer || vm.getHypervisorType() == HypervisorType.KVM)) {
+            throw new InvalidParameterValueException("Root volume detach is not supported for hypervisor type " + vm.getHypervisorType());
         }
         if (!(vm.getState() == State.Stopped) || vm.getState() == State.Destroyed) {
             throw new InvalidParameterValueException("Root volume detach can happen only when vm is in states: " + State.Stopped.toString() + " or " + State.Destroyed.toString());

--- a/cosmic-marvin/marvin/lib/base.py
+++ b/cosmic-marvin/marvin/lib/base.py
@@ -701,11 +701,15 @@ class VirtualMachine:
                 })
         apiclient.migrateVirtualMachineWithVolume(cmd)
 
-    def attach_volume(self, apiclient, volume):
+    def attach_volume(self, apiclient, volume, deviceid=None):
         """Attach volume to instance"""
         cmd = attachVolume.attachVolumeCmd()
         cmd.id = volume.id
         cmd.virtualmachineid = self.id
+
+        if deviceid is not None:
+            cmd.deviceid = deviceid
+
         return apiclient.attachVolume(cmd)
 
     def detach_volume(self, apiclient, volume):


### PR DESCRIPTION
Backport of ACS PR 1500

It works on KVM, just there was a check blocking it. As soon as you detach a root disk, it will became a normal 'data' disk. When you attach a 'data disk' with deviceid=0, it will become a 'root disk'.

I didn't backport the Marvin test, as we haven't included that file in our run. We can look into it and port it too. Didn't make sense to add a test that we are not running. The Marvin lib part that supports supplying a deviceid could come in handy.