### PR TITLE
Have dnsmasq listen only on interfaces where VMs live

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
@@ -58,6 +58,11 @@ class CsDhcp(CsDataBag):
             if not i['dnsmasq']:
                 continue
             device = i['dev']
+            # Listen only on the interfaces we configure VMs on
+            sline = "interface=%s" % (device)
+            line = "interface=%s" % (device)
+            self.conf.search(sline, line)
+            # Ip address
             ip = i['ip'].split('/')[0]
             sline = "dhcp-range=interface:%s,set:interface-%s-%s" % (device, device, idx)
             line = "dhcp-range=interface:%s,set:interface-%s-%s,%s,static" % (device, device, idx, ip)


### PR DESCRIPTION
Before it was listening on all interfaces, now only the guest interfaces:

```
root@r-19-VM:/opt/cloud/bin/cs# netstat -nap | grep LISTEN | grep dnsmasq
tcp        0      0 10.1.1.1:53             0.0.0.0:*               LISTEN      19121/dnsmasq   
tcp        0      0 10.1.2.1:53             0.0.0.0:*               LISTEN      19121/dnsmasq 
```

cloud.conf:
```
root@r-19-VM:/opt/cloud/bin/cs# cat /etc/dnsmasq.d/cloud.conf 
dhcp-hostsfile=/etc/dhcphosts.txt
dhcp-optsfile=/etc/dhcpopts.txt
log-dhcp
interface=eth4
dhcp-range=interface:eth4,set:interface-eth4-0,10.1.1.1,static
dhcp-option=tag:interface-eth4-0,15,cs2cloud
dhcp-option=tag:interface-eth4-0,6,10.1.1.1
dhcp-option=tag:interface-eth4-0,3,10.1.1.1
dhcp-option=tag:interface-eth4-0,1,255.255.255.0
interface=eth5
dhcp-range=interface:eth5,set:interface-eth5-1,10.1.2.1,static
dhcp-option=tag:interface-eth5-1,15,cs2cloud
dhcp-option=tag:interface-eth5-1,6,10.1.2.1
dhcp-option=tag:interface-eth5-1,3,10.1.2.1
dhcp-option=tag:interface-eth5-1,1,255.255.255.0
```

VM could get an ip address.