### PR TITLE
Make private gateway permissions clear

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/vpc.js
+++ b/cosmic-client/src/main/webapp/scripts/vpc.js
@@ -2368,7 +2368,7 @@
                                                     data: item,
                                                     actionFilter: function (args) {
                                                         var allowedActions = [];
-                                                        if (isAdmin()) {
+                                                        if (isAdmin() || isDomainAdmin()) {
                                                             allowedActions.push("remove");
                                                             allowedActions.push("replaceACL");
 

--- a/cosmic-client/src/main/webapp/scripts/vpc.js
+++ b/cosmic-client/src/main/webapp/scripts/vpc.js
@@ -1872,6 +1872,7 @@
                                     url: createURL("listNetworks"),
                                     data: {
                                         zoneid: args.context.vpc[0].zoneid,
+                                        domainid: args.context.vpc[0].domainid,
                                         traffictype: "Guest",
                                         type: "private"
                                     },
@@ -2052,6 +2053,7 @@
                                                     url: createURL("listNetworks"),
                                                     data: {
                                                         zoneid: args.context.vpc[0].zoneid,
+                                                        domainid: args.context.vpc[0].domainid,
                                                         traffictype: "Guest",
                                                         type: "private"
                                                     },

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -1428,9 +1428,14 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             throw new InvalidParameterValueException("Gateway/netmask fields are not supported anymore");
         }
 
-        final Network privateNtwk = _ntwkDao.findByIdAndDomainId(networkId, gatewayDomainId);
+        final Network privateNtwk = _ntwkDao.findById(networkId);
         if (privateNtwk == null) {
-            throw new InvalidParameterValueException("Unable to find private network based on the network ID");
+            throw new InvalidParameterValueException("The private network specified could not be found.");
+        }
+
+        if (privateNtwk.getDomainId() != vpc.getDomainId() && !_accountMgr.isRootAdmin(caller.getId())) {
+            throw new InvalidParameterValueException("VPC '" + vpc.getName() + "' does not have permission to operate on private network '" + privateNtwk.getName()
+                    + "' as they need to belong to the same domain.");
         }
 
         if (NetUtils.isNetworkAWithinNetworkB(privateNtwk.getCidr(), vpc.getCidr())) {


### PR DESCRIPTION
Domain admins can only connect a private network that has the same domain as their VPC, regardless if it's a project or not. If it is not allowed, the error message is now more descriptive.

Root admins can plug any private network in any VPC. The domain of the VPC will then own the private gateway, can even delete it, but will be unable to recreate it. This works only via the API.

In the UI two changes were made:
- hide private networks from the list that are from another domain
- add option to delete the private gateway (that worked only via api)
