### PR TITLE
When Storage Migrations are disabled, we should still allow it for ISOs

### DIFF
--- a/cosmic-core/engine/orchestration/src/main/java/com/cloud/engine/orchestration/VolumeOrchestrator.java
+++ b/cosmic-core/engine/orchestration/src/main/java/com/cloud/engine/orchestration/VolumeOrchestrator.java
@@ -1109,7 +1109,8 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
                                 } else {
                                     storageMigrationEnabled = StorageMigrationEnabled.value();
                                 }
-                                if (storageMigrationEnabled) {
+                                // Always allow ISOs volumes to be "migrated"
+                                if (storageMigrationEnabled || vol.getIsoId() != null) {
                                     if (s_logger.isDebugEnabled()) {
                                         s_logger.debug("Shared volume " + vol + " will be migrated on storage pool " + assignedPool + " assigned by deploymentPlanner");
                                     }


### PR DESCRIPTION
When disabling `enable.storage.migration` we've seen issues with `ISO` booting. In most cases you don't want volume migrations to start automatically (in case of resource issues in the current cluster for example), as those may run for many hours and block any other operation. Instead, the start should fail leaving options open for the admin to free-up resources.

This PR allows to disable storage migrations, while also allowing ISOs to work.