### PR TITLE
IpAssociation: send traffic type lower case

### DIFF
--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/IpAssociationConfigItem.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/IpAssociationConfigItem.java
@@ -22,7 +22,7 @@ public class IpAssociationConfigItem extends AbstractConfigItemFacade {
 
         for (final IpAddressTO ip : command.getIpAddresses()) {
             final IpAddress ipAddress = new IpAddress(ip.getPublicIp(), ip.isSourceNat(), ip.isAdd(), ip.isOneToOneNat(), ip.isFirstIP(), ip.getVlanGateway(), ip.getVlanNetmask(),
-                    ip.getVifMacAddress(), ip.getNicDevId(), ip.isNewNic(), ip.getTrafficType().toString());
+                    ip.getVifMacAddress(), ip.getNicDevId(), ip.isNewNic(), ip.getTrafficType().toString().toLowerCase());
             ips.add(ipAddress);
         }
 


### PR DESCRIPTION
This is fixing the problem on the Java side. Previous we added a safe-guard on the Python side as well. See #235 

Backport of ACS PR 1943