### PR TITLE
Implement clientTimeout and serverTimeout API params for LB rules

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/agent/api/to/LoadBalancerTO.java
+++ b/cosmic-core/api/src/main/java/com/cloud/agent/api/to/LoadBalancerTO.java
@@ -36,22 +36,24 @@ public class LoadBalancerTO {
     private HealthCheckPolicyTO[] healthCheckPolicies;
     private LbSslCert sslCert; /* XXX: Should this be SslCertTO?  */
     private AutoScaleVmGroupTO autoScaleVmGroupTO;
+    private int clientTimeout;
+    private int serverTimeout;
 
-    public LoadBalancerTO(final String id, final String srcIp, final int srcPort, final String protocol, final String algorithm, final boolean revoked, final boolean
-            alreadyAdded, final boolean inline,
-                          final List<LbDestination> argDestinations, final List<LbStickinessPolicy> stickinessPolicies) {
+    public LoadBalancerTO(final String id, final String srcIp, final int srcPort, final String protocol, final String algorithm, final boolean revoked,
+                          final boolean alreadyAdded, final boolean inline, final List<LbDestination> argDestinations, final List<LbStickinessPolicy> stickinessPolicies,
+                          final int clientTimeout, final int serverTimeout) {
 
-        this(id, srcIp, srcPort, protocol, algorithm, revoked, alreadyAdded, inline, argDestinations, stickinessPolicies, null, null, null);
+        this(id, srcIp, srcPort, protocol, algorithm, revoked, alreadyAdded, inline, argDestinations, stickinessPolicies, null, null, null, clientTimeout, serverTimeout);
     }
 
-    public LoadBalancerTO(final String id, final String srcIp, final int srcPort, final String protocol, final String algorithm, final boolean revoked, final boolean
-            alreadyAdded, final boolean inline,
-                          final List<LbDestination> argDestinations, final List<LbStickinessPolicy> stickinessPolicies, final List<LbHealthCheckPolicy> healthCheckPolicies,
-                          final LbSslCert sslCert,
-                          final String lbProtocol) {
-        this(id, srcIp, srcPort, protocol, algorithm, revoked, alreadyAdded, inline, argDestinations);
+    public LoadBalancerTO(final String id, final String srcIp, final int srcPort, final String protocol, final String algorithm, final boolean revoked,
+                          final boolean alreadyAdded, final boolean inline, final List<LbDestination> argDestinations, final List<LbStickinessPolicy> stickinessPolicies,
+                          final List<LbHealthCheckPolicy> healthCheckPolicies, final LbSslCert sslCert, final String lbProtocol, final int clientTimeout, final int serverTimeout) {
+        this(id, srcIp, srcPort, protocol, algorithm, revoked, alreadyAdded, inline, argDestinations, clientTimeout, serverTimeout);
         this.stickinessPolicies = null;
         this.healthCheckPolicies = null;
+        this.clientTimeout = clientTimeout;
+        this.serverTimeout = serverTimeout;
         if (stickinessPolicies != null && stickinessPolicies.size() > 0) {
             this.stickinessPolicies = new StickinessPolicyTO[MAX_STICKINESS_POLICIES];
             int index = 0;
@@ -91,9 +93,8 @@ public class LoadBalancerTO {
         this.lbProtocol = lbProtocol;
     }
 
-    public LoadBalancerTO(final String uuid, final String srcIp, final int srcPort, final String protocol, final String algorithm, final boolean revoked, final boolean
-            alreadyAdded, final boolean inline,
-                          List<LbDestination> destinations) {
+    public LoadBalancerTO(final String uuid, final String srcIp, final int srcPort, final String protocol, final String algorithm, final boolean revoked,
+                          final boolean alreadyAdded, final boolean inline, List<LbDestination> destinations, final Integer clientTimeout, final Integer serverTimeout) {
         if (destinations == null) { // for autoscaleconfig destinations will be null;
             destinations = new ArrayList<>();
         }
@@ -109,6 +110,8 @@ public class LoadBalancerTO {
         this.stickinessPolicies = null;
         this.sslCert = null;
         this.lbProtocol = null;
+        this.clientTimeout = clientTimeout;
+        this.serverTimeout = serverTimeout;
         int i = 0;
         for (final LbDestination destination : destinations) {
             this.destinations[i++] = new DestinationTO(destination.getIpAddress(), destination.getDestinationPortStart(), destination.isRevoked(), false);
@@ -184,6 +187,22 @@ public class LoadBalancerTO {
 
     public LbSslCert getSslCert() {
         return this.sslCert;
+    }
+
+    public int getClientTimeout() {
+        return clientTimeout;
+    }
+
+    public void setClientTimeout(final int clientTimeout) {
+        this.clientTimeout = clientTimeout;
+    }
+
+    public int getServerTimeout() {
+        return serverTimeout;
+    }
+
+    public void setServerTimeout(final int serverTimeout) {
+        this.serverTimeout = serverTimeout;
     }
 
     public void setAutoScaleVmGroup(final LbAutoScaleVmGroup lbAutoScaleVmGroup) {

--- a/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
@@ -24,6 +24,7 @@ public class ApiConstants {
     public static final String CERTIFICATE_CHAIN = "certchain";
     public static final String CERTIFICATE_FINGERPRINT = "fingerprint";
     public static final String CERTIFICATE_ID = "certid";
+    public static final String CLIENT_TIMEOUT = "clienttimeout";
     public static final String PRIVATE_KEY = "privatekey";
     public static final String DOMAIN_SUFFIX = "domainsuffix";
     public static final String DNS_SEARCH_ORDER = "dnssearchorder";
@@ -212,6 +213,7 @@ public class ApiConstants {
     public static final String SECURITY_GROUP_ID = "securitygroupid";
     public static final String SENT = "sent";
     public static final String SENT_BYTES = "sentbytes";
+    public static final String SERVER_TIMEOUT = "servertimeout";
     public static final String SERVICE_OFFERING_ID = "serviceofferingid";
     public static final String SESSIONKEY = "sessionkey";
     public static final String SHOW_CAPACITIES = "showcapacities";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/CreateLoadBalancerRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/CreateLoadBalancerRuleCmd.java
@@ -106,6 +106,16 @@ public class CreateLoadBalancerRuleCmd extends BaseAsyncCreateCmd /*implements L
             ".4", authorized = {RoleType.Admin})
     private Boolean display;
 
+    @Parameter(name = ApiConstants.CLIENT_TIMEOUT,
+            type = CommandType.INTEGER,
+            description = "the HAProxy client_timeout setting for this load balancing rule (in ms).")
+    private Integer clientTimeout;
+
+    @Parameter(name = ApiConstants.SERVER_TIMEOUT,
+            type = CommandType.INTEGER,
+            description = "the HAProxy server_timeout setting for this load balancing rule (in ms).")
+    private Integer serverTimeout;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -128,6 +138,22 @@ public class CreateLoadBalancerRuleCmd extends BaseAsyncCreateCmd /*implements L
 
     public Integer getPublicPort() {
         return publicPort;
+    }
+
+    public Integer getClientTimeout() {
+        return clientTimeout;
+    }
+
+    public void setClientTimeout(final Integer clientTimeout) {
+        this.clientTimeout = clientTimeout;
+    }
+
+    public Integer getServerTimeout() {
+        return serverTimeout;
+    }
+
+    public void setServerTimeout(final Integer serverTimeout) {
+        this.serverTimeout = serverTimeout;
     }
 
     public List<String> getSourceCidrList() {
@@ -261,7 +287,7 @@ public class CreateLoadBalancerRuleCmd extends BaseAsyncCreateCmd /*implements L
             final LoadBalancer result =
                     _lbService.createPublicLoadBalancerRule(getXid(), getName(), getDescription(), getSourcePortStart(), getSourcePortEnd(), getDefaultPortStart(),
                             getDefaultPortEnd(), getSourceIpAddressId(), getProtocol(), getAlgorithm(), getNetworkId(), getEntityOwnerId(), getOpenFirewall(), getLbProtocol(),
-                            isDisplay());
+                            isDisplay(), getClientTimeout(), getServerTimeout());
             this.setEntityId(result.getId());
             this.setEntityUuid(result.getUuid());
         } catch (final NetworkRuleConflictException e) {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/UpdateLoadBalancerRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/UpdateLoadBalancerRuleCmd.java
@@ -50,6 +50,16 @@ public class UpdateLoadBalancerRuleCmd extends BaseAsyncCustomIdCmd {
             ".4", authorized = {RoleType.Admin})
     private Boolean display;
 
+    @Parameter(name = ApiConstants.CLIENT_TIMEOUT,
+            type = CommandType.INTEGER,
+            description = "the HAProxy client_timeout setting for this load balancing rule (in ms).")
+    private Integer clientTimeout;
+
+    @Parameter(name = ApiConstants.SERVER_TIMEOUT,
+            type = CommandType.INTEGER,
+            description = "the HAProxy server_timeout setting for this load balancing rule (in ms).")
+    private Integer serverTimeout;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -68,6 +78,22 @@ public class UpdateLoadBalancerRuleCmd extends BaseAsyncCustomIdCmd {
 
     public Boolean getDisplay() {
         return display;
+    }
+
+    public Integer getClientTimeout() {
+        return clientTimeout;
+    }
+
+    public void setClientTimeout(final Integer clientTimeout) {
+        this.clientTimeout = clientTimeout;
+    }
+
+    public Integer getServerTimeout() {
+        return serverTimeout;
+    }
+
+    public void setServerTimeout(final Integer serverTimeout) {
+        this.serverTimeout = serverTimeout;
     }
 
     @Override

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/LoadBalancerResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/LoadBalancerResponse.java
@@ -90,6 +90,14 @@ public class LoadBalancerResponse extends BaseResponse implements ControlledEnti
     @Param(description = "is rule for display to the regular user", since = "4.4", authorized = {RoleType.Admin})
     private Boolean forDisplay;
 
+    @SerializedName(ApiConstants.CLIENT_TIMEOUT)
+    @Param(description = "the HAProxy client_timeout setting for this load balancing rule.")
+    private Integer clientTimeout;
+
+    @SerializedName(ApiConstants.SERVER_TIMEOUT)
+    @Param(description = "the HAProxy server_timeout setting for this load balancing rule.")
+    private Integer serverTimeout;
+
     public void setId(final String id) {
         this.id = id;
     }
@@ -120,6 +128,22 @@ public class LoadBalancerResponse extends BaseResponse implements ControlledEnti
 
     public void setAlgorithm(final String algorithm) {
         this.algorithm = algorithm;
+    }
+
+    public Integer getClientTimeout() {
+        return clientTimeout;
+    }
+
+    public void setClientTimeout(final Integer clientTimeout) {
+        this.clientTimeout = clientTimeout;
+    }
+
+    public Integer getServerTimeout() {
+        return serverTimeout;
+    }
+
+    public void setServerTimeout(final Integer serverTimeout) {
+        this.serverTimeout = serverTimeout;
     }
 
     @Override

--- a/cosmic-core/api/src/main/java/com/cloud/network/lb/LoadBalancingRule.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/lb/LoadBalancingRule.java
@@ -22,6 +22,8 @@ public class LoadBalancingRule {
     private List<LbHealthCheckPolicy> healthCheckPolicies;
     private LbSslCert sslCert;
     private String lbProtocol;
+    private int clientTimeout;
+    private int serverTimeout;
 
     public LoadBalancingRule(final LoadBalancer lb, final List<LbDestination> destinations, final List<LbStickinessPolicy> stickinessPolicies,
                              final List<LbHealthCheckPolicy> healthCheckPolicies, final Ip sourceIp) {
@@ -41,6 +43,10 @@ public class LoadBalancingRule {
         this.sourceIp = sourceIp;
         this.sslCert = sslCert;
         this.lbProtocol = lbProtocol;
+        if (lb != null) {
+            this.clientTimeout = lb.getClientTimeout();
+            this.serverTimeout = lb.getServerTimeout();
+        }
     }
 
     public long getId() {
@@ -135,6 +141,22 @@ public class LoadBalancingRule {
         this.autoScaleVmGroup = autoScaleVmGroup;
     }
 
+    public int getClientTimeout() {
+        return clientTimeout;
+    }
+
+    public void setClientTimeout(final int clientTimeout) {
+        this.clientTimeout = clientTimeout;
+    }
+
+    public int getServerTimeout() {
+        return serverTimeout;
+    }
+
+    public void setServerTimeout(final int serverTimeout) {
+        this.serverTimeout = serverTimeout;
+    }
+
     public boolean isAutoScaleConfig() {
         return this.autoScaleVmGroup != null;
     }
@@ -202,8 +224,7 @@ public class LoadBalancingRule {
         }
 
         public LbHealthCheckPolicy(final String pingpath, final String description, final int responseTime, final int healthcheckInterval, final int healthcheckThresshold, final
-        int unhealthThresshold,
-                                   final boolean revoke) {
+        int unhealthThresshold, final boolean revoke) {
             this.pingpath = pingpath;
             this.description = description;
             this.responseTime = responseTime;

--- a/cosmic-core/api/src/main/java/com/cloud/network/lb/LoadBalancingRulesService.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/lb/LoadBalancingRulesService.java
@@ -32,8 +32,8 @@ public interface LoadBalancingRulesService {
      * @throws InsufficientAddressCapacityException
      */
     LoadBalancer createPublicLoadBalancerRule(String xId, String name, String description, int srcPortStart, int srcPortEnd, int defPortStart, int defPortEnd,
-                                              Long ipAddrId, String protocol, String algorithm, long networkId, long lbOwnerId, boolean openFirewall, String lbProtocol, Boolean
-                                                      forDisplay) throws NetworkRuleConflictException,
+                                              Long ipAddrId, String protocol, String algorithm, long networkId, long lbOwnerId, boolean openFirewall, String lbProtocol,
+                                              Boolean forDisplay, Integer clientTimeout, Integer serverTimeout) throws NetworkRuleConflictException,
             InsufficientAddressCapacityException;
 
     LoadBalancer updateLoadBalancerRule(UpdateLoadBalancerRuleCmd cmd);

--- a/cosmic-core/api/src/main/java/com/cloud/network/rules/LoadBalancer.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/rules/LoadBalancer.java
@@ -8,4 +8,8 @@ public interface LoadBalancer extends FirewallRule, LoadBalancerContainer {
     int getDefaultPortStart();
 
     int getDefaultPortEnd();
+
+    int getClientTimeout();
+
+    int getServerTimeout();
 }

--- a/cosmic-core/api/src/main/java/com/cloud/network/rules/LoadBalancerContainer.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/rules/LoadBalancerContainer.java
@@ -10,6 +10,10 @@ public interface LoadBalancerContainer {
 
     String getLbProtocol();
 
+    int getServerTimeout();
+
+    int getClientTimeout();
+
     Scheme getScheme();
 
     public enum Scheme {

--- a/cosmic-core/db-scripts/src/main/resources/db/schema-531to532.sql
+++ b/cosmic-core/db-scripts/src/main/resources/db/schema-531to532.sql
@@ -2,3 +2,9 @@
 -- Schema upgrade from 5.3.1 to 5.3.2;
 --
 
+-- New config properties for HAproxy loadbalancer
+ALTER table load_balancing_rules ADD client_timeout int(10) NULL COMMENT 'client_timeout of haproxy config';
+ALTER table load_balancing_rules ADD server_timeout int(10) NULL COMMENT 'server_timeout of haproxy config';
+INSERT IGNORE INTO `cloud`.`configuration`(category, instance, component, name, value, description, default_value)
+VALUES ('Network', 'DEFAULT', 'management-server', 'network.loadbalancer.haproxy.default.timeout.client', '60000', 'Default HAProxy client timeout setting (in ms)', '60000'),
+('Network', 'DEFAULT', 'management-server', 'network.loadbalancer.haproxy.default.timeout.server', '60000', 'Default HAProxy server timeout setting (in ms)', '60000');

--- a/cosmic-core/engine/components-api/src/main/java/com/cloud/network/lb/LoadBalancingRulesManager.java
+++ b/cosmic-core/engine/components-api/src/main/java/com/cloud/network/lb/LoadBalancingRulesManager.java
@@ -17,7 +17,8 @@ import java.util.List;
 public interface LoadBalancingRulesManager {
 
     LoadBalancer createPublicLoadBalancer(String xId, String name, String description, int srcPort, int destPort, long sourceIpId, String protocol, String algorithm,
-                                          boolean openFirewall, CallContext caller, String lbProtocol, Boolean forDisplay) throws NetworkRuleConflictException;
+                                          boolean openFirewall, CallContext caller, String lbProtocol, Boolean forDisplay, int clientTimeout, int serverTimeout)
+            throws NetworkRuleConflictException;
 
     boolean removeAllLoadBalanacersForIp(long ipId, Account caller, long callerUserId);
 

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/lb/ApplicationLoadBalancerRuleVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/lb/ApplicationLoadBalancerRuleVO.java
@@ -42,13 +42,17 @@ public class ApplicationLoadBalancerRuleVO extends FirewallRuleVO implements App
     @Column(name = "source_ip_address")
     @Enumerated(value = EnumType.STRING)
     private Ip sourceIp = null;
+    @Column(name = "client_timeout")
+    private int clientTimeout;
+    @Column(name = "server_timeout")
+    private int serverTimeout;
 
     public ApplicationLoadBalancerRuleVO() {
     }
 
     public ApplicationLoadBalancerRuleVO(final String name, final String description, final int srcPort, final int instancePort, final String algorithm, final long networkId,
-                                         final long accountId, final long domainId,
-                                         final Ip sourceIp, final long sourceIpNtwkId, final Scheme scheme) {
+                                         final long accountId, final long domainId, final Ip sourceIp, final long sourceIpNtwkId, final Scheme scheme, final int clientTimeout,
+                                         final int serverTimeout) {
         super(null, null, srcPort, srcPort, NetUtils.TCP_PROTO, networkId, accountId, domainId, Purpose.LoadBalancing, null, null, null, null, null);
 
         this.name = name;
@@ -59,6 +63,8 @@ public class ApplicationLoadBalancerRuleVO extends FirewallRuleVO implements App
         this.sourceIp = sourceIp;
         this.sourceIpNetworkId = sourceIpNtwkId;
         this.scheme = scheme;
+        this.clientTimeout = clientTimeout;
+        this.serverTimeout = serverTimeout;
     }
 
     @Override
@@ -109,5 +115,23 @@ public class ApplicationLoadBalancerRuleVO extends FirewallRuleVO implements App
     @Override
     public int getInstancePort() {
         return defaultPortStart;
+    }
+
+    @Override
+    public int getClientTimeout() {
+        return clientTimeout;
+    }
+
+    public void setClientTimeout(final int clientTimeout) {
+        this.clientTimeout = clientTimeout;
+    }
+
+    @Override
+    public int getServerTimeout() {
+        return serverTimeout;
+    }
+
+    public void setServerTimeout(final int serverTimeout) {
+        this.serverTimeout = serverTimeout;
     }
 }

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/network/dao/LoadBalancerVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/network/dao/LoadBalancerVO.java
@@ -38,13 +38,16 @@ public class LoadBalancerVO extends FirewallRuleVO implements LoadBalancer {
     private int defaultPortStart;
     @Column(name = "default_port_end")
     private int defaultPortEnd;
+    @Column(name = "client_timeout")
+    private int clientTimeout;
+    @Column(name = "server_timeout")
+    private int serverTimeout;
 
     public LoadBalancerVO() {
     }
 
-    public LoadBalancerVO(final String xId, final String name, final String description, final long srcIpId, final int srcPort, final int dstPort, final String algorithm, final
-    long networkId, final long accountId,
-                          final long domainId, final String lbProtocol) {
+    public LoadBalancerVO(final String xId, final String name, final String description, final long srcIpId, final int srcPort, final int dstPort, final String algorithm,
+                          final long networkId, final long accountId, final long domainId, final String lbProtocol, final int clientTimeout, final int serverTimeout) {
         super(xId, srcIpId, srcPort, NetUtils.TCP_PROTO, networkId, accountId, domainId, Purpose.LoadBalancing, null, null, null, null);
         this.name = name;
         this.description = description;
@@ -53,6 +56,8 @@ public class LoadBalancerVO extends FirewallRuleVO implements LoadBalancer {
         this.defaultPortEnd = dstPort;
         this.scheme = Scheme.Public;
         this.lbProtocol = lbProtocol;
+        this.clientTimeout = clientTimeout;
+        this.serverTimeout = serverTimeout;
     }
 
     @Override
@@ -104,5 +109,23 @@ public class LoadBalancerVO extends FirewallRuleVO implements LoadBalancer {
     @Override
     public int getDefaultPortEnd() {
         return defaultPortEnd;
+    }
+
+    @Override
+    public int getClientTimeout() {
+        return clientTimeout;
+    }
+
+    public void setClientTimeout(final int clientTimeout) {
+        this.clientTimeout = clientTimeout;
+    }
+
+    @Override
+    public int getServerTimeout() {
+        return serverTimeout;
+    }
+
+    public void setServerTimeout(final int serverTimeout) {
+        this.serverTimeout = serverTimeout;
     }
 }

--- a/cosmic-core/nucleo/src/main/java/com/cloud/network/HAProxyConfigurator.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/network/HAProxyConfigurator.java
@@ -28,7 +28,7 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
             "\tuser haproxy", "\tgroup haproxy", "\tdaemon"};
 
     private static final String[] defaultsSection = {"defaults", "\tlog     global", "\tmode    tcp", "\toption  dontlognull", "\tretries 3", "\toption redispatch",
-            "\toption forwardfor", "\toption forceclose", "\ttimeout connect    5000", "\ttimeout client     50000", "\ttimeout server     50000"};
+            "\toption forwardfor", "\toption forceclose", "\ttimeout connect    5000", "\ttimeout client     60000", "\ttimeout server     60000"};
 
     private static final String[] defaultListen = {"listen  vmops 0.0.0.0:9", "\toption transparent"};
 
@@ -58,9 +58,7 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
         result.add(blankLine);
 
         if (pools.isEmpty()) {
-            // haproxy cannot handle empty listen / frontend or backend, so add
-            // a dummy listener
-            // on port 9
+            // HAproxy cannot handle empty listen / frontend or backend, so add a dummy listener on port 9
             result.addAll(Arrays.asList(defaultListen));
         }
         result.add(blankLine);
@@ -77,19 +75,16 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
         final PortForwardingRuleTO firstRule = fwRules.get(0);
         final String publicIP = firstRule.getSrcIp();
         final String publicPort = Integer.toString(firstRule.getSrcPortRange()[0]);
-        // FIXEME: String algorithm = firstRule.getAlgorithm();
 
         final List<String> result = new ArrayList<>();
-        // add line like this: "listen  65_37_141_30-80 65.37.141.30:80"
+        // Add line like this: "listen  65_37_141_30-80 65.37.141.30:80"
         StringBuilder sb = new StringBuilder();
         sb.append("listen ").append(poolName).append(" ").append(publicIP).append(":").append(publicPort);
         result.add(sb.toString());
         sb = new StringBuilder();
         // FIXME sb.append("\t").append("balance ").append(algorithm);
         result.add(sb.toString());
-        if (publicPort.equals(NetUtils.HTTP_PORT)
-            // && global option httpclose set (or maybe not in this spot???)
-                ) {
+        if (publicPort.equals(NetUtils.HTTP_PORT)) {
             sb = new StringBuilder();
             sb.append("\t").append("mode http");
             result.add(sb.toString());
@@ -99,7 +94,7 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
         }
         int i = 0;
         for (final PortForwardingRuleTO rule : fwRules) {
-            // add line like this: "server  65_37_141_30-80_3 10.1.1.4:80 check"
+            // Add line like this: "server  65_37_141_30-80_3 10.1.1.4:80 check"
             if (rule.revoked()) {
                 continue;
             }
@@ -124,9 +119,9 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
     public String[] generateConfiguration(final LoadBalancerConfigCommand lbCmd) {
         final List<String> result = new ArrayList<>();
         final List<String> gSection = Arrays.asList(globalSection);
-        //        note that this is overwritten on the String in the static ArrayList<String>
+        // Note that this is overwritten on the String in the static ArrayList<String>
         gSection.set(2, "\tmaxconn " + lbCmd.maxconn);
-        // TODO DH: write test for this function
+
         final String pipesLine = "\tmaxpipes " + Long.toString(Long.parseLong(lbCmd.maxconn) / 4);
         gSection.set(3, pipesLine);
         if (s_logger.isDebugEnabled()) {
@@ -135,9 +130,6 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
             }
         }
         result.addAll(gSection);
-        // TODO decide under what circumstances these options are needed
-        //        result.add("\tnokqueue");
-        //        result.add("\tnopoll");
 
         result.add(blankLine);
         final List<String> dSection = Arrays.asList(defaultsSection);
@@ -152,7 +144,7 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
         }
         result.addAll(dSection);
         if (!lbCmd.lbStatsVisibility.equals("disabled")) {
-            /* new rule : listen admin_page guestip/link-local:8081 */
+            // new rule : listen admin_page guestip/link-local:8081
             if (lbCmd.lbStatsVisibility.equals("global")) {
                 result.add(generateStatsRule(lbCmd, "stats_on_public", lbCmd.lbStatsPublicIP));
             } else if (lbCmd.lbStatsVisibility.equals("guest-network")) {
@@ -164,10 +156,7 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
                 result.add(generateStatsRule(lbCmd, "stats_on_guest", lbCmd.lbStatsGuestIP));
                 result.add(generateStatsRule(lbCmd, "stats_on_private", lbCmd.lbStatsPrivateIP));
             } else {
-                /*
-                 * stats will be available on the default http serving port, no
-                 * special stats port
-                 */
+                // Stats will be available on the default http serving port, no special stats port
                 final StringBuilder subRule =
                         new StringBuilder("\tstats enable\n\tstats uri     ").append(lbCmd.lbStatsUri)
                                                                              .append("\n\tstats realm   Haproxy\\ Statistics\n\tstats auth    ")
@@ -187,9 +176,7 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
         }
         result.add(blankLine);
         if (!has_listener) {
-            // haproxy cannot handle empty listen / frontend or backend, so add
-            // a dummy listener
-            // on port 9
+            // HAproxy cannot handle empty listen / frontend or backend, so add a dummy listener on port 9
             result.addAll(Arrays.asList(defaultListen));
         }
         return result.toArray(new String[result.size()]);
@@ -197,7 +184,6 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
 
     private String generateStatsRule(final LoadBalancerConfigCommand lbCmd, final String ruleName, final String statsIp) {
         final StringBuilder rule = new StringBuilder("\nlisten ").append(ruleName).append(" ").append(statsIp).append(":").append(lbCmd.lbStatsPort);
-        // TODO DH: write test for this in both cases
         if (!lbCmd.keepAliveEnabled) {
             s_logger.info("Haproxy mode http enabled");
             rule.append("\n\tmode http\n\toption httpclose");
@@ -222,12 +208,14 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
         final String algorithm = lbTO.getAlgorithm();
 
         final List<String> result = new ArrayList<>();
-        // add line like this: "listen  65_37_141_30-80 65.37.141.30:80"
+        // Add line like this: "listen  65_37_141_30-80 65.37.141.30:80"
         sb = new StringBuilder();
         sb.append("listen ").append(poolName).append(" ").append(publicIP).append(":").append(publicPort);
         result.add(sb.toString());
         sb = new StringBuilder();
         sb.append("\t").append("balance ").append(algorithm);
+        sb.append("\n\t").append("timeout client ").append(lbTO.getClientTimeout());
+        sb.append("\n\t").append("timeout server ").append(lbTO.getServerTimeout());
         result.add(sb.toString());
 
         int i = 0;
@@ -236,7 +224,7 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
         final List<String> dstSubRule = new ArrayList<>();
         final List<String> dstWithCookieSubRule = new ArrayList<>();
         for (final DestinationTO dest : lbTO.getDestinations()) {
-            // add line like this: "server  65_37_141_30-80_3 10.1.1.4:80 check"
+            // Add line like this: "server  65_37_141_30-80_3 10.1.1.4:80 check"
             if (dest.isRevoked()) {
                 continue;
             }
@@ -263,7 +251,7 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
         }
 
         Boolean httpbasedStickiness = false;
-        /* attach stickiness sub rule only if the destinations are available */
+        // Attach stickiness sub rule only if the destinations are available
         if (stickinessSubRule != null && destsAvailable == true) {
             for (final StickinessPolicyTO stickinessPolicy : lbTO.getStickinessPolicies()) {
                 if (stickinessPolicy == null) {
@@ -299,167 +287,6 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
         return result;
     }
 
-    /*
-    cookie <name> [ rewrite | insert | prefix ] [ indirect ] [ nocache ]
-                [ postonly ] [ domain <domain> ]*
-    Enable cookie-based persistence in a backend.
-    May be used in sections :   defaults | frontend | listen | backend
-                                   yes   |    no    |   yes  |   yes
-    Arguments :
-      <name>    is the name of the cookie which will be monitored, modified or
-                inserted in order to bring persistence. This cookie is sent to
-                the client via a "Set-Cookie" header in the response, and is
-                brought back by the client in a "Cookie" header in all requests.
-                Special care should be taken to choose a name which does not
-                conflict with any likely application cookie. Also, if the same
-                backends are subject to be used by the same clients (eg:
-                HTTP/HTTPS), care should be taken to use different cookie names
-                between all backends if persistence between them is not desired.
-
-      rewrite   This keyword indicates that the cookie will be provided by the
-                server and that haproxy will have to modify its value to set the
-                server's identifier in it. This mode is handy when the management
-                of complex combinations of "Set-cookie" and "Cache-control"
-                headers is left to the application. The application can then
-                decide whether or not it is appropriate to emit a persistence
-                cookie. Since all responses should be monitored, this mode only
-                works in HTTP close mode. Unless the application behaviour is
-                very complex and/or broken, it is advised not to start with this
-                mode for new deployments. This keyword is incompatible with
-                "insert" and "prefix".
-
-      insert    This keyword indicates that the persistence cookie will have to
-                be inserted by haproxy in the responses. If the server emits a
-                cookie with the same name, it will be replaced anyway. For this
-                reason, this mode can be used to upgrade existing configurations
-                running in the "rewrite" mode. The cookie will only be a session
-                cookie and will not be stored on the client's disk. Due to
-                caching effects, it is generally wise to add the "indirect" and
-                "nocache" or "postonly" keywords (see below). The "insert"
-                keyword is not compatible with "rewrite" and "prefix".
-
-      prefix    This keyword indicates that instead of relying on a dedicated
-                cookie for the persistence, an existing one will be completed.
-                This may be needed in some specific environments where the client
-                does not support more than one single cookie and the application
-                already needs it. In this case, whenever the server sets a cookie
-                named <name>, it will be prefixed with the server's identifier
-                and a delimiter. The prefix will be removed from all client
-                requests so that the server still finds the cookie it emitted.
-                Since all requests and responses are subject to being modified,
-                this mode requires the HTTP close mode. The "prefix" keyword is
-                not compatible with "rewrite" and "insert".
-
-      indirect  When this option is specified in insert mode, cookies will only
-                be added when the server was not reached after a direct access,
-                which means that only when a server is elected after applying a
-                load-balancing algorithm, or after a redispatch, then the cookie
-                will be inserted. If the client has all the required information
-                to connect to the same server next time, no further cookie will
-                be inserted. In all cases, when the "indirect" option is used in
-                insert mode, the cookie is always removed from the requests
-                transmitted to the server. The persistence mechanism then becomes
-                totally transparent from the application point of view.
-
-      nocache   This option is recommended in conjunction with the insert mode
-                when there is a cache between the client and HAProxy, as it
-                ensures that a cacheable response will be tagged non-cacheable if
-                a cookie needs to be inserted. This is important because if all
-                persistence cookies are added on a cacheable home page for
-                instance, then all customers will then fetch the page from an
-                outer cache and will all share the same persistence cookie,
-                leading to one server receiving much more traffic than others.
-                See also the "insert" and "postonly" options.
-
-      postonly  This option ensures that cookie insertion will only be performed
-                on responses to POST requests. It is an alternative to the
-                "nocache" option, because POST responses are not cacheable, so
-                this ensures that the persistence cookie will never get cached.
-                Since most sites do not need any sort of persistence before the
-                first POST which generally is a login request, this is a very
-                efficient method to optimize caching without risking to find a
-                persistence cookie in the cache.
-                See also the "insert" and "nocache" options.
-
-      domain    This option allows to specify the domain at which a cookie is
-                inserted. It requires exactly one parameter: a valid domain
-                name. If the domain begins with a dot, the browser is allowed to
-                use it for any host ending with that name. It is also possible to
-                specify several domain names by invoking this option multiple
-                times. Some browsers might have small limits on the number of
-                domains, so be careful when doing that. For the record, sending
-                10 domains to MSIE 6 or Firefox 2 works as expected.
-
-    There can be only one persistence cookie per HTTP backend, and it can be
-    declared in a defaults section. The value of the cookie will be the value
-    indicated after the "cookie" keyword in a "server" statement. If no cookie
-    is declared for a given server, the cookie is not set.
-
-    Examples :
-          cookie JSESSIONID prefix
-          cookie SRV insert indirect nocache
-          cookie SRV insert postonly indirect
-
-
-    appsession <cookie> len <length> timeout <holdtime>
-             [request-learn] [prefix] [mode <path-parameters|query-string>]
-    Define session stickiness on an existing application cookie.
-    May be used in sections :   defaults | frontend | listen | backend
-                                   no    |    no    |   yes  |   yes
-    Arguments :
-      <cookie>   this is the name of the cookie used by the application and which
-                 HAProxy will have to learn for each new session.
-
-      <length>   this is the max number of characters that will be memorized and
-                 checked in each cookie value.
-
-      <holdtime> this is the time after which the cookie will be removed from
-                 memory if unused. If no unit is specified, this time is in
-                 milliseconds.
-
-      request-learn
-                 If this option is specified, then haproxy will be able to learn
-                 the cookie found in the request in case the server does not
-                 specify any in response. This is typically what happens with
-                 PHPSESSID cookies, or when haproxy's session expires before
-                 the application's session and the correct server is selected.
-                 It is recommended to specify this option to improve reliability.
-
-      prefix     When this option is specified, haproxy will match on the cookie
-                 prefix (or URL parameter prefix). The appsession value is the
-                 data following this prefix.
-
-                 Example :
-                 appsession ASPSESSIONID len 64 timeout 3h prefix
-
-                 This will match the cookie ASPSESSIONIDXXXX=XXXXX,
-                 the appsession value will be XXXX=XXXXX.
-
-      mode       This option allows to change the URL parser mode.
-                 2 modes are currently supported :
-                 - path-parameters :
-                   The parser looks for the appsession in the path parameters
-                   part (each parameter is separated by a semi-colon), which is
-                   convenient for JSESSIONID for example.
-                   This is the default mode if the option is not set.
-                 - query-string :
-                   In this mode, the parser will look for the appsession in the
-                   query string.
-
-    When an application cookie is defined in a backend, HAProxy will check when
-    the server sets such a cookie, and will store its value in a table, and
-    associate it with the server's identifier. Up to <length> characters from
-    the value will be retained. On each connection, haproxy will look for this
-    cookie both in the "Cookie:" headers, and as a URL parameter (depending on
-    the mode used). If a known value is found, the client will be directed to the
-    server associated with this value. Otherwise, the load balancing algorithm is
-    applied. Cookies are automatically removed from memory when they have been
-    unused for a duration longer than <holdtime>.
-
-    The definition of an application cookie is limited to one per backend.
-    Example :
-          appsession JSESSIONID len 52 timeout 3h
-     */
     private String getLbSubRuleForStickiness(final LoadBalancerTO lbTO) {
         int i = 0;
 
@@ -476,11 +303,6 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
             final List<Pair<String, String>> paramsList = stickinessPolicy.getParams();
             i++;
 
-            /*
-             * cookie <name> [ rewrite | insert | prefix ] [ indirect ] [ nocache ]
-              [ postonly ] [ domain <domain> ]*
-
-             */
             if (StickinessMethodType.LBCookieBased.getName().equalsIgnoreCase(stickinessPolicy.getMethodName())) {
                 /* Default Values */
                 String cookieName = null; // optional
@@ -516,7 +338,8 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
                         postonly = true;
                     }
                 }
-                if (cookieName == null) {// re-check all haproxy mandatory params
+                if (cookieName == null) {
+                    // re-check all haproxy mandatory params
                     final StringBuilder tempSb = new StringBuilder();
                     String srcip = lbTO.getSrcIp();
                     if (srcip == null) {
@@ -539,11 +362,11 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
                     sb.append(domainSb).append(" ");
                 }
             } else if (StickinessMethodType.SourceBased.getName().equalsIgnoreCase(stickinessPolicy.getMethodName())) {
-                /* Default Values */
+                // Default Values
                 String tablesize = "200k"; // optional
                 String expire = "30m"; // optional
 
-                /* overwrite default values with the stick parameters */
+                // Overwrite default values with the stick parameters
                 for (final Pair<String, String> paramKV : paramsList) {
                     final String key = paramKV.first();
                     final String value = paramKV.second();
@@ -557,12 +380,7 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
                 sb.append("\t").append("stick-table type ip size ").append(tablesize).append(" expire ").append(expire);
                 sb.append("\n\t").append("stick on src");
             } else if (StickinessMethodType.AppCookieBased.getName().equalsIgnoreCase(stickinessPolicy.getMethodName())) {
-                /*
-                 * FORMAT : appsession <cookie> len <length> timeout <holdtime>
-                 * [request-learn] [prefix] [mode
-                 * <path-parameters|query-string>]
-                 */
-                /* example: appsession JSESSIONID len 52 timeout 3h */
+
                 String cookieName = null; // optional
                 String length = "52"; // optional
                 String holdtime = "3h"; // optional
@@ -592,7 +410,8 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
                         prefix = true;
                     }
                 }
-                if (cookieName == null) {// re-check all haproxy mandatory params
+                if (cookieName == null) {
+                    // Re-check all haproxy mandatory params
                     final StringBuilder tempSb = new StringBuilder();
                     String srcip = lbTO.getSrcIp();
                     if (srcip == null) {
@@ -612,11 +431,7 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
                     sb.append("mode ").append(mode).append(" ");
                 }
             } else {
-                /*
-                 * Error is silently swallowed.
-                 * Not supposed to reach here, validation of methods are
-                 * done at the higher layer
-                 */
+                // Error is silently swallowed. Not supposed to reach here, validation of methods are done at the higher layer
                 s_logger.warn("Haproxy stickiness policy for lb rule: " + lbTO.getSrcIp() + ":" + lbTO.getSrcPort() + ": Not Applied, cause:invalid method ");
                 return null;
             }
@@ -641,7 +456,7 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
             sb.append(lbTO.getSrcPort()).append(":");
             sb.append(lbTO.getProtocol()).append(":");
             for (final DestinationTO dest : lbTO.getDestinations()) {
-                // add dst entry like this: "10.1.1.4:80"
+                // Add dst entry like this: "10.1.1.4:80"
                 if (dest.isRevoked()) {
                     continue;
                 }

--- a/cosmic-core/nucleo/src/test/java/com/cloud/agent/resource/virtualnetwork/ConfigHelperTest.java
+++ b/cosmic-core/nucleo/src/test/java/com/cloud/agent/resource/virtualnetwork/ConfigHelperTest.java
@@ -81,7 +81,7 @@ public class ConfigHelperTest {
         final List<LbDestination> dests = new ArrayList<>();
         dests.add(new LbDestination(80, 8080, "10.1.10.2", false));
         dests.add(new LbDestination(80, 8080, "10.1.10.2", true));
-        lbs.add(new LoadBalancerTO(UUID.randomUUID().toString(), "64.10.1.10", 80, "tcp", "algo", false, false, false, dests));
+        lbs.add(new LoadBalancerTO(UUID.randomUUID().toString(), "64.10.1.10", 80, "tcp", "algo", false, false, false, dests, 60000, 60000));
 
         final LoadBalancerTO[] arrayLbs = new LoadBalancerTO[lbs.size()];
         lbs.toArray(arrayLbs);

--- a/cosmic-core/nucleo/src/test/java/com/cloud/agent/resource/virtualnetwork/VirtualRoutingResourceTest.java
+++ b/cosmic-core/nucleo/src/test/java/com/cloud/agent/resource/virtualnetwork/VirtualRoutingResourceTest.java
@@ -778,7 +778,7 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
         final List<LbDestination> dests = new ArrayList<>();
         dests.add(new LbDestination(80, 8080, "10.1.10.2", false));
         dests.add(new LbDestination(80, 8080, "10.1.10.2", true));
-        lbs.add(new LoadBalancerTO(UUID.randomUUID().toString(), "64.10.1.10", 80, "tcp", "algo", false, false, false, dests));
+        lbs.add(new LoadBalancerTO(UUID.randomUUID().toString(), "64.10.1.10", 80, "tcp", "algo", false, false, false, dests, 60000, 60000));
         final LoadBalancerTO[] arrayLbs = new LoadBalancerTO[lbs.size()];
         lbs.toArray(arrayLbs);
         final NicTO nic = new NicTO();
@@ -793,7 +793,7 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
         final List<LbDestination> dests = new ArrayList<>();
         dests.add(new LbDestination(80, 8080, "10.1.10.2", false));
         dests.add(new LbDestination(80, 8080, "10.1.10.2", true));
-        lbs.add(new LoadBalancerTO(UUID.randomUUID().toString(), "64.10.1.10", 80, "tcp", "algo", false, false, false, dests));
+        lbs.add(new LoadBalancerTO(UUID.randomUUID().toString(), "64.10.1.10", 80, "tcp", "algo", false, false, false, dests, 60000, 60000));
         final LoadBalancerTO[] arrayLbs = new LoadBalancerTO[lbs.size()];
         lbs.toArray(arrayLbs);
         final NicTO nic = new NicTO();

--- a/cosmic-core/nucleo/src/test/java/com/cloud/network/HAProxyConfiguratorTest.java
+++ b/cosmic-core/nucleo/src/test/java/com/cloud/network/HAProxyConfiguratorTest.java
@@ -15,9 +15,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-/**
- * @author dhoogland
- */
 public class HAProxyConfiguratorTest {
 
     /**
@@ -53,7 +50,7 @@ public class HAProxyConfiguratorTest {
      */
     @Test
     public void testGenerateConfigurationLoadBalancerConfigCommand() {
-        final LoadBalancerTO lb = new LoadBalancerTO("1", "10.2.0.1", 80, "http", "bla", false, false, false, null);
+        final LoadBalancerTO lb = new LoadBalancerTO("1", "10.2.0.1", 80, "http", "bla", false, false, false, null, 60000, 60000);
         final LoadBalancerTO[] lba = new LoadBalancerTO[1];
         lba[0] = lb;
         final HAProxyConfigurator hpg = new HAProxyConfigurator();
@@ -88,7 +85,7 @@ public class HAProxyConfiguratorTest {
         final List<LbDestination> dests = new ArrayList<>();
         dests.add(new LbDestination(443, 8443, "10.1.10.2", false));
         dests.add(new LbDestination(443, 8443, "10.1.10.2", true));
-        final LoadBalancerTO lb = new LoadBalancerTO("1", "10.2.0.1", 443, "tcp", "http", false, false, false, dests);
+        final LoadBalancerTO lb = new LoadBalancerTO("1", "10.2.0.1", 443, "tcp", "http", false, false, false, dests, 60000, 60000);
         lb.setLbProtocol("tcp-proxy");
         final LoadBalancerTO[] lba = new LoadBalancerTO[1];
         lba[0] = lb;

--- a/cosmic-core/plugins/network/internal-loadbalancer/src/main/java/com/cloud/network/lb/InternalLoadBalancerVMManagerImpl.java
+++ b/cosmic-core/plugins/network/internal-loadbalancer/src/main/java/com/cloud/network/lb/InternalLoadBalancerVMManagerImpl.java
@@ -67,6 +67,7 @@ import com.cloud.user.AccountManager;
 import com.cloud.user.User;
 import com.cloud.user.UserVO;
 import com.cloud.user.dao.UserDao;
+import com.cloud.utils.NumbersUtil;
 import com.cloud.utils.Pair;
 import com.cloud.utils.component.ManagerBase;
 import com.cloud.utils.db.DB;
@@ -421,7 +422,13 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
             final int srcPort = rule.getSourcePortStart();
             final List<LbDestination> destinations = rule.getDestinations();
             final List<LbStickinessPolicy> stickinessPolicies = rule.getStickinessPolicies();
-            final LoadBalancerTO lb = new LoadBalancerTO(uuid, srcIp, srcPort, protocol, algorithm, revoked, false, inline, destinations, stickinessPolicies);
+
+            // Load default values and fallback to hardcoded if not available
+            final Integer defaultClientTimeout = NumbersUtil.parseInt(_configDao.getValue(Config.DefaultLoadBalancerClientTimeout.key()), 60000);
+            final Integer defaultServerTimeout = NumbersUtil.parseInt(_configDao.getValue(Config.DefaultLoadBalancerServerTimeout.key()), 60000);
+
+            final LoadBalancerTO lb = new LoadBalancerTO(uuid, srcIp, srcPort, protocol, algorithm, revoked, false, inline, destinations, stickinessPolicies,
+                    defaultClientTimeout, defaultServerTimeout);
             lbs[i++] = lb;
         }
 

--- a/cosmic-core/plugins/network/internal-loadbalancer/src/test/java/com/cloud/internallbelement/InternalLbElementTest.java
+++ b/cosmic-core/plugins/network/internal-loadbalancer/src/test/java/com/cloud/internallbelement/InternalLbElementTest.java
@@ -193,7 +193,8 @@ public class InternalLbElementTest {
     //TEST FOR validateLBRule METHOD
     @Test
     public void verifyValidateLBRule() throws ResourceUnavailableException {
-        final ApplicationLoadBalancerRuleVO lb = new ApplicationLoadBalancerRuleVO(null, null, 22, 22, "roundrobin", 1L, 1L, 1L, new Ip("10.10.10.1"), 1L, Scheme.Internal);
+        final ApplicationLoadBalancerRuleVO lb =
+                new ApplicationLoadBalancerRuleVO(null, null, 22, 22, "roundrobin", 1L, 1L, 1L, new Ip("10.10.10.1"), 1L, Scheme.Internal, 5000, 5000);
         lb.setState(FirewallRule.State.Add);
 
         final LoadBalancingRule rule = new LoadBalancingRule(lb, null, null, null, new Ip("10.10.10.1"));

--- a/cosmic-core/plugins/network/internal-loadbalancer/src/test/java/com/cloud/internallbvmmgr/InternalLBVMManagerTest.java
+++ b/cosmic-core/plugins/network/internal-loadbalancer/src/test/java/com/cloud/internallbvmmgr/InternalLBVMManagerTest.java
@@ -325,7 +325,8 @@ public class InternalLBVMManagerTest extends TestCase {
         vms.add(vm);
 
         final List<LoadBalancingRule> rules = new ArrayList<>();
-        final ApplicationLoadBalancerRuleVO lb = new ApplicationLoadBalancerRuleVO(null, null, 22, 22, "roundrobin", 1L, 1L, 1L, new Ip(requestedIp), 1L, Scheme.Internal);
+        final ApplicationLoadBalancerRuleVO lb =
+                new ApplicationLoadBalancerRuleVO(null, null, 22, 22, "roundrobin", 1L, 1L, 1L, new Ip(requestedIp), 1L, Scheme.Internal, 60000, 60000);
         lb.setState(FirewallRule.State.Add);
 
         final LoadBalancingRule rule = new LoadBalancingRule(lb, null, null, null, new Ip(requestedIp));

--- a/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -968,6 +968,9 @@ public class ApiResponseHelper implements ResponseGenerator {
         lbResponse.setAlgorithm(loadBalancer.getAlgorithm());
         lbResponse.setLbProtocol(loadBalancer.getLbProtocol());
         lbResponse.setForDisplay(loadBalancer.isDisplay());
+        lbResponse.setClientTimeout(loadBalancer.getClientTimeout());
+        lbResponse.setServerTimeout(loadBalancer.getServerTimeout());
+
         final FirewallRule.State state = loadBalancer.getState();
         String stateToSet = state.toString();
         if (state.equals(FirewallRule.State.Revoke)) {

--- a/cosmic-core/server/src/main/java/com/cloud/configuration/Config.java
+++ b/cosmic-core/server/src/main/java/com/cloud/configuration/Config.java
@@ -258,6 +258,22 @@ public enum Config {
             "4096",
             "Load Balancer(haproxy) maximum number of concurrent connections(global max)",
             null),
+    DefaultLoadBalancerServerTimeout(
+            "Network",
+            ManagementServer.class,
+            Integer.class,
+            "network.loadbalancer.haproxy.default.timeout.server",
+            "60000",
+            "Load Balancer(haproxy) default server timeout setting (in ms)",
+            null),
+    DefaultLoadBalancerClientTimeout(
+            "Network",
+            ManagementServer.class,
+            Integer.class,
+            "network.loadbalancer.haproxy.default.timeout.client",
+            "60000",
+            "Load Balancer(haproxy) default client timeout setting (in ms)",
+            null),
     NetworkRouterRpFilter(
             "Network",
             ManagementServer.class,

--- a/cosmic-core/server/src/main/java/com/cloud/network/ExternalLoadBalancerDeviceManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/ExternalLoadBalancerDeviceManagerImpl.java
@@ -943,9 +943,14 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
 
             if ((destinations != null && !destinations.isEmpty()) || rule.isAutoScaleConfig()) {
                 final boolean inline = _networkMgr.isNetworkInlineMode(network);
+
+                // Load default values and fallback to hardcoded if not available
+                final Integer defaultClientTimeout = NumbersUtil.parseInt(_configDao.getValue(Config.DefaultLoadBalancerClientTimeout.key()), 60000);
+                final Integer defaultServerTimeout = NumbersUtil.parseInt(_configDao.getValue(Config.DefaultLoadBalancerServerTimeout.key()), 60000);
+
                 final LoadBalancerTO loadBalancer =
                         new LoadBalancerTO(uuid, srcIp, srcPort, protocol, algorithm, revoked, false, inline, destinations, rule.getStickinessPolicies(),
-                                rule.getHealthCheckPolicies(), rule.getLbSslCert(), rule.getLbProtocol());
+                                rule.getHealthCheckPolicies(), rule.getLbSslCert(), rule.getLbProtocol(), defaultClientTimeout, defaultServerTimeout);
                 if (rule.isAutoScaleConfig()) {
                     loadBalancer.setAutoScaleVmGroup(rule.getAutoScaleVmGroup());
                 }
@@ -1162,9 +1167,14 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
 
             if ((destinations != null && !destinations.isEmpty()) || !rule.isAutoScaleConfig()) {
                 final boolean inline = _networkMgr.isNetworkInlineMode(network);
+
+                // Load default values and fallback to hardcoded if not available
+                final Integer defaultClientTimeout = NumbersUtil.parseInt(_configDao.getValue(Config.DefaultLoadBalancerClientTimeout.key()), 60000);
+                final Integer defaultServerTimeout = NumbersUtil.parseInt(_configDao.getValue(Config.DefaultLoadBalancerServerTimeout.key()), 60000);
+
                 final LoadBalancerTO loadBalancer =
                         new LoadBalancerTO(uuid, srcIp, srcPort, protocol, algorithm, revoked, false, inline, destinations, rule.getStickinessPolicies(),
-                                rule.getHealthCheckPolicies(), rule.getLbSslCert(), rule.getLbProtocol());
+                                rule.getHealthCheckPolicies(), rule.getLbSslCert(), rule.getLbProtocol(), defaultClientTimeout, defaultServerTimeout);
                 loadBalancersToApply.add(loadBalancer);
             }
         }

--- a/cosmic-core/server/src/main/java/com/cloud/network/lb/ApplicationLoadBalancerManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/lb/ApplicationLoadBalancerManagerImpl.java
@@ -78,12 +78,10 @@ public class ApplicationLoadBalancerManagerImpl extends ManagerBase implements A
 
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_LOAD_BALANCER_CREATE, eventDescription = "creating load balancer")
-    public ApplicationLoadBalancerRule createApplicationLoadBalancer(final String name, final String description, final Scheme scheme, final long sourceIpNetworkId, final String
-            sourceIp,
-                                                                     final int sourcePort, final int instancePort, final String algorithm, final long networkId, final long
-                                                                             lbOwnerId, final Boolean forDisplay)
-            throws InsufficientAddressCapacityException, NetworkRuleConflictException,
-            InsufficientVirtualNetworkCapacityException {
+    public ApplicationLoadBalancerRule createApplicationLoadBalancer(final String name, final String description, final Scheme scheme, final long sourceIpNetworkId,
+                                                                     final String sourceIp, final int sourcePort, final int instancePort, final String algorithm,
+                                                                     final long networkId, final long lbOwnerId, final Boolean forDisplay)
+            throws InsufficientAddressCapacityException, NetworkRuleConflictException, InsufficientVirtualNetworkCapacityException {
 
         //Validate LB rule guest network
         final Network guestNtwk = _networkModel.getNetwork(networkId);
@@ -107,12 +105,10 @@ public class ApplicationLoadBalancerManagerImpl extends ManagerBase implements A
         return createApplicationLoadBalancer(name, description, scheme, sourceIpNtwk, sourceIp, sourcePort, instancePort, algorithm, lbOwner, guestNtwk, forDisplay);
     }
 
-    protected ApplicationLoadBalancerRule createApplicationLoadBalancer(final String name, final String description, final Scheme scheme, final Network sourceIpNtwk, final
-    String sourceIp,
-                                                                        final int sourcePort, final int instancePort, final String algorithm, final Account lbOwner, final
-                                                                        Network guestNtwk, final Boolean
-                                                                                forDisplay) throws NetworkRuleConflictException,
-            InsufficientVirtualNetworkCapacityException {
+    protected ApplicationLoadBalancerRule createApplicationLoadBalancer(final String name, final String description, final Scheme scheme, final Network sourceIpNtwk,
+                                                                        final String sourceIp, final int sourcePort, final int instancePort, final String algorithm,
+                                                                        final Account lbOwner, final Network guestNtwk, final Boolean forDisplay)
+            throws NetworkRuleConflictException, InsufficientVirtualNetworkCapacityException {
 
         //Only Internal scheme is supported in this release
         if (scheme != Scheme.Internal) {
@@ -130,7 +126,7 @@ public class ApplicationLoadBalancerManagerImpl extends ManagerBase implements A
 
         final ApplicationLoadBalancerRuleVO newRule =
                 new ApplicationLoadBalancerRuleVO(name, description, sourcePort, instancePort, algorithm, guestNtwk.getId(), lbOwner.getId(), lbOwner.getDomainId(),
-                        sourceIpAddr, sourceIpNtwk.getId(), scheme);
+                        sourceIpAddr, sourceIpNtwk.getId(), scheme, 600000, 600000);
 
         if (forDisplay != null) {
             newRule.setDisplay(forDisplay);

--- a/cosmic-core/server/src/test/java/com/cloud/network/lb/ApplicationLoadBalancerTest.java
+++ b/cosmic-core/server/src/test/java/com/cloud/network/lb/ApplicationLoadBalancerTest.java
@@ -119,7 +119,7 @@ public class ApplicationLoadBalancerTest extends TestCase {
 
         final ApplicationLoadBalancerRuleVO lbRule =
                 new ApplicationLoadBalancerRuleVO("new", "new", 22, 22, "roundrobin", validGuestNetworkId, validAccountId, 1L, new Ip(validRequestedIp), validGuestNetworkId,
-                        Scheme.Internal);
+                        Scheme.Internal, 60000, 60000);
         Mockito.when(_lbDao.persist(Matchers.any(ApplicationLoadBalancerRuleVO.class))).thenReturn(lbRule);
 
         Mockito.when(_lbMgr.validateLbRule(Matchers.any(LoadBalancingRule.class))).thenReturn(true);

--- a/cosmic-core/server/src/test/java/com/cloud/network/lb/AssignLoadBalancerTest.java
+++ b/cosmic-core/server/src/test/java/com/cloud/network/lb/AssignLoadBalancerTest.java
@@ -167,7 +167,7 @@ public class AssignLoadBalancerTest {
         final List<Long> vmIds = new ArrayList<>();
         vmIds.add(2L);
 
-        final LoadBalancerVO lbVO = new LoadBalancerVO("1", "L1", "Lbrule", 1, 22, 22, "rb", 204, 0, 0, "tcp");
+        final LoadBalancerVO lbVO = new LoadBalancerVO("1", "L1", "Lbrule", 1, 22, 22, "rb", 204, 0, 0, "tcp", 60000, 60000);
 
         final LoadBalancerDao lbDao = Mockito.mock(LoadBalancerDao.class);
         final LoadBalancerVMMapDao lb2VmMapDao = Mockito.mock(LoadBalancerVMMapDao.class);
@@ -203,7 +203,7 @@ public class AssignLoadBalancerTest {
         final List<Long> vmIds = new ArrayList<>();
         vmIds.add(2L);
 
-        final LoadBalancerVO lbVO = new LoadBalancerVO("1", "L1", "Lbrule", 1, 22, 22, "rb", 204, 0, 0, "tcp");
+        final LoadBalancerVO lbVO = new LoadBalancerVO("1", "L1", "Lbrule", 1, 22, 22, "rb", 204, 0, 0, "tcp", 60000, 60000);
 
         final LoadBalancerDao lbDao = Mockito.mock(LoadBalancerDao.class);
         final LoadBalancerVMMapDao lb2VmMapDao = Mockito.mock(LoadBalancerVMMapDao.class);

--- a/cosmic-core/server/src/test/java/com/cloud/network/lb/UpdateLoadBalancerTest.java
+++ b/cosmic-core/server/src/test/java/com/cloud/network/lb/UpdateLoadBalancerTest.java
@@ -74,7 +74,7 @@ public class UpdateLoadBalancerTest {
     @Test
     public void testValidateRuleBeforeUpdateLB() throws ResourceAllocationException, ResourceUnavailableException, InsufficientCapacityException {
 
-        final LoadBalancerVO lb = new LoadBalancerVO(null, null, null, 0L, 0, 0, null, 0L, 0L, domainId, null);
+        final LoadBalancerVO lb = new LoadBalancerVO(null, null, null, 0L, 0, 0, null, 0L, 0L, domainId, null, 60000, 60000);
 
         when(lbDao.findById(anyLong())).thenReturn(lb);
         when(netModel.getPublicIpAddress(anyLong())).thenReturn(Mockito.mock(PublicIpAddress.class));
@@ -92,7 +92,7 @@ public class UpdateLoadBalancerTest {
     @Test(expected = InvalidParameterValueException.class)
     public void testRuleNotValidated() throws ResourceAllocationException, ResourceUnavailableException, InsufficientCapacityException {
 
-        final LoadBalancerVO lb = new LoadBalancerVO(null, null, null, 0L, 0, 0, null, 0L, 0L, domainId, null);
+        final LoadBalancerVO lb = new LoadBalancerVO(null, null, null, 0L, 0, 0, null, 0L, 0L, domainId, null, 60000, 60000);
 
         when(lbDao.findById(anyLong())).thenReturn(lb);
         when(netModel.getPublicIpAddress(anyLong())).thenReturn(Mockito.mock(PublicIpAddress.class));


### PR DESCRIPTION
Allows to specify timeouts on create LB command with new `clienttimeout` and `servertimeout` parameters:

```
create loadbalancerrule publicport=84 privateport=84 algorithm=source name=remi publicipid=1d463871-e5d2-4bb3-8ba6-120a03688805 networkid=461b181c-a1bb-4c3f-b337-cfd1e5568c4f clienttimeout=12345 servertimeout=12345          
```

On router in `haproxy.cfg` you can see a default (from global settings) and a custom timeout secified via api:
```
listen 192_168_23_8-83 192.168.23.8:83
        balance source
        timeout client 60000
        timeout server 60000
        server 192_168_23_8-83_0 10.1.1.59:83 check

listen 192_168_23_8-84 192.168.23.8:84
        balance source
        timeout client 12345
        timeout server 12345
        server 192_168_23_8-84_0 10.1.1.59:84 check
```

You can also edit an existing rule like this:

```
update loadbalancerrule id=08291553-210a-43ac-8c7f-66f5c0a2950e servertimeout=1234567 clienttimeout=112233
```

Result:

```         
listen 192_168_23_4-22 192.168.23.4:22
        balance roundrobin
        timeout client 112233
        timeout server 1234567
        server 192_168_23_4-22_0 10.5.1.62:22 check
```

When no `clienttimeout` or `servertimeout` is specified, it's taken from the global settings `network.loadbalancer.haproxy.default.timeout.client` and `network.loadbalancer.haproxy.default.timeout.server`. If they are not present, a value of `60000` is used.
