### PR TITLE
Support separate service offerings for redundant routers

### DIFF
--- a/cosmic-client/src/main/webapp/css/cloudstack3.css
+++ b/cosmic-client/src/main/webapp/css/cloudstack3.css
@@ -1905,7 +1905,7 @@ span.compact {
     position: relative;
     top: 9px;
     float: left;
-    width: 345px;
+    width: 95%;
 }
 
 .detail-group .main-groups table td.value > span.copypasteenabledvalue {
@@ -6361,11 +6361,11 @@ label.error {
 }
 
 .instance-wizard .step.service-offering.custom-size .select-container {
-    height: 235px;
+    height: 400px;
 }
 
 .instance-wizard .step.service-offering.custom-iops .select-container {
-    height: 235px;
+    height: 400px;
 }
 
 .instance-wizard .step.service-offering .custom-size {
@@ -10855,7 +10855,7 @@ div.container div.panel div#details-tab-addloadBalancer.detail-group div.loadBal
 }
 
 .tagger ul li span.label > span.value {
-    max-width: 160px;
+    max-width: 300px;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/cosmic-client/src/main/webapp/css/token-input-facebook.css
+++ b/cosmic-client/src/main/webapp/css/token-input-facebook.css
@@ -13,7 +13,7 @@ ul.token-input-list-facebook {
     overflow: hidden;
     height: auto !important;
     height: 1%;
-    width: 233px;
+    width: 95%;
     border: 1px solid #AFAFAF;
     cursor: text;
     font-size: 12px;

--- a/cosmic-client/src/main/webapp/l10n/en.js
+++ b/cosmic-client/src/main/webapp/l10n/en.js
@@ -1388,6 +1388,7 @@ var dictionary = {
     "label.server": "Server",
     "label.service.capabilities": "Service Capabilities",
     "label.service.offering": "Service Offering",
+    "label.service.offering.secondary": "Service Offering (secondary)",
     "label.service.offering.details": "Service offering details",
     "label.service.state": "Service State",
     "label.services": "Services",

--- a/cosmic-client/src/main/webapp/scripts/configuration.js
+++ b/cosmic-client/src/main/webapp/scripts/configuration.js
@@ -3359,15 +3359,17 @@
                                     traffictype: {
                                         label: 'label.traffic.type'
                                     },
-                                    supportsstrechedl2subnet: {
-                                        label: 'label.supportsstrechedl2subnet',
-                                        converter: cloudStack.converters.toBooleanText
-                                    },
                                     supportedServices: {
                                         label: 'label.supported.services'
                                     },
                                     serviceCapabilities: {
                                         label: 'label.service.capabilities'
+                                    },
+                                    serviceofferingname: {
+                                        label: 'label.service.offering'
+                                    },
+                                    secondaryserviceofferingname: {
+                                        label: 'label.service.offering.secondary'
                                     },
                                     tags: {
                                         label: 'label.tags'
@@ -3929,21 +3931,15 @@
                                     serviceCapabilities: {
                                         label: 'label.service.capabilities'
                                     },
-                                    distributedvpcrouter: {
-                                        label: 'label.vpc.distributedvpcrouter',
-                                        converter: cloudStack.converters.toBooleanText
-                                    },
-                                    supportsregionLevelvpc: {
-                                        label: 'label.vpc.supportsregionlevelvpc',
-                                        converter: cloudStack.converters.toBooleanText
-                                    },
-                                    serviceCapabilities: {
-                                        label: 'label.service.capabilities'
-                                    },
                                     tags: {
                                         label: 'label.tags'
+                                    },
+                                    serviceofferingname: {
+                                        label: 'label.service.offering'
+                                    },
+                                    secondaryserviceofferingname: {
+                                        label: 'label.service.offering.secondary'
                                     }
-
                                 }],
 
                                 dataProvider: function (args) {

--- a/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
@@ -215,6 +215,7 @@ public class ApiConstants {
     public static final String SENT_BYTES = "sentbytes";
     public static final String SERVER_TIMEOUT = "servertimeout";
     public static final String SERVICE_OFFERING_ID = "serviceofferingid";
+    public static final String SECONDARY_SERVICE_OFFERING_ID = "secondaryserviceofferingid";
     public static final String SESSIONKEY = "sessionkey";
     public static final String SHOW_CAPACITIES = "showcapacities";
     public static final String SHOW_REMOVED = "showremoved";

--- a/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
@@ -215,7 +215,9 @@ public class ApiConstants {
     public static final String SENT_BYTES = "sentbytes";
     public static final String SERVER_TIMEOUT = "servertimeout";
     public static final String SERVICE_OFFERING_ID = "serviceofferingid";
+    public static final String SERVICE_OFFERING_NAME = "serviceofferingname";
     public static final String SECONDARY_SERVICE_OFFERING_ID = "secondaryserviceofferingid";
+    public static final String SECONDARY_SERVICE_OFFERING_NAME = "secondaryserviceofferingname";
     public static final String SESSIONKEY = "sessionkey";
     public static final String SHOW_CAPACITIES = "showcapacities";
     public static final String SHOW_REMOVED = "showremoved";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/CreateNetworkOfferingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/CreateNetworkOfferingCmd.java
@@ -61,6 +61,11 @@ public class CreateNetworkOfferingCmd extends BaseCmd {
             entityType = ServiceOfferingResponse.class,
             description = "the service offering ID used by virtual router provider")
     private Long serviceOfferingId;
+    @Parameter(name = ApiConstants.SECONDARY_SERVICE_OFFERING_ID,
+            type = CommandType.UUID,
+            entityType = ServiceOfferingResponse.class,
+            description = "the ID of the service offering for the second VPC router appliance (in case of redundancy)")
+    private Long secondaryServiceOfferingId;
     @Parameter(name = ApiConstants.GUEST_IP_TYPE, type = CommandType.STRING, required = true, description = "guest type of the network offering: Shared or Isolated")
     private String guestIptype;
     @Parameter(name = ApiConstants.SUPPORTED_SERVICES,
@@ -138,6 +143,10 @@ public class CreateNetworkOfferingCmd extends BaseCmd {
 
     public Long getServiceOfferingId() {
         return serviceOfferingId;
+    }
+
+    public Long getSecondaryServiceOfferingId() {
+        return secondaryServiceOfferingId;
     }
 
     public List<String> getSupportedServices() {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/CreateVPCOfferingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/CreateVPCOfferingCmd.java
@@ -59,6 +59,12 @@ public class CreateVPCOfferingCmd extends BaseAsyncCreateCmd {
             description = "the ID of the service offering for the VPC router appliance")
     private Long serviceOfferingId;
 
+    @Parameter(name = ApiConstants.SECONDARY_SERVICE_OFFERING_ID,
+            type = CommandType.UUID,
+            entityType = ServiceOfferingResponse.class,
+            description = "the ID of the service offering for the second VPC router appliance (in case of redundancy)")
+    private Long secondaryServiceOfferingId;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -66,7 +72,7 @@ public class CreateVPCOfferingCmd extends BaseAsyncCreateCmd {
     @Override
     public void create() throws ResourceAllocationException {
         final VpcOffering vpcOff = _vpcProvSvc.createVpcOffering(getVpcOfferingName(), getDisplayText(),
-                getSupportedServices(), getServiceProviders(), getServiceCapabilitystList(), getServiceOfferingId());
+                getSupportedServices(), getServiceProviders(), getServiceCapabilitystList(), getServiceOfferingId(), getSecondaryServiceOfferingId());
         if (vpcOff != null) {
             setEntityId(vpcOff.getId());
             setEntityUuid(vpcOff.getUuid());
@@ -121,6 +127,10 @@ public class CreateVPCOfferingCmd extends BaseAsyncCreateCmd {
 
     public Long getServiceOfferingId() {
         return serviceOfferingId;
+    }
+
+    public Long getSecondaryServiceOfferingId() {
+        return secondaryServiceOfferingId;
     }
 
     @Override

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/NetworkOfferingResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/NetworkOfferingResponse.java
@@ -74,6 +74,18 @@ public class NetworkOfferingResponse extends BaseResponse {
     @Param(description = "the ID of the service offering used by virtual router provider")
     private String serviceOfferingId;
 
+    @SerializedName(ApiConstants.SERVICE_OFFERING_NAME)
+    @Param(description = "the name of the service offering used by virtual router provider")
+    private String serviceOfferingName;
+
+    @SerializedName(ApiConstants.SECONDARY_SERVICE_OFFERING_ID)
+    @Param(description = "the ID of the secondary service offering used by virtual router provider")
+    private String secondaryServiceOfferingId;
+
+    @SerializedName(ApiConstants.SECONDARY_SERVICE_OFFERING_NAME)
+    @Param(description = "the name of the secondary service offering used by virtual router provider")
+    private String secondaryServiceOfferingName;
+
     @SerializedName(ApiConstants.SERVICE)
     @Param(description = "the list of supported services", responseObject = ServiceResponse.class)
     private List<ServiceResponse> services;
@@ -160,6 +172,18 @@ public class NetworkOfferingResponse extends BaseResponse {
 
     public void setServiceOfferingId(final String serviceOfferingId) {
         this.serviceOfferingId = serviceOfferingId;
+    }
+
+    public void setServiceOfferingName(final String serviceOfferingName) {
+        this.serviceOfferingName = serviceOfferingName;
+    }
+
+    public void setSecondaryServiceOfferingId(final String secondaryServiceOfferingId) {
+        this.secondaryServiceOfferingId = secondaryServiceOfferingId;
+    }
+
+    public void setSecondaryServiceOfferingName(final String secondaryServiceOfferingName) {
+        this.secondaryServiceOfferingName = secondaryServiceOfferingName;
     }
 
     public void setSpecifyIpRanges(final Boolean specifyIpRanges) {

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/VpcOfferingResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/VpcOfferingResponse.java
@@ -49,6 +49,22 @@ public class VpcOfferingResponse extends BaseResponse {
     @Param(description = " indicated if the offering can support region level vpc", since = "4.4")
     private Boolean supportsRegionLevelVpc;
 
+    @SerializedName(ApiConstants.SERVICE_OFFERING_ID)
+    @Param(description = "The primary system compute offering id used for the virtual router")
+    private String serviceOfferingId;
+
+    @SerializedName(ApiConstants.SERVICE_OFFERING_NAME)
+    @Param(description = "The primary system compute offering name used for the virtual router")
+    private String serviceOfferingName;
+
+    @SerializedName(ApiConstants.SECONDARY_SERVICE_OFFERING_ID)
+    @Param(description = "The secondary system compute offering id used for the virtual router")
+    private String secondaryServiceOfferingId;
+
+    @SerializedName(ApiConstants.SECONDARY_SERVICE_OFFERING_NAME)
+    @Param(description = "The secondary system compute offering name used for the virtual router")
+    private String secondaryServiceOfferingName;
+
     public void setId(final String id) {
         this.id = id;
     }
@@ -83,5 +99,37 @@ public class VpcOfferingResponse extends BaseResponse {
 
     public void setSupportsRegionLevelVpc(final Boolean supports) {
         this.supportsRegionLevelVpc = supports;
+    }
+
+    public String getServiceOfferingId() {
+        return serviceOfferingId;
+    }
+
+    public void setServiceOfferingId(final String serviceOfferingId) {
+        this.serviceOfferingId = serviceOfferingId;
+    }
+
+    public String getServiceOfferingName() {
+        return serviceOfferingName;
+    }
+
+    public void setServiceOfferingName(final String serviceOfferingName) {
+        this.serviceOfferingName = serviceOfferingName;
+    }
+
+    public String getSecondaryServiceOfferingId() {
+        return secondaryServiceOfferingId;
+    }
+
+    public void setSecondaryServiceOfferingId(final String secondaryServiceOfferingId) {
+        this.secondaryServiceOfferingId = secondaryServiceOfferingId;
+    }
+
+    public String getSecondaryServiceOfferingName() {
+        return secondaryServiceOfferingName;
+    }
+
+    public void setSecondaryServiceOfferingName(final String secondaryServiceOfferingName) {
+        this.secondaryServiceOfferingName = secondaryServiceOfferingName;
     }
 }

--- a/cosmic-core/api/src/main/java/com/cloud/network/vpc/VpcOffering.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/vpc/VpcOffering.java
@@ -36,6 +36,11 @@ public interface VpcOffering extends InternalIdentity, Identity {
     Long getServiceOfferingId();
 
     /**
+     * @return secondary service offering id used by VPC virutal router
+     */
+    Long getSecondaryServiceOfferingId();
+
+    /**
      * @return true if the offering provides a distributed router capable of one-hop forwarding
      */
     boolean supportsDistributedRouter();

--- a/cosmic-core/api/src/main/java/com/cloud/network/vpc/VpcProvisioningService.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/vpc/VpcProvisioningService.java
@@ -12,7 +12,8 @@ public interface VpcProvisioningService {
     public VpcOffering createVpcOffering(String name, String displayText, List<String> supportedServices,
                                          Map<String, List<String>> serviceProviders,
                                          Map serviceCapabilitystList,
-                                         Long serviceOfferingId);
+                                         Long serviceOfferingId,
+                                         Long secondaryServiceOfferingId);
 
     Pair<List<? extends VpcOffering>, Integer> listVpcOfferings(Long id, String name, String displayText, List<String> supportedServicesStr, Boolean isDefault, String keyword,
                                                                 String state, Long startIndex, Long pageSizeVal);

--- a/cosmic-core/api/src/main/java/com/cloud/offering/NetworkOffering.java
+++ b/cosmic-core/api/src/main/java/com/cloud/offering/NetworkOffering.java
@@ -68,6 +68,8 @@ public interface NetworkOffering extends InfrastructureEntity, InternalIdentity,
 
     Long getServiceOfferingId();
 
+    Long getSecondaryServiceOfferingId();
+
     boolean getDedicatedLB();
 
     boolean getSharedSourceNat();

--- a/cosmic-core/api/src/main/java/com/cloud/offering/ServiceOffering.java
+++ b/cosmic-core/api/src/main/java/com/cloud/offering/ServiceOffering.java
@@ -13,7 +13,7 @@ public interface ServiceOffering extends DiskOffering, InfrastructureEntity, Int
     public static final String consoleProxyDefaultOffUniqueName = "Cloud.com-ConsoleProxy";
     public static final String ssvmDefaultOffUniqueName = "Cloud.com-SecondaryStorage";
     public static final String routerDefaultOffUniqueName = "Cloud.Com-SoftwareRouter";
-    public static final String elbVmDefaultOffUniqueName = "Cloud.Com-ElasticLBVm";
+    public static final String routerDefaultSecondaryOffUniqueName = "Cloud.Com-SoftwareRouter2";
     public static final String internalLbVmDefaultOffUniqueName = "Cloud.Com-InternalLBVm";
 
     /**

--- a/cosmic-core/db-scripts/src/main/resources/db/schema-532to533.sql
+++ b/cosmic-core/db-scripts/src/main/resources/db/schema-532to533.sql
@@ -10,3 +10,8 @@ INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervis
 
 -- URL field length
 ALTER TABLE `cloud`.`template_store_ref` MODIFY COLUMN `download_url` varchar(2048);
+
+-- Redundant routers separate offering for second router
+ALTER table vpc_offerings ADD `secondary_service_offering_id` bigint(20) unsigned DEFAULT NULL COMMENT 'service offering id that a secondary virtual router is tied to';
+ALTER table network_offerings ADD `secondary_service_offering_id` bigint(20) unsigned DEFAULT NULL COMMENT 'service offering id that a secondary virtual router is tied to';
+

--- a/cosmic-core/engine/components-api/src/main/java/com/cloud/configuration/ConfigurationManager.java
+++ b/cosmic-core/engine/components-api/src/main/java/com/cloud/configuration/ConfigurationManager.java
@@ -186,7 +186,7 @@ public interface ConfigurationManager {
 
     NetworkOfferingVO createNetworkOffering(String name, String displayText, TrafficType trafficType, String tags, boolean specifyVlan, Availability availability,
                                             Integer networkRate, Map<Service, Set<Provider>> serviceProviderMap, boolean isDefault, Network.GuestType type, boolean systemOnly,
-                                            Long serviceOfferingId,
+                                            Long serviceOfferingId, Long secondaryServiceOfferingId,
                                             boolean conserveMode, Map<Service, Map<Capability, String>> serviceCapabilityMap, boolean specifyIpRanges, boolean isPersistent,
                                             Map<NetworkOffering.Detail, String> details, boolean egressDefaultPolicy, Integer maxconn, boolean enableKeepAlive);
 

--- a/cosmic-core/engine/orchestration/src/main/java/com/cloud/engine/orchestration/NetworkOrchestrator.java
+++ b/cosmic-core/engine/orchestration/src/main/java/com/cloud/engine/orchestration/NetworkOrchestrator.java
@@ -456,9 +456,10 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
 
                 //Default vpc offering without SourceNat and without LB service
                 if (_networkOfferingDao.findByUniqueName(NetworkOffering.DefaultIsolatedNetworkOfferingForVpcNetworksWithoutSourceNat) == null) {
-                    //remove LB service
+                    //remove services this VPC does not need
                     defaultVPCOffProviders.remove(Service.Lb);
                     defaultVPCOffProviders.remove(Service.SourceNat);
+                    defaultVPCOffProviders.remove(Service.StaticNat);
                     defaultVPCOffProviders.remove(Service.PortForwarding);
                     defaultVPCOffProviders.remove(Service.Gateway);
                     defaultVPCOffProviders.remove(Service.Vpn);

--- a/cosmic-core/engine/orchestration/src/main/java/com/cloud/engine/orchestration/NetworkOrchestrator.java
+++ b/cosmic-core/engine/orchestration/src/main/java/com/cloud/engine/orchestration/NetworkOrchestrator.java
@@ -408,7 +408,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 //SG enabled network offering
                 if (_networkOfferingDao.findByUniqueName(NetworkOffering.DefaultSharedNetworkOfferingWithSGService) == null) {
                     offering = _configMgr.createNetworkOffering(NetworkOffering.DefaultSharedNetworkOfferingWithSGService, "Offering for Shared Security group enabled networks",
-                            TrafficType.Guest, null, true, Availability.Optional, null, defaultSharedNetworkOfferingProviders, true, GuestType.Shared, false, null, true,
+                            TrafficType.Guest, null, true, Availability.Optional, null, defaultSharedNetworkOfferingProviders, true, GuestType.Shared, false, null, null, true,
                             null, true, false, null, false, null, true);
                     offering.setState(NetworkOffering.State.Enabled);
                     _networkOfferingDao.update(offering.getId(), offering);
@@ -417,7 +417,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 //Shared network offering with no SG service
                 if (_networkOfferingDao.findByUniqueName(NetworkOffering.DefaultSharedNetworkOffering) == null) {
                     offering = _configMgr.createNetworkOffering(NetworkOffering.DefaultSharedNetworkOffering, "Offering for Shared networks", TrafficType.Guest, null, true,
-                            Availability.Optional, null, defaultSharedNetworkOfferingProviders, true, GuestType.Shared, false, null, true, null, true, false, null, false,
+                            Availability.Optional, null, defaultSharedNetworkOfferingProviders, true, GuestType.Shared, false, null, null, true, null, true, false, null, false,
                             null, true);
                     offering.setState(NetworkOffering.State.Enabled);
                     _networkOfferingDao.update(offering.getId(), offering);
@@ -427,7 +427,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 if (_networkOfferingDao.findByUniqueName(NetworkOffering.DefaultIsolatedNetworkOfferingWithSourceNatService) == null) {
                     offering = _configMgr.createNetworkOffering(NetworkOffering.DefaultIsolatedNetworkOfferingWithSourceNatService,
                             "Offering for Isolated networks with Source Nat service enabled", TrafficType.Guest, null, false, Availability.Required, null,
-                            defaultIsolatedSourceNatEnabledNetworkOfferingProviders, true, GuestType.Isolated, false, null, true, null, false, false, null, false, null,
+                            defaultIsolatedSourceNatEnabledNetworkOfferingProviders, true, GuestType.Isolated, false, null, null, true, null, false, false, null, false, null,
                             true);
 
                     offering.setState(NetworkOffering.State.Enabled);
@@ -438,7 +438,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 if (_networkOfferingDao.findByUniqueName(NetworkOffering.DefaultIsolatedNetworkOfferingForVpcNetworks) == null) {
                     offering = _configMgr.createNetworkOffering(NetworkOffering.DefaultIsolatedNetworkOfferingForVpcNetworks,
                             "Offering for Isolated VPC networks with Source Nat service enabled", TrafficType.Guest, null, false, Availability.Optional, null,
-                            defaultVPCOffProviders, true, GuestType.Isolated, false, null, false, null, false, false, null, false, null, true);
+                            defaultVPCOffProviders, true, GuestType.Isolated, false, null, null, false, null, false, false, null, false, null, true);
                     offering.setState(NetworkOffering.State.Enabled);
                     _networkOfferingDao.update(offering.getId(), offering);
                 }
@@ -449,7 +449,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                     defaultVPCOffProviders.remove(Service.Lb);
                     offering = _configMgr.createNetworkOffering(NetworkOffering.DefaultIsolatedNetworkOfferingForVpcNetworksNoLB,
                             "Offering for Isolated VPC networks with Source Nat service enabled and LB service disabled", TrafficType.Guest, null, false, Availability.Optional,
-                            null, defaultVPCOffProviders, true, GuestType.Isolated, false, null, false, null, false, false, null, false, null, true);
+                            null, defaultVPCOffProviders, true, GuestType.Isolated, false, null, null, false, null, false, false, null, false, null, true);
                     offering.setState(NetworkOffering.State.Enabled);
                     _networkOfferingDao.update(offering.getId(), offering);
                 }
@@ -464,7 +464,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                     defaultVPCOffProviders.remove(Service.Vpn);
                     offering = _configMgr.createNetworkOffering(NetworkOffering.DefaultIsolatedNetworkOfferingForVpcNetworksWithoutSourceNat,
                             "Offering for Isolated VPC networks without Source Nat service enabled and LB service disabled", TrafficType.Guest, null, false, Availability.Optional,
-                            null, defaultVPCOffProviders, true, GuestType.Isolated, false, null, false, null, false, false, null, false, null, true);
+                            null, defaultVPCOffProviders, true, GuestType.Isolated, false, null, null, false, null, false, false, null, false, null, true);
                     offering.setState(NetworkOffering.State.Enabled);
                     _networkOfferingDao.update(offering.getId(), offering);
                 }
@@ -472,7 +472,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 //Isolated offering with source nat disabled
                 if (_networkOfferingDao.findByUniqueName(NetworkOffering.DefaultIsolatedNetworkOffering) == null) {
                     offering = _configMgr.createNetworkOffering(NetworkOffering.DefaultIsolatedNetworkOffering, "Offering for Isolated networks with no Source Nat service",
-                            TrafficType.Guest, null, true, Availability.Optional, null, defaultIsolatedNetworkOfferingProviders, true, GuestType.Isolated, false, null,
+                            TrafficType.Guest, null, true, Availability.Optional, null, defaultIsolatedNetworkOfferingProviders, true, GuestType.Isolated, false, null, null,
                             true, null, true, false, null, false, null, true);
                     offering.setState(NetworkOffering.State.Enabled);
                     _networkOfferingDao.update(offering.getId(), offering);
@@ -497,7 +497,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 if (_networkOfferingDao.findByUniqueName(NetworkOffering.DefaultIsolatedNetworkOfferingForVpcNetworksWithInternalLB) == null) {
                     offering = _configMgr.createNetworkOffering(NetworkOffering.DefaultIsolatedNetworkOfferingForVpcNetworksWithInternalLB,
                             "Offering for Isolated VPC networks with Internal Lb support", TrafficType.Guest, null, false, Availability.Optional, null, internalLbOffProviders,
-                            true, GuestType.Isolated, false, null, false, null, false, false, null, false, null, true);
+                            true, GuestType.Isolated, false, null, null, false, null, false, false, null, false, null, true);
                     offering.setState(NetworkOffering.State.Enabled);
                     offering.setInternalLb(true);
                     offering.setPublicLb(false);

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/network/vpc/VpcOfferingVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/network/vpc/VpcOfferingVO.java
@@ -38,6 +38,8 @@ public class VpcOfferingVO implements VpcOffering {
     Date created;
     @Column(name = "service_offering_id")
     Long serviceOfferingId;
+    @Column(name = "secondary_service_offering_id")
+    Long secondaryServiceOfferingId;
     @Column(name = "supports_distributed_router")
     boolean supportsDistributedRouter = false;
     @Column(name = "supports_region_level_vpc")
@@ -51,28 +53,29 @@ public class VpcOfferingVO implements VpcOffering {
         this.uuid = UUID.randomUUID().toString();
     }
 
-    public VpcOfferingVO(final String name, final String displayText, final boolean isDefault, final Long serviceOfferingId,
+    public VpcOfferingVO(final String name, final String displayText, final boolean isDefault, final Long serviceOfferingId, final Long secondaryServiceOfferingId,
                          final boolean supportsDistributedRouter, final boolean offersRegionLevelVPC,
                          final boolean redundantRouter) {
-        this(name, displayText, serviceOfferingId);
+        this(name, displayText, serviceOfferingId, secondaryServiceOfferingId);
         this.isDefault = isDefault;
         this.supportsDistributedRouter = supportsDistributedRouter;
         this.offersRegionLevelVPC = offersRegionLevelVPC;
         this.redundantRouter = redundantRouter;
     }
 
-    public VpcOfferingVO(final String name, final String displayText, final Long serviceOfferingId) {
+    public VpcOfferingVO(final String name, final String displayText, final Long serviceOfferingId, final Long secondaryServiceOfferingId) {
         this.name = name;
         this.displayText = displayText;
         this.uniqueName = name;
         this.serviceOfferingId = serviceOfferingId;
+        this.secondaryServiceOfferingId = secondaryServiceOfferingId;
         this.uuid = UUID.randomUUID().toString();
         this.state = State.Disabled;
     }
 
-    public VpcOfferingVO(final String name, final String displayText, final boolean isDefault, final Long serviceOfferingId,
+    public VpcOfferingVO(final String name, final String displayText, final boolean isDefault, final Long serviceOfferingId, final Long secondaryServiceOfferingId,
                          final boolean supportsDistributedRouter, final boolean offersRegionLevelVPC) {
-        this(name, displayText, serviceOfferingId);
+        this(name, displayText, serviceOfferingId, secondaryServiceOfferingId);
         this.isDefault = isDefault;
         this.supportsDistributedRouter = supportsDistributedRouter;
         this.offersRegionLevelVPC = offersRegionLevelVPC;
@@ -162,6 +165,18 @@ public class VpcOfferingVO implements VpcOffering {
     @Override
     public boolean getRedundantRouter() {
         return this.redundantRouter;
+    }
+
+    public Long getSecondaryServiceOfferingId() {
+        if (secondaryServiceOfferingId != null) {
+            return secondaryServiceOfferingId;
+        } else {
+            return getServiceOfferingId();
+        }
+    }
+
+    public void setSecondaryServiceOfferingId(final Long secondaryServiceOfferingId) {
+        this.secondaryServiceOfferingId = secondaryServiceOfferingId;
     }
 
     public void setState(final State state) {

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/offerings/NetworkOfferingVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/offerings/NetworkOfferingVO.java
@@ -42,6 +42,8 @@ public class NetworkOfferingVO implements NetworkOffering {
     boolean systemOnly;
     @Column(name = "service_offering_id")
     Long serviceOfferingId;
+    @Column(name = "secondary_service_offering_id")
+    Long secondaryServiceOfferingId;
     @Column(name = "tags", length = 4096)
     String tags;
     @Column(name = "default")
@@ -426,6 +428,18 @@ public class NetworkOfferingVO implements NetworkOffering {
 
     public Date getRemoved() {
         return removed;
+    }
+
+    public Long getSecondaryServiceOfferingId() {
+        if (secondaryServiceOfferingId != null) {
+            return secondaryServiceOfferingId;
+        } else {
+            return getServiceOfferingId();
+        }
+    }
+
+    public void setSecondaryServiceOfferingId(final Long secondaryServiceOfferingId) {
+        this.secondaryServiceOfferingId = secondaryServiceOfferingId;
     }
 
     @Override

--- a/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -230,6 +230,7 @@ import com.cloud.region.ha.GlobalLoadBalancerRule;
 import com.cloud.server.ResourceTag;
 import com.cloud.server.ResourceTag.ResourceObjectType;
 import com.cloud.service.ServiceOfferingVO;
+import com.cloud.service.dao.ServiceOfferingDao;
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.DiskOfferingVO;
 import com.cloud.storage.GuestOS;
@@ -318,6 +319,8 @@ public class ApiResponseHelper implements ResponseGenerator {
     private VolumeDao _volumeDao;
     @Inject
     private DataStoreManager _dataStoreMgr;
+    @Inject
+    ServiceOfferingDao _serviceOfferingDao;
     @Inject
     private SnapshotDataStoreDao _snapshotStoreDao;
     @Inject
@@ -1815,10 +1818,17 @@ public class ApiResponseHelper implements ResponseGenerator {
             so = ApiDBUtils.findDefaultRouterServiceOffering();
         }
         if (so != null) {
-            final ServiceOffering soffering = ApiDBUtils.findServiceOfferingById(so);
-            if (soffering != null) {
-                response.setServiceOfferingId(soffering.getUuid());
+            final ServiceOffering serviceOffering = ApiDBUtils.findServiceOfferingById(so);
+            if (serviceOffering != null) {
+                response.setServiceOfferingId(serviceOffering.getUuid());
+                response.setServiceOfferingName(serviceOffering.getName());
             }
+        }
+
+        ServiceOffering secondaryServiceOffering = _serviceOfferingDao.findById(offering.getSecondaryServiceOfferingId());
+        if (secondaryServiceOffering != null) {
+            response.setSecondaryServiceOfferingId(secondaryServiceOffering.getUuid());
+            response.setSecondaryServiceOfferingName(secondaryServiceOffering.getName());
         }
 
         if (offering.getGuestType() != null) {
@@ -2508,7 +2518,16 @@ public class ApiResponseHelper implements ResponseGenerator {
         response.setState(offering.getState().name());
         response.setSupportsDistributedRouter(offering.supportsDistributedRouter());
         response.setSupportsRegionLevelVpc(offering.offersRegionLevelVPC());
-
+        ServiceOffering serviceOffering = _serviceOfferingDao.findById(offering.getServiceOfferingId());
+        if (serviceOffering != null) {
+            response.setServiceOfferingId(serviceOffering.getUuid());
+            response.setServiceOfferingName(serviceOffering.getName());
+        }
+        ServiceOffering secondaryServiceOffering = _serviceOfferingDao.findById(offering.getSecondaryServiceOfferingId());
+        if (secondaryServiceOffering != null) {
+            response.setSecondaryServiceOfferingId(secondaryServiceOffering.getUuid());
+            response.setSecondaryServiceOfferingName(secondaryServiceOffering.getName());
+        }
         final Map<Service, Set<Provider>> serviceProviderMap = ApiDBUtils.listVpcOffServices(offering.getId());
         final List<ServiceResponse> serviceResponses = getServiceResponses(serviceProviderMap);
 

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
@@ -39,6 +39,7 @@ import com.cloud.network.dao.UserIpv6AddressDao;
 import com.cloud.network.router.VirtualRouter.RedundantState;
 import com.cloud.network.router.VirtualRouter.Role;
 import com.cloud.network.router.deployment.RouterDeploymentDefinition;
+import com.cloud.network.vpc.Vpc;
 import com.cloud.network.vpn.Site2SiteVpnManager;
 import com.cloud.offering.NetworkOffering;
 import com.cloud.resource.ResourceManager;
@@ -422,7 +423,16 @@ public class NetworkHelperImpl implements NetworkHelper {
             throws InsufficientAddressCapacityException, InsufficientServerCapacityException, InsufficientCapacityException, StorageUnavailableException,
             ResourceUnavailableException {
 
-        final ServiceOfferingVO routerOffering = _serviceOfferingDao.findById(routerDeploymentDefinition.getServiceOfferingId());
+        final Vpc vpc = routerDeploymentDefinition.getVpc();
+        final List<DomainRouterVO> routers = _routerDao.listByVpcId(vpc.getId());
+
+        ServiceOfferingVO routerOffering;
+        if (vpc.isRedundant() && routers.size() % 2 == 0) {
+            routerOffering = _serviceOfferingDao.findById(routerDeploymentDefinition.getSecondaryServiceOfferingId());
+        } else {
+            routerOffering = _serviceOfferingDao.findById(routerDeploymentDefinition.getServiceOfferingId());
+        }
+
         _serviceOfferingDao.loadDetails(routerOffering);
         final String serviceofferingHypervisor = routerOffering.getDetail("hypervisor");
         if (serviceofferingHypervisor != null && !serviceofferingHypervisor.isEmpty()) {

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -447,6 +447,11 @@ public class VirtualNetworkApplianceManagerImpl extends ManagerBase implements V
         final List<ServiceOfferingVO> offerings = _serviceOfferingDao.createSystemServiceOfferings("System Offering For Software Router",
                 ServiceOffering.routerDefaultOffUniqueName, 1, _routerRamSize, _routerCpuMHz, null,
                 null, true, null, ProvisioningType.THIN, true, null, true, VirtualMachine.Type.DomainRouter, true);
+
+        final List<ServiceOfferingVO> SecondaryOfferings = _serviceOfferingDao.createSystemServiceOfferings("System Offering For Secundary Software Router",
+                ServiceOffering.routerDefaultSecondaryOffUniqueName, 1, _routerRamSize, _routerCpuMHz, null,
+                null, true, null, ProvisioningType.THIN, true, null, true, VirtualMachine.Type.DomainRouter, true);
+
         // this can sometimes happen, if DB is manually or programmatically manipulated
         if (offerings == null || offerings.size() < 2) {
             final String msg = "Data integrity problem : System Offering For Software router VM has been removed?";

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/deployment/RouterDeploymentDefinition.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/deployment/RouterDeploymentDefinition.java
@@ -394,9 +394,9 @@ public class RouterDeploymentDefinition {
     }
 
     protected void findSecondaryServiceOfferingId() {
-        serviceOfferingId = networkOfferingDao.findById(guestNetwork.getNetworkOfferingId()).getSecondaryServiceOfferingId();
-        if (serviceOfferingId == null) {
-            findServiceOfferingId();
+        secondaryServiceOfferingId = networkOfferingDao.findById(guestNetwork.getNetworkOfferingId()).getSecondaryServiceOfferingId();
+        if (secondaryServiceOfferingId == null) {
+            secondaryServiceOfferingId = serviceOfferingId;
         }
     }
 

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/deployment/RouterDeploymentDefinition.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/deployment/RouterDeploymentDefinition.java
@@ -86,6 +86,7 @@ public class RouterDeploymentDefinition {
     protected DeploymentPlan plan;
     protected List<DomainRouterVO> routers = new ArrayList<>();
     protected Long serviceOfferingId;
+    protected Long secondaryServiceOfferingId;
     protected Long tableLockId;
     protected boolean isPublicNetwork;
     protected boolean isGateway = true;
@@ -100,6 +101,14 @@ public class RouterDeploymentDefinition {
 
     public Long getServiceOfferingId() {
         return serviceOfferingId;
+    }
+
+    public Long getSecondaryServiceOfferingId() {
+        if (secondaryServiceOfferingId != null) {
+            return secondaryServiceOfferingId;
+        } else {
+            return getServiceOfferingId();
+        }
     }
 
     public Vpc getVpc() {
@@ -358,6 +367,7 @@ public class RouterDeploymentDefinition {
         if (getNumberOfRoutersToDeploy() > 0 && prepareDeployment()) {
             findVirtualProvider();
             findServiceOfferingId();
+            findSecondaryServiceOfferingId();
             findSourceNatIP();
             deployAllVirtualRouters();
         }
@@ -380,6 +390,13 @@ public class RouterDeploymentDefinition {
         serviceOfferingId = networkOfferingDao.findById(guestNetwork.getNetworkOfferingId()).getServiceOfferingId();
         if (serviceOfferingId == null) {
             findDefaultServiceOfferingId();
+        }
+    }
+
+    protected void findSecondaryServiceOfferingId() {
+        serviceOfferingId = networkOfferingDao.findById(guestNetwork.getNetworkOfferingId()).getSecondaryServiceOfferingId();
+        if (serviceOfferingId == null) {
+            findServiceOfferingId();
         }
     }
 

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/deployment/VpcRouterDeploymentDefinition.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/deployment/VpcRouterDeploymentDefinition.java
@@ -190,6 +190,14 @@ public class VpcRouterDeploymentDefinition extends RouterDeploymentDefinition {
     }
 
     @Override
+    protected void findSecondaryServiceOfferingId() {
+        secondaryServiceOfferingId = vpcOffDao.findById(vpc.getVpcOfferingId()).getSecondaryServiceOfferingId();
+        if (secondaryServiceOfferingId == null) {
+            secondaryServiceOfferingId = serviceOfferingId;
+        }
+    }
+
+    @Override
     protected void deployAllVirtualRouters() throws ConcurrentOperationException, InsufficientCapacityException,
             ResourceUnavailableException {
 

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -229,7 +229,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
                     final Map<Service, Set<Provider>> svcProviderMap = getServiceSetMap(DEFAULT_SERVICES);
                     createVpcOffering(VpcOffering.defaultVPCOfferingName, VpcOffering.defaultVPCOfferingName, svcProviderMap,
-                            true, State.Enabled, null, false, false, false);
+                            true, State.Enabled, null, null, false, false, false);
                 }
 
                 if (_vpcOffDao.findByUniqueName(VpcOffering.defaultRemoteGatewayVPCOfferingName) == null) {
@@ -237,7 +237,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
                     final Map<Service, Set<Provider>> svcProviderMap = getServiceSetMap(REMOTE_GATEWAY_SERVICES);
                     createVpcOffering(VpcOffering.defaultRemoteGatewayVPCOfferingName, VpcOffering.defaultRemoteGatewayVPCOfferingName, svcProviderMap,
-                            true, State.Enabled, null, false, false, false);
+                            true, State.Enabled, null, null, false, false, false);
                 }
 
                 if (_vpcOffDao.findByUniqueName(VpcOffering.defaultRemoteGatewayWithVPNVPCOfferingName) == null) {
@@ -245,7 +245,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
                     final Map<Service, Set<Provider>> svcProviderMap = getServiceSetMap(REMOTE_GATEWAY_WITH_VPN_SERVICES);
                     createVpcOffering(VpcOffering.defaultRemoteGatewayWithVPNVPCOfferingName, VpcOffering.defaultRemoteGatewayWithVPNVPCOfferingName, svcProviderMap,
-                            true, State.Enabled, null, false, false, false);
+                            true, State.Enabled, null, null, false, false, false);
                 }
 
                 if (_vpcOffDao.findByUniqueName(VpcOffering.defaultInternalVPCOfferingName) == null) {
@@ -253,7 +253,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
                     final Map<Service, Set<Provider>> svcProviderMap = getServiceSetMap(INTERNAL_VPC_SERVICES);
                     createVpcOffering(VpcOffering.defaultInternalVPCOfferingName, VpcOffering.defaultInternalVPCOfferingName, svcProviderMap,
-                            true, State.Enabled, null, false, false, false);
+                            true, State.Enabled, null, null, false, false, false);
                 }
 
                 if (_vpcOffDao.findByUniqueName(VpcOffering.redundantVPCOfferingName) == null) {
@@ -261,7 +261,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
                     final Map<Service, Set<Provider>> svcProviderMap = getServiceSetMap(DEFAULT_SERVICES);
                     createVpcOffering(VpcOffering.redundantVPCOfferingName, VpcOffering.redundantVPCOfferingName, svcProviderMap,
-                            true, State.Enabled, null, false, false, true);
+                            true, State.Enabled, null, null, false, false, true);
                 }
             }
         });
@@ -354,15 +354,14 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     @DB
     private VpcOffering createVpcOffering(final String name, final String displayText,
                                           final Map<Network.Service, Set<Network.Provider>> svcProviderMap,
-                                          final boolean isDefault, final State state, final Long serviceOfferingId, final boolean supportsDistributedRouter,
-                                          final boolean offersRegionLevelVPC,
-                                          final boolean redundantRouter) {
+                                          final boolean isDefault, final State state, final Long serviceOfferingId, final Long secondaryServiceOfferingId,
+                                          final boolean supportsDistributedRouter, final boolean offersRegionLevelVPC, final boolean redundantRouter) {
 
         return Transaction.execute(new TransactionCallback<VpcOffering>() {
             @Override
             public VpcOffering doInTransaction(final TransactionStatus status) {
                 // create vpc offering object
-                VpcOfferingVO offering = new VpcOfferingVO(name, displayText, isDefault, serviceOfferingId,
+                VpcOfferingVO offering = new VpcOfferingVO(name, displayText, isDefault, serviceOfferingId, secondaryServiceOfferingId,
                         supportsDistributedRouter, offersRegionLevelVPC, redundantRouter);
 
                 if (state != null) {
@@ -409,7 +408,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             create = true)
     public VpcOffering createVpcOffering(final String name, final String displayText,
                                          final List<String> supportedServices, final Map<String, List<String>> serviceProviders,
-                                         final Map serviceCapabilitystList, final Long serviceOfferingId) {
+                                         final Map serviceCapabilitystList, final Long serviceOfferingId, final Long secondaryServiceOfferingId) {
 
         final Map<Network.Service, Set<Network.Provider>> svcProviderMap = new HashMap<>();
         final Set<Network.Provider> defaultProviders = new HashSet<>();
@@ -474,9 +473,8 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         final boolean supportsDistributedRouter = isVpcOfferingSupportsDistributedRouter(serviceCapabilitystList);
         final boolean offersRegionLevelVPC = isVpcOfferingForRegionLevelVpc(serviceCapabilitystList);
         final boolean redundantRouter = isVpcOfferingRedundantRouter(serviceCapabilitystList);
-        final VpcOffering offering = createVpcOffering(name, displayText, svcProviderMap, false, null, serviceOfferingId,
-                supportsDistributedRouter, offersRegionLevelVPC,
-                redundantRouter);
+        final VpcOffering offering = createVpcOffering(name, displayText, svcProviderMap, false, null, serviceOfferingId, secondaryServiceOfferingId,
+                supportsDistributedRouter, offersRegionLevelVPC, redundantRouter);
         CallContext.current().setEventDetails(" Id: " + offering.getId() + " Name: " + name);
 
         return offering;

--- a/cosmic-core/server/src/test/java/com/cloud/network/router/deployment/RouterDeploymentDefinitionTest.java
+++ b/cosmic-core/server/src/test/java/com/cloud/network/router/deployment/RouterDeploymentDefinitionTest.java
@@ -93,6 +93,7 @@ public class RouterDeploymentDefinitionTest extends RouterDeploymentDefinitionTe
         deployment.serviceOfferingId = null;
         assertNull(deployment.getServiceOfferingId());
         deployment.serviceOfferingId = OFFERING_ID;
+        deployment.secondaryServiceOfferingId = OFFERING_ID;
         assertEquals(OFFERING_ID, deployment.getServiceOfferingId().longValue());
         assertNotNull(deployment.getRouters());
         assertNotNull(deployment.getGuestNetwork());
@@ -641,9 +642,11 @@ public class RouterDeploymentDefinitionTest extends RouterDeploymentDefinitionTe
         when(mockNw.getNetworkOfferingId()).thenReturn(OFFERING_ID);
         when(mockNetworkOfferingDao.findById(OFFERING_ID)).thenReturn(mockNwOfferingVO);
         when(mockNwOfferingVO.getServiceOfferingId()).thenReturn(OFFERING_ID);
+        when(mockNwOfferingVO.getSecondaryServiceOfferingId()).thenReturn(OFFERING_ID);
 
         // Execute
         deployment.findServiceOfferingId();
+        deployment.findSecondaryServiceOfferingId();
 
         // Assert
         assertEquals("Service offering id not matching the one associated with network offering",
@@ -657,11 +660,13 @@ public class RouterDeploymentDefinitionTest extends RouterDeploymentDefinitionTe
         when(mockNw.getNetworkOfferingId()).thenReturn(OFFERING_ID);
         when(mockNetworkOfferingDao.findById(OFFERING_ID)).thenReturn(mockNwOfferingVO);
         when(mockNwOfferingVO.getServiceOfferingId()).thenReturn(null);
+        when(mockNwOfferingVO.getSecondaryServiceOfferingId()).thenReturn(null);
         when(mockServiceOfferingDao.findDefaultSystemOffering(Matchers.anyString(), Matchers.anyBoolean())).thenReturn(mockSvcOfferingVO);
         when(mockSvcOfferingVO.getId()).thenReturn(DEFAULT_OFFERING_ID);
 
         // Execute
         deployment.findServiceOfferingId();
+        deployment.findSecondaryServiceOfferingId();
 
         // Assert
         assertEquals("Since there is no service offering associated with network offering, offering id should have matched default one",
@@ -781,6 +786,7 @@ public class RouterDeploymentDefinitionTest extends RouterDeploymentDefinitionTe
         doReturn(passPreparation).when(deploymentUT).prepareDeployment();
         doNothing().when(deploymentUT).findVirtualProvider();
         doNothing().when(deploymentUT).findServiceOfferingId();
+        doNothing().when(deploymentUT).findSecondaryServiceOfferingId();
         doNothing().when(deploymentUT).findSourceNatIP();
         doNothing().when(deploymentUT).deployAllVirtualRouters();
 
@@ -798,6 +804,7 @@ public class RouterDeploymentDefinitionTest extends RouterDeploymentDefinitionTe
         }
         verify(deploymentUT, times(proceedToDeployment)).findVirtualProvider();
         verify(deploymentUT, times(proceedToDeployment)).findServiceOfferingId();
+        verify(deploymentUT, times(proceedToDeployment)).findSecondaryServiceOfferingId();
         verify(deploymentUT, times(proceedToDeployment)).findSourceNatIP();
         verify(deploymentUT, times(proceedToDeployment)).deployAllVirtualRouters();
     }

--- a/cosmic-core/server/src/test/java/com/cloud/networkoffering/CreateNetworkOfferingTest.java
+++ b/cosmic-core/server/src/test/java/com/cloud/networkoffering/CreateNetworkOfferingTest.java
@@ -102,7 +102,7 @@ public class CreateNetworkOfferingTest extends TestCase {
     public void createSharedNtwkOffWithVlan() {
         final NetworkOfferingVO off =
                 configMgr.createNetworkOffering("shared", "shared", TrafficType.Guest, null, true, Availability.Optional, 200, null, false, Network.GuestType.Shared, false,
-                        null, false, null, true, false, null, false, null, true);
+                        null, null, false, null, true, false, null, false, null, true);
         assertNotNull("Shared network offering with specifyVlan=true failed to create ", off);
     }
 
@@ -110,7 +110,7 @@ public class CreateNetworkOfferingTest extends TestCase {
     public void createSharedNtwkOffWithNoVlan() {
         final NetworkOfferingVO off =
                 configMgr.createNetworkOffering("shared", "shared", TrafficType.Guest, null, false, Availability.Optional, 200, null, false, Network.GuestType.Shared,
-                        false, null, false, null, true, false, null, false, null, true);
+                        false, null, null,  false, null, true, false, null, false, null, true);
         assertNull("Shared network offering with specifyVlan=false was created", off);
     }
 
@@ -118,7 +118,7 @@ public class CreateNetworkOfferingTest extends TestCase {
     public void createSharedNtwkOffWithSpecifyIpRanges() {
         final NetworkOfferingVO off =
                 configMgr.createNetworkOffering("shared", "shared", TrafficType.Guest, null, true, Availability.Optional, 200, null, false, Network.GuestType.Shared, false,
-                        null, false, null, true, false, null, false, null, true);
+                        null, null, false, null, true, false, null, false, null, true);
 
         assertNotNull("Shared network offering with specifyIpRanges=true failed to create ", off);
     }
@@ -127,7 +127,7 @@ public class CreateNetworkOfferingTest extends TestCase {
     public void createSharedNtwkOffWithoutSpecifyIpRanges() {
         final NetworkOfferingVO off =
                 configMgr.createNetworkOffering("shared", "shared", TrafficType.Guest, null, true, Availability.Optional, 200, null, false, Network.GuestType.Shared,
-                        false, null, false, null, false, false, null, false, null, true);
+                        false, null, null, false, null, false, false, null, false, null, true);
         assertNull("Shared network offering with specifyIpRanges=false was created", off);
     }
 
@@ -140,7 +140,7 @@ public class CreateNetworkOfferingTest extends TestCase {
         serviceProviderMap.put(Network.Service.SourceNat, vrProvider);
         final NetworkOfferingVO off =
                 configMgr.createNetworkOffering("isolated", "isolated", TrafficType.Guest, null, false, Availability.Optional, 200, serviceProviderMap, false,
-                        Network.GuestType.Isolated, false, null, false, null, false, false, null, false, null, true);
+                        Network.GuestType.Isolated, false, null, null, false, null, false, false, null, false, null, true);
 
         assertNotNull("Isolated network offering with specifyIpRanges=false failed to create ", off);
     }
@@ -153,7 +153,7 @@ public class CreateNetworkOfferingTest extends TestCase {
         serviceProviderMap.put(Network.Service.SourceNat, vrProvider);
         final NetworkOfferingVO off =
                 configMgr.createNetworkOffering("isolated", "isolated", TrafficType.Guest, null, true, Availability.Optional, 200, serviceProviderMap, false,
-                        Network.GuestType.Isolated, false, null, false, null, false, false, null, false, null, true);
+                        Network.GuestType.Isolated, false, null, null, false, null, false, false, null, false, null, true);
         assertNotNull("Isolated network offering with specifyVlan=true wasn't created", off);
     }
 
@@ -165,7 +165,7 @@ public class CreateNetworkOfferingTest extends TestCase {
         serviceProviderMap.put(Network.Service.SourceNat, vrProvider);
         final NetworkOfferingVO off =
                 configMgr.createNetworkOffering("isolated", "isolated", TrafficType.Guest, null, false, Availability.Optional, 200, serviceProviderMap, false,
-                        Network.GuestType.Isolated, false, null, false, null, true, false, null, false, null, true);
+                        Network.GuestType.Isolated, false, null, null, false, null, true, false, null, false, null, true);
         assertNull("Isolated network offering with specifyIpRanges=true and source nat service enabled, was created", off);
     }
 
@@ -176,7 +176,7 @@ public class CreateNetworkOfferingTest extends TestCase {
         final Set<Network.Provider> vrProvider = new HashSet<>();
         final NetworkOfferingVO off =
                 configMgr.createNetworkOffering("isolated", "isolated", TrafficType.Guest, null, false, Availability.Optional, 200, serviceProviderMap, false,
-                        Network.GuestType.Isolated, false, null, false, null, true, false, null, false, null, true);
+                        Network.GuestType.Isolated, false, null, null, false, null, true, false, null, false, null, true);
         assertNotNull("Isolated network offering with specifyIpRanges=true and with no sourceNatService, failed to create", off);
     }
 
@@ -193,7 +193,7 @@ public class CreateNetworkOfferingTest extends TestCase {
         serviceProviderMap.put(Network.Service.Lb, vrProvider);
         final NetworkOfferingVO off =
                 configMgr.createNetworkOffering("isolated", "isolated", TrafficType.Guest, null, true, Availability.Optional, 200, serviceProviderMap, false,
-                        Network.GuestType.Isolated, false, null, false, null, false, false, null, false, null, true);
+                        Network.GuestType.Isolated, false, null, null, false, null, false, false, null, false, null, true);
         // System.out.println("Creating Vpc Network Offering");
         assertNotNull("Vpc Isolated network offering with Vpc provider ", off);
     }

--- a/cosmic-core/server/src/test/java/com/cloud/vpc/MockConfigurationManagerImpl.java
+++ b/cosmic-core/server/src/test/java/com/cloud/vpc/MockConfigurationManagerImpl.java
@@ -415,7 +415,7 @@ public class MockConfigurationManagerImpl extends ManagerBase implements Configu
                                                    final Availability availability,
                                                    final Integer networkRate, final Map<Service, Set<Provider>> serviceProviderMap, final boolean isDefault, final GuestType
                                                            type, final boolean systemOnly,
-                                                   final Long serviceOfferingId,
+                                                   final Long serviceOfferingId, final Long secondaryServiceOfferingId,
                                                    final boolean conserveMode, final Map<Service, Map<Capability, String>> serviceCapabilityMap, final boolean specifyIpRanges,
                                                    final boolean isPersistent,
                                                    final Map<NetworkOffering.Detail, String> details, final boolean egressDefaultPolicy, final Integer maxconn, final boolean


### PR DESCRIPTION
This introduces the ability to have a separate service offering for each of the routers in a redundant pair. It makes it possible to use different tags for each, giving flexibility and control over their deployment destination.

Networks and VPCs that have a single router still have just one offering. Service offering details have been added to the corresponding API calls and their responses. The UI has also been enhanced to display this info.
