### PR TITLE
Add Safe guards as the DB values are BIGINT unsigned so cannot be below zero

### DIFF
--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStoragePool.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStoragePool.java
@@ -130,7 +130,11 @@ public class LibvirtStoragePool implements KvmStoragePool {
         return capacity;
     }
 
-    public void setCapacity(final long capacity) {
+    public void setCapacity(long capacity) {
+        // Safe guard as the DB values are BIGINT unsigned so cannot be below zero
+        if (capacity < 0) {
+            capacity = 0;
+        }
         this.capacity = capacity;
     }
 
@@ -139,7 +143,11 @@ public class LibvirtStoragePool implements KvmStoragePool {
         return used;
     }
 
-    public void setUsed(final long used) {
+    public void setUsed(long used) {
+        // Safe guard as the DB values are BIGINT unsigned so cannot be below zero
+        if (used < 0) {
+            used = 0;
+        }
         this.used = used;
     }
 
@@ -148,7 +156,11 @@ public class LibvirtStoragePool implements KvmStoragePool {
         return available;
     }
 
-    public void setAvailable(final long available) {
+    public void setAvailable(long available) {
+        // Safe guard as the DB values are BIGINT unsigned so cannot be below zero
+        if (available < 0) {
+            available = 0;
+        }
         this.available = available;
     }
 


### PR DESCRIPTION
Noticed this on an agent that would not connect:

```
Succesfully refreshed pool d7515f0b-9baa-3ede-ac36-35196ae14b30 Capacity: 10995116277760 Used: -148226048 Available: 10995264503808
```

Note that `used` is somehow below zero. Not sure how that happened?

As a result, agent was unable to connect due to DB failure. An unsigned BIGINT cannot below zero:

```
2017-02-10 20:09:21.787 INFO  [c.c.u.e.CSExceptionErrorCode] (logid: a8a97887) (ctx: 32ea6068) Could not find exception: com.cloud.exception.ConnectionException in error code list for exceptions
2017-02-10 20:09:21.787 WARN  [c.c.a.m.AgentManagerImpl] (logid: a8a97887) (ctx: 32ea6068) Monitor StoragePoolMonitor says there is an error in the connect process for 491 due to Unable to connect host 491 to storage pool id 101 due to 
com.cloud.utils.exception.CloudRuntimeException: DB Exception on: sql : 'UPDATE storage_pool SET storage_pool.capacity_bytes=?, storage_pool.used_bytes=? WHERE storage_pool.id = ? ', parameters : [10995116277760,-148226048,101]
```

I "fixed" the agent by manually refreshing the libvirt pool a few times, after which it returned the correct value. 

This PR makes sure that negative values are set to zero so the DB will accept them and so the agents connect. Still weird it can go below zero in the first place.