### PR TITLE
Maven Release Plugin would fail on a non-existing dependency

### DIFF
--- a/cosmic-core/engine/api/pom.xml
+++ b/cosmic-core/engine/api/pom.xml
@@ -26,11 +26,6 @@
         </dependency>
         <dependency>
             <groupId>cloud.cosmic</groupId>
-            <artifactId>cloud-framework-rest</artifactId>
-            <version>5.3.2.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>cloud.cosmic</groupId>
             <artifactId>cloud-framework-ipc</artifactId>
             <version>5.3.2.0-SNAPSHOT</version>
         </dependency>


### PR DESCRIPTION
Maven Release Plugin is failing to release a new version of Cosmic due to references to a non-existing dependency (after: 762bc45fdcbb517b73a2e1b21b9458c8d1606429):

```
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:01 min
[INFO] Finished at: 2017-02-20T14:15:51+01:00
[INFO] Final Memory: 82M/1963M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project cosmic: Can't release project due to non released dependencies :
[ERROR] cloud.cosmic:cloud-framework-rest:jar:5.3.2.0-SNAPSHOT:compile
[ERROR] in project 'Cosmic Cloud Engine API' (cloud.cosmic:cloud-engine-api:jar:5.3.2.0-SNAPSHOT)
```