### PR TITLE
Check gateway with CIDR when creating a network tier

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -825,6 +825,10 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
             if (cidr != null && !NetUtils.isValidCIDR(cidr)) {
                 throw new InvalidParameterValueException("Invalid format for the CIDR parameter");
             }
+            // validate gateway with cidr
+            if (cidr != null && gateway != null && !NetUtils.isIpWithtInCidrRange(gateway, cidr)) {
+                throw new InvalidParameterValueException("The gateway ip " + gateway + " should be part of the CIDR of the network " + cidr);
+            }
             // if end ip is not specified, default it to startIp
             if (startIP != null) {
                 if (!NetUtils.isValidIp(startIP)) {


### PR DESCRIPTION
A gateway was allowed outside of the CIDR, which results in trouble so we should prevent it.

![screen shot 2017-02-16 at 14 14 28](https://cloud.githubusercontent.com/assets/1630096/23022710/8f19808e-f452-11e6-9833-92bdfe252129.png)

![screen shot 2017-02-16 at 14 14 39](https://cloud.githubusercontent.com/assets/1630096/23022716/93dbcfd2-f452-11e6-8698-d5fe577e3a5f.png)
