### PR TITLE
Configure OWASP dependency checker for sonar collection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <cs.target.dir>target</cs.target.dir>
+        <cs.dependency.check.report.dir>${cosmic.dir}/target/dependency-check</cs.dependency.check.report.dir>
 
         <coverage.reports.dir>${cosmic.dir}/target/coverage-reports</coverage.reports.dir>
         <unit.tests.report>${coverage.reports.dir}/jacoco-ut.exec</unit.tests.report>
@@ -679,6 +680,7 @@
             <properties>
                 <maven.test.failure.ignore>true</maven.test.failure.ignore>
 
+                <sonar.dependencyCheck.reportPath>${cs.dependency.check.report.dir}/dependency-check-report.xml</sonar.dependencyCheck.reportPath>
                 <sonar.jacoco.reportPath>${unit.tests.report}</sonar.jacoco.reportPath>
                 <sonar.jacoco.itReportPath>${integration.tests.report}</sonar.jacoco.itReportPath>
                 <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
@@ -836,13 +838,10 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>aggregate</goal>
-                                </goals>
-                            </execution>
-                        </executions>
+                        <configuration>
+                            <format>XML</format>
+                            <outputDirectory>${cs.dependency.check.report.dir}</outputDirectory>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Required change for https://github.com/MissionCriticalCloud/organization_utils/pull/103

