### PR TITLE
Cleanup legacy Apache config files

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsFile.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsFile.py
@@ -131,12 +131,12 @@ class CsFile:
 
         return found
 
-    def deleteLine(self, search):
+    def deleteLine(self, search, remove_hashes=True):
         found = False
         logging.debug("Searching for %s to remove the line " % search)
         temp_config = []
         for index, line in enumerate(self.new_config):
-            if line.lstrip().startswith("#"):
+            if line.lstrip().startswith("#") and remove_hashes:
                 continue
             if search not in line:
                 temp_config.append(line)


### PR DESCRIPTION
This is also done in cloud-early-config, but we need the Python scripts to handle it too in case a router gets updated without reboot.