### PR TITLE
Make the version of the Agent visible

### DIFF
--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyResource.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyResource.java
@@ -78,6 +78,7 @@ public class ConsoleProxyResource extends ServerResourceBase implements ServerRe
         fillNetworkInformation(cmd);
         cmd.setProxyPort(_proxyPort);
         cmd.setProxyVmId(_proxyVmId);
+        cmd.setVersion(ConsoleProxyResource.class.getPackage().getImplementationVersion());
         if (_pubIp != null) {
             cmd.setPublicIpAddress(_pubIp);
         }

--- a/cosmic-agent/src/main/java/com/cloud/agent/service/Agent.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/service/Agent.java
@@ -243,7 +243,9 @@ public class Agent implements HandlerFactory, IAgentControl {
         startup.setPod(agentProperties.getPod());
         startup.setGuid(getResourceGuid());
         startup.setResourceName(getResourceName());
-        startup.setVersion(agentProperties.getVersion());
+        if (startup.getVersion() == null) {
+            startup.setVersion(agentProperties.getVersion());
+        }
     }
 
     protected synchronized long getNextSequence() {

--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1993,6 +1993,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         cmd.setCluster(getCluster());
         cmd.setGatewayIpAddress(localGateway);
         cmd.setIqn(getIqn());
+        cmd.setVersion(LibvirtComputingResource.class.getPackage().getImplementationVersion());
 
         StartupStorageCommand sscmd = null;
         try {

--- a/cosmic-core/services/secondary-storage-server/src/main/java/com/cloud/storage/resource/NfsSecondaryStorageResource.java
+++ b/cosmic-core/services/secondary-storage-server/src/main/java/com/cloud/storage/resource/NfsSecondaryStorageResource.java
@@ -1943,6 +1943,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
 
         final StartupSecondaryStorageCommand cmd = new StartupSecondaryStorageCommand();
         fillNetworkInformation(cmd);
+        cmd.setVersion(NfsSecondaryStorageResource.class.getPackage().getImplementationVersion());
         if (_publicIp != null) {
             cmd.setPublicIpAddress(_publicIp);
         }


### PR DESCRIPTION
The KVM Agent and the system VMs now report the version they are running.

```
(local) 🐵 > list hosts filter=name,version
count = 4
host:
+------------------+-----------------------------------+
|     version      |                name               |
+------------------+-----------------------------------+
| 5.3.2.0-SNAPSHOT |              s-25-VM              |
| 5.3.2.0-SNAPSHOT |              v-24-VM              |
| 5.3.2.0-SNAPSHOT | Nicira Controller - 192.168.22.83 |
| 5.3.2.0-SNAPSHOT |                kvm1               |
+------------------+-----------------------------------+
```