### PR TITLE
Fix typo in logging resulting in trace in exception handling

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
@@ -240,6 +240,6 @@ def copy(src, dest):
     try:
         shutil.copy2(src, dest)
     except IOError:
-        logging.Error("Could not copy %s to %s" % (src, dest))
+        logging.error("Could not copy %s to %s" % (src, dest))
     else:
         logging.info("Copied %s to %s" % (src, dest))


### PR DESCRIPTION
When a file is not found, the exception is handled. However, since `logging.Error` doesn't exist (should be `logging.error` we end up with a stack trace and non-zero exit status. This fails the request from the mgt server and then requires manual intervention. This PR solves that.

Error seen:

```
[INFO] Processing JSON file vm_dhcp_entry.json.c4f542f4-1253-401d-9f59-e72a0ac972f5
Traceback (most recent call last):
  File "/opt/cloud/bin/update_config.py", line 141, in <module>
    process_file()
  File "/opt/cloud/bin/update_config.py", line 49, in process_file
    finish_config()
  File "/opt/cloud/bin/update_config.py", line 32, in finish_config
    returncode = configure.main(sys.argv)
  File "/opt/cloud/bin/configure.py", line 918, in main
    config.address().process()
  File "/opt/cloud/bin/cs/CsAddress.py", line 103, in process
    ip.post_configure(address)
  File "/opt/cloud/bin/cs/CsAddress.py", line 286, in post_configure
    self.post_config_change("add")
  File "/opt/cloud/bin/cs/CsAddress.py", line 522, in post_config_change
    app.setup()
  File "/opt/cloud/bin/cs/CsApp.py", line 29, in setup
    "/etc/apache2/conf.d/vhost%s.conf" % self.dev)
  File "/opt/cloud/bin/cs/CsHelper.py", line 233, in copy_if_needed
    copy(src, dest)
  File "/opt/cloud/bin/cs/CsHelper.py", line 243, in copy
    logging.Error("Could not copy %s to %s" % (src, dest))
AttributeError: 'module' object has no attribute 'Error'
```