### PR TITLE
Restart VPC should not make the VPC redundant by default

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/RestartVPCCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/RestartVPCCmd.java
@@ -33,10 +33,10 @@ public class RestartVPCCmd extends BaseAsyncCmd {
     @Parameter(name = ApiConstants.ID, type = CommandType.UUID, entityType = VpcResponse.class, required = true, description = "the id of the VPC")
     private Long id;
 
-    @Parameter(name = ApiConstants.CLEANUP, type = CommandType.BOOLEAN, required = false, description = "If cleanup old network elements")
+    @Parameter(name = ApiConstants.CLEANUP, type = CommandType.BOOLEAN, required = false, description = "Cleanup old network elements (defaults to true)")
     private Boolean cleanup;
 
-    @Parameter(name = ApiConstants.MAKEREDUNDANTE, type = CommandType.BOOLEAN, required = false, description = "Turn a single VPC into a redundant one.")
+    @Parameter(name = ApiConstants.MAKEREDUNDANTE, type = CommandType.BOOLEAN, required = false, description = "Turn a single VPC into a redundant one (defaults to false).")
     private Boolean makeredundant;
 
     /////////////////////////////////////////////////////
@@ -98,7 +98,7 @@ public class RestartVPCCmd extends BaseAsyncCmd {
         if (makeredundant != null) {
             return makeredundant;
         }
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Only when the user explicitly specifies the 'makeredundant' parameter.

Restart VPC API should not make them redundant by default

Imagine this VPC:

```
(local) 🐵 > list vpcs filter=name,redundantvpcrouter,id
count = 1
vpc:
+--------------------+------+--------------------------------------+
| redundantvpcrouter | name |                  id                  |
+--------------------+------+--------------------------------------+
|       False        | vpc1 | 4da99ed2-1803-4fe4-8ce2-64317296bebd |
+--------------------+------+--------------------------------------+
```

It has a single router, hence is non-redundant:

```
(local) 🐵 > list routers vpcid=4da99ed2-1803-4fe4-8ce2-64317296bebd filter=id,redundantstate,name
count = 1
router:
+----------------+--------------------------------------+--------+
| redundantstate |                  id                  |  name  |
+----------------+--------------------------------------+--------+
|    UNKNOWN     | 177c5e40-8ed6-4f2a-b2ab-5cbb11d88c3b | r-3-VM |
+----------------+--------------------------------------+--------+
```

If you restart the VPC:

```
(local) 🐵 > restart vpc id=4da99ed2-1803-4fe4-8ce2-64317296bebd 
 
accountid = 552f3f83-fb6c-11e6-8cba-5254001daa61
cmd = com.cloud.api.command.user.vpc.RestartVPCCmd
created = 2017-02-25T16:52:28+0100
jobid = 085338ee-4030-444c-a965-e41a96417c89
jobprocstatus = 0
jobresult:
success = True
jobresultcode = 0
jobresulttype = object
jobstatus = 1
userid = 552f586f-fb6c-11e6-8cba-5254001daa61
```

You will end up with two routers:
```
(local) 🐵 > list routers vpcid=4da99ed2-1803-4fe4-8ce2-64317296bebd filter=id,redundantstate,name
count = 2
router:
+----------------+--------------------------------------+--------+
| redundantstate |                  id                  |  name  |
+----------------+--------------------------------------+--------+
|    UNKNOWN     | 3ffefbda-f83e-4a07-993b-ee8669714a2c | r-5-VM |
|    UNKNOWN     | 28dc1d7b-ddb8-4989-89ee-f51a368ed6dc | r-4-VM |
+----------------+--------------------------------------+--------+
```

The `restart vpc` api call has a parameter `makeredundant` that defaults to `True`. It should only make a VPC redundant if a user explicitly asks for it. 

With the changes in this PR:

```
(local) 🐵 > list vpcs filter=name,redundantvpcrouter,id
count = 2
vpc:
+--------------------+------+--------------------------------------+
| redundantvpcrouter | name |                  id                  |
+--------------------+------+--------------------------------------+
|       False        | vpc2 | f8aa36fe-959b-4ce9-ae0c-0a7ea22f4e79 |
|        True        | vpc1 | 4da99ed2-1803-4fe4-8ce2-64317296bebd |
+--------------------+------+--------------------------------------+
```

One router:
```
(local) 🐵 > list routers vpcid=f8aa36fe-959b-4ce9-ae0c-0a7ea22f4e79  filter=id,redundantstate,name
count = 1
router:
+----------------+--------------------------------------+--------+
| redundantstate |                  id                  |  name  |
+----------------+--------------------------------------+--------+
|    UNKNOWN     | 9fd249b0-7629-47a7-8d50-53021dcf6e22 | r-6-VM |
+----------------+--------------------------------------+--------+
```

Restarting it:
```
(local) 🐵 > restart vpc id=f8aa36fe-959b-4ce9-ae0c-0a7ea22f4e79 
 
accountid = 552f3f83-fb6c-11e6-8cba-5254001daa61
cmd = com.cloud.api.command.user.vpc.RestartVPCCmd
created = 2017-02-25T17:17:49+0100
jobid = 3793b8e0-c2dd-42d1-a567-6ada5fa26330
jobprocstatus = 0
jobresult:
success = True
jobresultcode = 0
jobresulttype = object
jobstatus = 1
userid = 552f586f-fb6c-11e6-8cba-5254001daa61
```

Still one router, as expected:
```
(local) 🐵 > list routers vpcid=f8aa36fe-959b-4ce9-ae0c-0a7ea22f4e79  filter=id,redundantstate,name
count = 1
router:
+----------------+--------------------------------------+--------+
| redundantstate |                  id                  |  name  |
+----------------+--------------------------------------+--------+
|    UNKNOWN     | 10356904-6070-4ceb-a602-514124dd61dd | r-7-VM |
+----------------+--------------------------------------+--------+
```

Redundancy paramater also didn't change:
```
(local) 🐵 > list vpcs filter=name,redundantvpcrouter,id
count = 2
vpc:
+--------------------+------+--------------------------------------+
| redundantvpcrouter | name |                  id                  |
+--------------------+------+--------------------------------------+
|       False        | vpc2 | f8aa36fe-959b-4ce9-ae0c-0a7ea22f4e79 |
|        True        | vpc1 | 4da99ed2-1803-4fe4-8ce2-64317296bebd |
+--------------------+------+--------------------------------------+
```
