### PR TITLE
Allow changes to VPN connections while they are connected

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
@@ -640,14 +640,6 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
         }
         _accountMgr.checkAccess(caller, null, false, gw);
 
-        final List<Site2SiteVpnConnectionVO> conns = _vpnConnectionDao.listByCustomerGatewayId(id);
-        if (conns != null) {
-            for (final Site2SiteVpnConnection conn : conns) {
-                if (conn.getState() != State.Error) {
-                    throw new InvalidParameterValueException("Unable to update customer gateway with connections in non-Error state!");
-                }
-            }
-        }
         String name = cmd.getName();
         final String gatewayIp = cmd.getGatewayIp();
         if (!NetUtils.isValidIp(gatewayIp)) {


### PR DESCRIPTION
When a VPN connection is connected, it is not possible to change any of its settings:
![image](https://cloud.githubusercontent.com/assets/1630096/23332306/c3523afe-fb77-11e6-9d65-18f6be775ec4.png)

For users this is confusing. Let's remove the check, it's fine to edit it and take effect the next time a connection is restarted.