### PR TITLE
Show router host details to domain admins

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/api/query/dao/DomainRouterJoinDaoImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/query/dao/DomainRouterJoinDaoImpl.java
@@ -67,8 +67,7 @@ public class DomainRouterJoinDaoImpl extends GenericDaoBase<DomainRouterJoinVO, 
             routerResponse.setRequiresUpgrade(true);
         }
 
-        if (caller.getType() == Account.ACCOUNT_TYPE_RESOURCE_DOMAIN_ADMIN
-                || _accountMgr.isRootAdmin(caller.getId())) {
+        if (_accountMgr.isRootAdmin(caller.getId()) || (_accountMgr.isDomainAdmin(caller.getId()))) {
             if (router.getHostId() != null) {
                 routerResponse.setHostId(router.getHostUuid());
                 routerResponse.setHostName(router.getHostName());


### PR DESCRIPTION
Show details on the hypervisor a router runs on to domain admins (they could already see it for vms).

![image](https://cloud.githubusercontent.com/assets/1630096/23343858/8d715a9a-fc72-11e6-9e75-a314a199e0b6.png)
