### PR TITLE
UI: Put name field on top of register template form (like before)

### DIFF
--- a/cosmic-client/src/main/webapp/l10n/en.js
+++ b/cosmic-client/src/main/webapp/l10n/en.js
@@ -763,7 +763,7 @@ var dictionary = {
     "label.host.tags": "Host Tags",
     "label.hosts": "Hosts",
     "label.hourly": "Hourly",
-    "label.hvm": "HVM",
+    "label.hvm": "Requires HVM",
     "label.hypervisor": "Hypervisor",
     "label.hypervisor.capabilities": "Hypervisor capabilities",
     "label.hypervisor.snapshot.reserve": "Hypervisor Snapshot Reserve",

--- a/cosmic-client/src/main/webapp/scripts/templates.js
+++ b/cosmic-client/src/main/webapp/scripts/templates.js
@@ -108,7 +108,7 @@
                                         label: 'label.description',
                                         docID: 'helpRegisterTemplateDescription',
                                         validation: {
-                                            required: true
+                                            required: false
                                         }
                                     },
                                     url: {
@@ -343,9 +343,16 @@
                             },
 
                             action: function (args) {
+
+                                if (args.data.description != "") {
+                                    displayText = args.data.description
+                                } else {
+                                    displayText = args.data.name
+                                }
+
                                 var data = {
                                     name: args.data.name,
-                                    displayText: args.data.description,
+                                    displayText: displayText,
                                     url: args.data.url,
                                     zoneid: args.data.zone,
                                     format: args.data.format,
@@ -514,7 +521,7 @@
                                         label: 'label.description',
                                         docID: 'helpRegisterTemplateDescription',
                                         validation: {
-                                            required: true
+                                            required: false
                                         }
                                     },
 

--- a/cosmic-client/src/main/webapp/scripts/templates.js
+++ b/cosmic-client/src/main/webapp/scripts/templates.js
@@ -97,13 +97,6 @@
                                 docID: 'helpNetworkOfferingName',
                                 preFilter: cloudStack.preFilter.createTemplate,
                                 fields: {
-                                    url: {
-                                        label: 'label.url',
-                                        docID: 'helpRegisterTemplateURL',
-                                        validation: {
-                                            required: true
-                                        }
-                                    },
                                     name: {
                                         label: 'label.name',
                                         docID: 'helpRegisterTemplateName',
@@ -114,6 +107,13 @@
                                     description: {
                                         label: 'label.description',
                                         docID: 'helpRegisterTemplateDescription',
+                                        validation: {
+                                            required: true
+                                        }
+                                    },
+                                    url: {
+                                        label: 'label.url',
+                                        docID: 'helpRegisterTemplateURL',
                                         validation: {
                                             required: true
                                         }
@@ -169,8 +169,7 @@
 
                                             var apiCmd;
                                             if (args.zone == -1) { //All Zones
-                                                //apiCmd = "listHypervisors&zoneid=-1"; //"listHypervisors&zoneid=-1" has been changed to return only hypervisors available in all zones (bug 8809)
-                                                apiCmd = "listHypervisors";
+                                                apiCmd = "listHypervisors&zoneid=-1";
                                             }
                                             else {
                                                 apiCmd = "listHypervisors&zoneid=" + args.zone;


### PR DESCRIPTION
In older (CloudStack) versions the form starts with the name, which makes more sense. Put that field on top again.

Before:
![image](https://cloud.githubusercontent.com/assets/1630096/23343473/5e6cd20c-fc6c-11e6-8161-e9a1933c1b86.png)

After:
![image](https://cloud.githubusercontent.com/assets/1630096/23343528/5d0d76e0-fc6d-11e6-836e-6bcc0e886180.png)

