### PR TITLE
Restrict snapshots in UI for KVM to only allow manual volums snapshots

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/instances.js
+++ b/cosmic-client/src/main/webapp/scripts/instances.js
@@ -389,29 +389,29 @@
                             });
                             args.response.error();
                         }
-                    })).done(function(jsonvm, jsonvmp) {
-                        var items = jsonvm[0].listvirtualmachinesresponse.virtualmachine;
-                        if (args.context.projects == null && isAdmin()) {
-                            var pitems = jsonvmp[0].listvirtualmachinesresponse.virtualmachine;
-                            if (pitems) {
-                                if (items) {
-                                    items.push(pitems[0]);
-                                } else {
-                                    items = pitems;
-                                }
+                    })).done(function (jsonvm, jsonvmp) {
+                    var items = jsonvm[0].listvirtualmachinesresponse.virtualmachine;
+                    if (args.context.projects == null && isAdmin()) {
+                        var pitems = jsonvmp[0].listvirtualmachinesresponse.virtualmachine;
+                        if (pitems) {
+                            if (items) {
+                                items.push(pitems[0]);
+                            } else {
+                                items = pitems;
                             }
                         }
-                        if (items) {
-                            $.each(items, function (idx, vm) {
-                                if (vm.nic && vm.nic.length > 0 && vm.nic[0].ipaddress) {
-                                    items[idx].ipaddress = vm.nic[0].ipaddress;
-                                }
-                            });
-                        }
-                        args.response.success({
-                            data: items
+                    }
+                    if (items) {
+                        $.each(items, function (idx, vm) {
+                            if (vm.nic && vm.nic.length > 0 && vm.nic[0].ipaddress) {
+                                items[idx].ipaddress = vm.nic[0].ipaddress;
+                            }
                         });
+                    }
+                    args.response.success({
+                        data: items
                     });
+                });
             },
 
             detailView: {
@@ -419,9 +419,6 @@
                 viewAll: [{
                     path: 'storage.volumes',
                     label: 'label.volumes'
-                }, {
-                    path: 'vmsnapshots',
-                    label: 'label.snapshots'
                 }, {
                     path: 'affinityGroups',
                     label: 'label.affinity.groups'
@@ -2519,7 +2516,7 @@
                             broadcasturi: {
                                 label: 'label.broadcast.uri'
                             },
-                            isolationuri : {
+                            isolationuri: {
                                 label: 'label.isolation.uri'
                             },
                             ip6address: {

--- a/cosmic-client/src/main/webapp/scripts/storage.js
+++ b/cosmic-client/src/main/webapp/scripts/storage.js
@@ -2335,11 +2335,9 @@
                 if (jsonObj.vmstate == 'Running') {
                     if (g_kvmsnapshotenabled == true) { //"kvm.snapshot.enabled" flag should be taken to account only when snapshot is being created for Running vm (CLOUDSTACK-4428)
                         allowedActions.push("takeSnapshot");
-                        allowedActions.push("recurringSnapshot");
                     }
                 } else {
                     allowedActions.push("takeSnapshot");
-                    allowedActions.push("recurringSnapshot");
                 }
             } else {
                 allowedActions.push("takeSnapshot");


### PR DESCRIPTION
VM snapshotting buttom removed:
![image](https://cloud.githubusercontent.com/assets/1630096/22929555/a1239658-f2bc-11e6-945a-c3698b18e0ec.png)

Used to be there (text link):
![image](https://cloud.githubusercontent.com/assets/1630096/22929540/8add1176-f2bc-11e6-9b85-05f54a4e8c8c.png)

New volume view:
![image](https://cloud.githubusercontent.com/assets/1630096/22929473/382183cc-f2bc-11e6-81b1-d2d92633eb41.png)

The recurring button is gone for KVM. Used to be there:
![image](https://cloud.githubusercontent.com/assets/1630096/22929499/5a73bff8-f2bc-11e6-99d0-73c88d1a56c6.png)
