### PR TITLE
Make it possible to change the offering of an existing VPC

### DIFF
--- a/cosmic-client/src/main/webapp/l10n/en.js
+++ b/cosmic-client/src/main/webapp/l10n/en.js
@@ -1834,6 +1834,7 @@ var dictionary = {
     "message.confirm.archive.selected.events": "Please confirm you would like to archive the selected events",
     "message.confirm.attach.disk": "Are you sure you want to attach disk?",
     "message.confirm.create.volume": "Are you sure you want to create volume?",
+    "message.confirm.change.vpcoffering": "Changing the VPC offering will cause a Restart with Cleanup to be executed, resulting in a few minutes downtime. Are you sure?",
     "message.confirm.current.guest.CIDR.unchanged": "Do you want to keep the current guest network CIDR unchanged?",
     "message.confirm.dedicate.cluster.domain.account": "Do you really want to dedicate this cluster to a domain/account?",
     "message.confirm.dedicate.host.domain.account": "Do you really want to dedicate this host to a domain/account?",

--- a/cosmic-client/src/main/webapp/scripts/network.js
+++ b/cosmic-client/src/main/webapp/scripts/network.js
@@ -731,28 +731,62 @@
                             edit: {
                                 label: 'label.edit',
                                 action: function (args) {
-                                    $.ajax({
-                                        url: createURL('updateVPC'),
-                                        data: {
-                                            id: args.context.vpc[0].id,
-                                            name: args.data.name,
-                                            displaytext: args.data.displaytext
-                                        },
-                                        success: function (json) {
-                                            var jid = json.updatevpcresponse.jobid;
-                                            args.response.success({
-                                                _custom: {
-                                                    jobId: jid,
-                                                    getUpdatedItem: function (json) {
-                                                        return json.queryasyncjobresultresponse.jobresult.vpc;
+                                    // should we update the vpc offering
+                                    if (args.data.vpcofferingid != null && args.data.vpcofferingid != args.context.vpc[0].vpcofferingid) {
+                                        cloudStack.dialog.confirm({
+                                            message: 'message.confirm.change.vpcoffering',
+                                            action: function () { //"Yes"    button is clicked
+                                                $.ajax({
+                                                    url: createURL('updateVPC'),
+                                                    data: {
+                                                        id: args.context.vpc[0].id,
+                                                        name: args.data.name,
+                                                        displaytext: args.data.displaytext,
+                                                        vpcofferingid: args.data.vpcofferingid
+                                                    },
+                                                    success: function (json) {
+                                                        var jid = json.updatevpcresponse.jobid;
+                                                        args.response.success({
+                                                            _custom: {
+                                                                jobId: jid,
+                                                                getUpdatedItem: function (json) {
+                                                                    return json.queryasyncjobresultresponse.jobresult.vpc;
+                                                                }
+                                                            }
+                                                        });
+                                                    },
+                                                    error: function (data) {
+                                                        args.response.error(parseXMLHttpResponse(data));
                                                     }
-                                                }
-                                            });
-                                        },
-                                        error: function (data) {
-                                            args.response.error(parseXMLHttpResponse(data));
-                                        }
-                                    });
+                                                });
+                                            },
+                                            cancelAction: function () { //"Cancel" button is clicked
+                                            }
+                                        });
+                                    } else {
+                                        $.ajax({
+                                            url: createURL('updateVPC'),
+                                            data: {
+                                                id: args.context.vpc[0].id,
+                                                name: args.data.name,
+                                                displaytext: args.data.displaytext
+                                            },
+                                            success: function (json) {
+                                                var jid = json.updatevpcresponse.jobid;
+                                                args.response.success({
+                                                    _custom: {
+                                                        jobId: jid,
+                                                        getUpdatedItem: function (json) {
+                                                            return json.queryasyncjobresultresponse.jobresult.vpc;
+                                                        }
+                                                    }
+                                                });
+                                            },
+                                            error: function (data) {
+                                                args.response.error(parseXMLHttpResponse(data));
+                                            }
+                                        });
+                                    }
                                 },
                                 notification: {
                                     poll: pollAsyncJobResult
@@ -896,6 +930,44 @@
                                     displaytext: {
                                         label: 'label.description',
                                         isEditable: true
+                                    },
+                                    vpcofferingid: {
+                                        label: 'label.vpc.offering',
+                                        isEditable: true,
+                                        select: function (args) {
+                                            if (args.context.vpc[0].state == 'Destroyed') {
+                                                args.response.success({
+                                                    data: []
+                                                });
+                                                return;
+                                            }
+
+                                            var items = [];
+                                            $.ajax({
+                                                url: createURL("listVPCOfferings"),
+                                                dataType: "json",
+                                                async: false,
+                                                success: function (json) {
+                                                    var vpcOfferingObjs = json.listvpcofferingsresponse.vpcoffering;
+                                                    $(vpcOfferingObjs).each(function () {
+                                                        items.push({
+                                                            id: this.id,
+                                                            description: this.displaytext
+                                                        });
+                                                    });
+                                                }
+                                            });
+
+                                            //include currently selected vpc offering to dropdown
+                                            items.push({
+                                                id: args.context.vpc[0].vpcofferingid,
+                                                description: args.context.vpc[0].vpcofferingdisplaytext + " (Current offering)"
+                                            });
+
+                                            args.response.success({
+                                                data: items
+                                            });
+                                        }
                                     },
                                     account: {
                                         label: 'label.account'

--- a/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
@@ -451,6 +451,8 @@ public class ApiConstants {
     public static final String END_POINT = "endpoint";
     public static final String REGION_ID = "regionid";
     public static final String VPC_OFF_ID = "vpcofferingid";
+    public static final String VPC_OFF_NAME = "vpcofferingname";
+    public static final String VPC_OFF_DISPLAYTEXT = "vpcofferingdisplaytext";
     public static final String NETWORK = "network";
     public static final String VPC_ID = "vpcid";
     public static final String GATEWAY_ID = "gatewayid";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/UpdateVPCCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/UpdateVPCCmdByAdmin.java
@@ -18,7 +18,7 @@ public class UpdateVPCCmdByAdmin extends UpdateVPCCmd {
 
     @Override
     public void execute() {
-        final Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc());
+        final Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc(), getVpcOfferingId());
         if (result != null) {
             final VpcResponse response = _responseGenerator.createVpcResponse(ResponseView.Full, result);
             response.setResponseName(getCommandName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/UpdateVPCCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/UpdateVPCCmd.java
@@ -11,6 +11,7 @@ import com.cloud.api.BaseAsyncCustomIdCmd;
 import com.cloud.api.Parameter;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
+import com.cloud.api.response.VpcOfferingResponse;
 import com.cloud.api.response.VpcResponse;
 import com.cloud.event.EventTypes;
 import com.cloud.network.vpc.Vpc;
@@ -42,13 +43,17 @@ public class UpdateVPCCmd extends BaseAsyncCustomIdCmd {
             ".4", authorized = {RoleType.Admin})
     private Boolean display;
 
+    @Parameter(name = ApiConstants.VPC_OFF_ID, type = CommandType.UUID, entityType = VpcOfferingResponse.class, description = "The new VPC offering ID to switch to. This will result " +
+            "in a restart+cleanup of the VPC")
+    private Long vpcOfferingId;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
 
     @Override
     public void execute() {
-        final Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc());
+        final Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc(), getVpcOfferingId());
         if (result != null) {
             final VpcResponse response = _responseGenerator.createVpcResponse(ResponseView.Restricted, result);
             response.setResponseName(getCommandName());
@@ -90,6 +95,10 @@ public class UpdateVPCCmd extends BaseAsyncCustomIdCmd {
 
     public Boolean getDisplayVpc() {
         return display;
+    }
+
+    public Long getVpcOfferingId() {
+        return vpcOfferingId;
     }
 
     @Override

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/VpcResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/VpcResponse.java
@@ -50,6 +50,14 @@ public class VpcResponse extends BaseResponse implements ControlledEntityRespons
     @Param(description = "vpc offering id the VPC is created from")
     private String vpcOfferingId;
 
+    @SerializedName(ApiConstants.VPC_OFF_NAME)
+    @Param(description = "name of the vpc offering the vpc is created from")
+    private String vpcOfferingName;
+
+    @SerializedName(ApiConstants.VPC_OFF_DISPLAYTEXT)
+    @Param(description = "display text of the vpc offering the vpc is created from")
+    private String vpcOfferingDisplayText;
+
     @SerializedName(ApiConstants.CREATED)
     @Param(description = "the date this VPC was created")
     private Date created;
@@ -205,5 +213,13 @@ public class VpcResponse extends BaseResponse implements ControlledEntityRespons
 
     public void setRedundantRouter(final Boolean redundantRouter) {
         this.redundantRouter = redundantRouter;
+    }
+
+    public void setVpcOfferingName(final String vpcOfferingName) {
+        this.vpcOfferingName = vpcOfferingName;
+    }
+
+    public void setVpcOfferingDisplayText(final String vpcOfferingDisplayText) {
+        this.vpcOfferingDisplayText = vpcOfferingDisplayText;
     }
 }

--- a/cosmic-core/api/src/main/java/com/cloud/network/vpc/VpcService.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/vpc/VpcService.java
@@ -54,7 +54,7 @@ public interface VpcService {
      * @param displayVpc  TODO
      * @return
      */
-    public Vpc updateVpc(long vpcId, String vpcName, String displayText, String customId, Boolean displayVpc);
+    public Vpc updateVpc(long vpcId, String vpcName, String displayText, String customId, Boolean displayVpc, Long vpcOfferingId);
 
     /**
      * Lists VPC(s) based on the parameters passed to the method call

--- a/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2527,6 +2527,8 @@ public class ApiResponseHelper implements ResponseGenerator {
         final VpcOffering voff = ApiDBUtils.findVpcOfferingById(vpc.getVpcOfferingId());
         if (voff != null) {
             response.setVpcOfferingId(voff.getUuid());
+            response.setVpcOfferingName(voff.getName());
+            response.setVpcOfferingDisplayText(voff.getDisplayText());
         }
         response.setCidr(vpc.getCidr());
         response.setRestartRequired(vpc.isRestartRequired());

--- a/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -1838,14 +1838,7 @@ public class ApiResponseHelper implements ResponseGenerator {
                 continue;
             }
             svcRsp.setName(service.getName());
-            final List<ProviderResponse> providers = new ArrayList<>();
-            for (final Provider provider : srvc_providers) {
-                if (provider != null) {
-                    final ProviderResponse providerRsp = new ProviderResponse();
-                    providerRsp.setName(provider.getName());
-                    providers.add(providerRsp);
-                }
-            }
+            final List<ProviderResponse> providers = getProviderResponses(srvc_providers);
             svcRsp.setProviders(providers);
 
             if (Service.Lb == service) {
@@ -1910,6 +1903,18 @@ public class ApiResponseHelper implements ResponseGenerator {
 
         response.setObjectName("networkoffering");
         return response;
+    }
+
+    private List<ProviderResponse> getProviderResponses(final Set<Provider> srvc_providers) {
+        final List<ProviderResponse> providers = new ArrayList<>();
+        for (final Provider provider : srvc_providers) {
+            if (provider != null) {
+                final ProviderResponse providerRsp = new ProviderResponse();
+                providerRsp.setName(provider.getName());
+                providers.add(providerRsp);
+            }
+        }
+        return providers;
     }
 
     @Override
@@ -2505,29 +2510,8 @@ public class ApiResponseHelper implements ResponseGenerator {
         response.setSupportsRegionLevelVpc(offering.offersRegionLevelVPC());
 
         final Map<Service, Set<Provider>> serviceProviderMap = ApiDBUtils.listVpcOffServices(offering.getId());
-        final List<ServiceResponse> serviceResponses = new ArrayList<>();
-        for (final Map.Entry<Service, Set<Provider>> entry : serviceProviderMap.entrySet()) {
-            final Service service = entry.getKey();
-            final Set<Provider> srvc_providers = entry.getValue();
+        final List<ServiceResponse> serviceResponses = getServiceResponses(serviceProviderMap);
 
-            final ServiceResponse svcRsp = new ServiceResponse();
-            // skip gateway service
-            if (service == Service.Gateway) {
-                continue;
-            }
-            svcRsp.setName(service.getName());
-            final List<ProviderResponse> providers = new ArrayList<>();
-            for (final Provider provider : srvc_providers) {
-                if (provider != null) {
-                    final ProviderResponse providerRsp = new ProviderResponse();
-                    providerRsp.setName(provider.getName());
-                    providers.add(providerRsp);
-                }
-            }
-            svcRsp.setProviders(providers);
-
-            serviceResponses.add(svcRsp);
-        }
         response.setServices(serviceResponses);
         response.setObjectName("vpcoffering");
         return response;
@@ -2553,28 +2537,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         response.setRegionLevelVpc(vpc.isRegionLevelVpc());
 
         final Map<Service, Set<Provider>> serviceProviderMap = ApiDBUtils.listVpcOffServices(vpc.getVpcOfferingId());
-        final List<ServiceResponse> serviceResponses = new ArrayList<>();
-        for (final Map.Entry<Service, Set<Provider>> entry : serviceProviderMap.entrySet()) {
-            final Service service = entry.getKey();
-            final Set<Provider> serviceProviders = entry.getValue();
-            final ServiceResponse svcRsp = new ServiceResponse();
-            // skip gateway service
-            if (service == Service.Gateway) {
-                continue;
-            }
-            svcRsp.setName(service.getName());
-            final List<ProviderResponse> providers = new ArrayList<>();
-            for (final Provider provider : serviceProviders) {
-                if (provider != null) {
-                    final ProviderResponse providerRsp = new ProviderResponse();
-                    providerRsp.setName(provider.getName());
-                    providers.add(providerRsp);
-                }
-            }
-            svcRsp.setProviders(providers);
-
-            serviceResponses.add(svcRsp);
-        }
+        final List<ServiceResponse> serviceResponses = getServiceResponses(serviceProviderMap);
 
         final List<NetworkResponse> networkResponses = new ArrayList<>();
         final List<? extends Network> networks = ApiDBUtils.listVpcNetworks(vpc.getId());
@@ -2603,6 +2566,25 @@ public class ApiResponseHelper implements ResponseGenerator {
         response.setTags(tagResponses);
         response.setObjectName("vpc");
         return response;
+    }
+
+    private List<ServiceResponse> getServiceResponses(final Map<Service, Set<Provider>> serviceProviderMap) {
+        final List<ServiceResponse> serviceResponses = new ArrayList<>();
+        for (final Map.Entry<Service, Set<Provider>> entry : serviceProviderMap.entrySet()) {
+            final Service service = entry.getKey();
+            final Set<Provider> serviceProviders = entry.getValue();
+            final ServiceResponse svcRsp = new ServiceResponse();
+            // skip gateway service
+            if (service == Service.Gateway) {
+                continue;
+            }
+            svcRsp.setName(service.getName());
+            final List<ProviderResponse> providers = getProviderResponses(serviceProviders);
+            svcRsp.setProviders(providers);
+
+            serviceResponses.add(svcRsp);
+        }
+        return serviceResponses;
     }
 
     @Override


### PR DESCRIPTION
This provides an easy way to update the offering of a VPC (prevents hacking the DB to get it done).

It will do some sanity checks and for now you need to have an offering that supports all the services that the current one also supports.

Two single VPCs, one redundant:
```
(local) 🐵 > list vpcs filter=name,redundantvpcrouter,id,vpcofferingid
count = 3
vpc:
+--------------------------------------+--------------------+------+--------------------------------------+
|            vpcofferingid             | redundantvpcrouter | name |                  id                  |
+--------------------------------------+--------------------+------+--------------------------------------+
| f7359e53-427e-44a2-9c42-f672c472d502 |       False        | vpc3 | 46d655ec-142c-4121-b5b4-546e2df3d1fd |
| f7359e53-427e-44a2-9c42-f672c472d502 |       False        | vpc2 | f8aa36fe-959b-4ce9-ae0c-0a7ea22f4e79 |
| 09a6cb5e-c2e5-4fd9-9d3f-a1f138f41fdc |        True        | vpc1 | 4da99ed2-1803-4fe4-8ce2-64317296bebd |
+--------------------------------------+--------------------+------+--------------------------------------+
```

Upgrade one to redundant:

```
(local) 🐵 > update vpc id=f8aa36fe-959b-4ce9-ae0c-0a7ea22f4e79 vpcofferingid=09a6cb5e-c2e5-4fd9-9d3f-a1f138f41fdc 
 
accountid = 552f3f83-fb6c-11e6-8cba-5254001daa61
cmd = com.cloud.api.command.admin.vpc.UpdateVPCCmdByAdmin
created = 2017-02-25T23:18:53+0100
jobid = 84e4557b-15a1-4bf5-986f-bf1c663a2b7f
jobprocstatus = 0
jobresult:
vpc:
id = f8aa36fe-959b-4ce9-ae0c-0a7ea22f4e79
name = vpc2
...
```

```
(local) 🐵 > list vpcs filter=name,redundantvpcrouter,id,vpcofferingid
count = 3
vpc:
+--------------------------------------+--------------------+------+--------------------------------------+
|            vpcofferingid             | redundantvpcrouter | name |                  id                  |
+--------------------------------------+--------------------+------+--------------------------------------+
| f7359e53-427e-44a2-9c42-f672c472d502 |       False        | vpc3 | 46d655ec-142c-4121-b5b4-546e2df3d1fd |
| 09a6cb5e-c2e5-4fd9-9d3f-a1f138f41fdc |        True        | vpc2 | f8aa36fe-959b-4ce9-ae0c-0a7ea22f4e79 |
| 09a6cb5e-c2e5-4fd9-9d3f-a1f138f41fdc |        True        | vpc1 | 4da99ed2-1803-4fe4-8ce2-64317296bebd |
+--------------------------------------+--------------------+------+--------------------------------------+
```

Two routers:
```
(local) 🐵 > list routers vpcid=f8aa36fe-959b-4ce9-ae0c-0a7ea22f4e79 filter=name,vpcid,redundantstate
count = 2
router:
+--------------------------------------+----------------+---------+
|                vpcid                 | redundantstate |   name  |
+--------------------------------------+----------------+---------+
| f8aa36fe-959b-4ce9-ae0c-0a7ea22f4e79 |     BACKUP     | r-25-VM |
| f8aa36fe-959b-4ce9-ae0c-0a7ea22f4e79 |     MASTER     | r-24-VM |
+--------------------------------------+----------------+---------+
```

And back to a single offering:
```
(local) 🐵 > update vpc id=f8aa36fe-959b-4ce9-ae0c-0a7ea22f4e79 vpcofferingid=f7359e53-427e-44a2-9c42-f672c472d502 
 
accountid = 552f3f83-fb6c-11e6-8cba-5254001daa61
cmd = com.cloud.api.command.admin.vpc.UpdateVPCCmdByAdmin
created = 2017-02-25T23:25:40+0100
jobid = 1e0c46b5-e165-4226-9d88-e06c4fe1d7fa
jobprocstatus = 0
jobresult:
vpc:
id = f8aa36fe-959b-4ce9-ae0c-0a7ea22f4e79
name = vpc2
...
```

And we have a single router now:
```
(local) 🐵 > list routers vpcid=f8aa36fe-959b-4ce9-ae0c-0a7ea22f4e79 filter=name,vpcid,redundantstate
count = 1
router:
+--------------------------------------+----------------+---------+
|                vpcid                 | redundantstate |   name  |
+--------------------------------------+----------------+---------+
| f8aa36fe-959b-4ce9-ae0c-0a7ea22f4e79 |    UNKNOWN     | r-26-VM |
+--------------------------------------+----------------+---------+
```

As part of this update a `restart+cleanup` is executed to build the VPC with the new offering.

Error handling:
```
(local) 🐵 > update vpc id=4da99ed2-1803-4fe4-8ce2-64317296bebd vpcofferingid=f7359e53-427e-44a2-9c42-f672c472d502 
Error 
Async job 1ba41f8f-bf62-4f9d-8be1-453214c14c00 failed
Error 431, The vpc already has the specified offering, so not upgrading. Use restart+cleanup to rebuild.
accountid = 552f3f83-fb6c-11e6-8cba-5254001daa61
cmd = com.cloud.api.command.admin.vpc.UpdateVPCCmdByAdmin
created = 2017-02-25T23:15:28+0100
jobid = 1ba41f8f-bf62-4f9d-8be1-453214c14c00
jobprocstatus = 0
jobresult:
errorcode = 431
errortext = The vpc already has the specified offering, so not upgrading. Use restart+cleanup to rebuild.
jobresultcode = 530
jobresulttype = object
jobstatus = 2
userid = 552f586f-fb6c-11e6-8cba-5254001daa61
```

```
(local) 🐵 > update vpc id=4da99ed2-1803-4fe4-8ce2-64317296bebd vpcofferingid=42f0d1bf-ba0e-44c1-9810-5e59ae11f12e 
Error 
Async job 6aae45f2-bf5f-4756-a943-a8247ba4351a failed
Error 431, The new vpc offering does not support these service(s) that this vpc requires for proper operation: [Gateway, Lb, PortForwarding, SourceNat, StaticNat]. Please select an offering with compatible services.
jobresultcode = 530
jobresulttype = object
jobstatus = 2
userid = 552f586f-fb6c-11e6-8cba-5254001daa61
```

Status WIP: will add some UI changes to support this feature.