### PR TITLE
Add support for VirtIO SCSI disks

### DIFF
--- a/cosmic-core/db-scripts/src/main/resources/db/schema-532to533.sql
+++ b/cosmic-core/db-scripts/src/main/resources/db/schema-532to533.sql
@@ -1,3 +1,9 @@
 --
 -- Schema upgrade from 5.3.2 to 5.3.3;
 --
+
+-- VirtIO-SCSI
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1002, UUID(), 7, 'VirtIO-SCSI capable OS (64-bit)', utc_timestamp());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'VirtIO-SCSI capable OS', 1002, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (1023, UUID(), 6, 'Windows VirtIO-SCSI', utc_timestamp());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'Windows VirtIO-SCSI', 1023, utc_timestamp(), 0);

--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVmDef.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVmDef.java
@@ -1311,6 +1311,35 @@ public class LibvirtVmDef {
         }
     }
 
+    public static class ScsiDef {
+        private short index = 0;
+        private int domain = 0;
+        private int bus = 0;
+        private int slot = 9;
+        private int function = 0;
+
+        public ScsiDef(short index, int domain, int bus, int slot, int function) {
+            this.index = index;
+            this.domain = domain;
+            this.bus = bus;
+            this.slot = slot;
+            this.function = function;
+        }
+        public ScsiDef() {
+
+        }
+        @Override
+        public String toString() {
+            StringBuilder scsiBuilder = new StringBuilder();
+
+            scsiBuilder.append(String.format("<controller type='scsi' index='%d' mode='virtio-scsi'>\n", this.index ));
+            scsiBuilder.append(String.format("<address type='pci' domain='0x%04X' bus='0x%02X' slot='0x%02X' function='0x%01X'/>\n",
+                    this.domain, this.bus, this.slot, this.function ) );
+            scsiBuilder.append("</controller>");
+            return scsiBuilder.toString();
+        }
+    }
+
     public static class InputDef {
         private final String type; /* tablet, mouse */
         private final String bus; /* ps2, usb, xen */


### PR DESCRIPTION
Any guest OS with `virtIO-SCSI` in its name, will get `virtIO-SCSI` drives.

Libvirt XML:
![image](https://cloud.githubusercontent.com/assets/1630096/23331414/eaec4daa-fb65-11e6-9bff-b42af959bb8e.png)

Inside VM:
![image](https://cloud.githubusercontent.com/assets/1630096/23331455/a49dc03a-fb66-11e6-9f8b-5f3f12fff49d.png)

Also works with for example deviceID=30:
```
(local) 🐵 > attach volume id=2bb6520e-a90b-4da7-9343-4609700a3257 virtualmachineid=b2d7df88-065a-4b0e-bd96-555a065f92cb deviceid=30
accountid = fc79045c-fb56-11e6-8cb2-5254001daa61
cmd = com.cloud.api.command.admin.volume.AttachVolumeCmdByAdmin
created = 2017-02-25T14:29:26+0100
...
deviceid = 30
diskofferingdisplaytext = Small Disk, 5 GB
```

```
    <disk type='file' device='disk'>
      <driver name='qemu' type='qcow2' cache='none'/>
      <source file='/mnt/812ea6a3-7ad0-30f4-9cab-01e3f2985b98/4b7d894e-c9fc-4234-9381-8ade5c02617e'/>
      <target dev='sda' bus='scsi'/>
      <serial>0-4b7d894ec9fc42349381</serial>
      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
    </disk>
    <disk type='file' device='disk'>
      <driver name='qemu' type='qcow2' cache='none'/>
      <source file='/mnt/812ea6a3-7ad0-30f4-9cab-01e3f2985b98/2bb6520e-a90b-4da7-9343-4609700a3257'/>
      <target dev='sdae' bus='scsi'/>
      <serial>30-2bb6520ea90b4da79343</serial>
      <address type='drive' controller='4' bus='0' target='0' unit='2'/>
    </disk>
```

![image](https://cloud.githubusercontent.com/assets/1630096/23331503/a29094c4-fb67-11e6-83ba-d81a934f9946.png)


As before, any guest OS with `non-virtIO` in its name, will get legacy `IDE` drives.
Everything else will still get `virtIO` drives.

Status: WIP. Everything works, all we need to do is create an upgrade path and move the SQL code there.

Backport from ACS PR 1955