### PR TITLE
Detect private gateways on the GuestType instead of hacking around

### DIFF
--- a/cosmic-core/engine/schema/src/main/java/com/cloud/vm/dao/DomainRouterDaoImpl.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/vm/dao/DomainRouterDaoImpl.java
@@ -357,7 +357,7 @@ public class DomainRouterDaoImpl extends GenericDaoBase<DomainRouterVO, Long> im
     public void addRouterToGuestNetwork(final VirtualRouter router, final Network guestNetwork) {
         if (_routerNetworkDao.findByRouterAndNetwork(router.getId(), guestNetwork.getId()) == null) {
             final NetworkOffering off = _offDao.findById(guestNetwork.getNetworkOfferingId());
-            if (!off.getName().equalsIgnoreCase(NetworkOffering.DefaultPrivateGatewayNetworkOffering)) {
+            if (!off.getGuestType().equals(Network.GuestType.Private)) {
                 final TransactionLegacy txn = TransactionLegacy.currentTxn();
                 txn.start();
                 //1) add router to network

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -1751,10 +1751,12 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
     @Override
     public boolean isPrivateGateway(final long ntwkId) {
         final Network network = getNetwork(ntwkId);
-        if (network.getTrafficType() != TrafficType.Guest || network.getNetworkOfferingId() != s_privateOfferingId.longValue()) {
-            return false;
+        if (network.getGuestType() != null && network.getGuestType().equals(Network.GuestType.Private)) {
+            s_logger.debug("Network " + network.getName() + " is a private gateway network.");
+            return true;
         }
-        return true;
+        s_logger.debug("Network " + network.getName() + " is NOT a private gateway network.");
+        return false;
     }
 
     @Override


### PR DESCRIPTION
It was noticed that `private gateways` created before release `5.3` were not detecting their `private gateway` interfaces properly. Newly created routers also had issues, when they were connected to `private networks` created before `5.3`. Since `private gateways` were now sent as `Guest` networks, things started to become a mess. Especially on redundant VPCs, as those ended up with a broken `keepalived` config. The problem was also seen on non-Redundant VPCs, although impact was limited.

Eventually it became clear that this issue was caused by the network offering that was used for the `private network`. The code had hardcoded offerings on several places that made it work only with this hardcoded offering, not with any custom created one.

This PR replaces those hardcoded offerings and leverages the `GuestType` of `Private` to detect the `private gateways`. After this, stop/start and restart+cleanup work fine again.