### PR TITLE
Make remote access vpn iptables rules work

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -671,7 +671,6 @@ class CsRemoteAccessVpn(CsDataBag):
 
         self.fw.append(["", "", "-A INPUT -i ppp+ -m udp -p udp --dport 53 -j ACCEPT"])
         self.fw.append(["", "", "-A INPUT -i ppp+ -m tcp -p tcp --dport 53 -j ACCEPT"])
-        self.fw.append(["nat", "", "-I PREROUTING -i ppp+ -m tcp --dport 53 -j DNAT --to-destination %s" % local_ip])
 
         if self.config.is_vpc():
             return


### PR DESCRIPTION
The DNAT rule was invalid due to ppp+ not yet being available. This produced an error when restoring iptables rules. Effectively one could not change iptables rules any more.