### PR TITLE
UI: Swap Gateway and CIDR fields to be more backwards compatible

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/vpc.js
+++ b/cosmic-client/src/main/webapp/scripts/vpc.js
@@ -3774,15 +3774,15 @@
                                 },
                                 isHidden: true
                             },
-                            cidr: {
-                                label: 'label.cidr',
+                            gateway: {
+                                label: 'label.gateway',
                                 docID: 'helpTierGateway',
                                 validation: {
                                     required: true
                                 }
                             },
-                            gateway: {
-                                label: 'label.gateway',
+                            cidr: {
+                                label: 'label.cidr',
                                 docID: 'helpTierGateway',
                                 validation: {
                                     required: true


### PR DESCRIPTION
While creating a bunch of tiers I realised the order is not logical. Could be because `gateway` used to be first but it does makes sense to first specify the `cidr`, then pick a `gateway` inside it.

Changed it to look like this:
![screen shot 2017-02-19 at 21 10 22](https://cloud.githubusercontent.com/assets/1630096/23106032/01c83638-f6e8-11e6-978f-9f180479c5eb.png)

See #264 where we replaced `netmask` with `cidr`.