### PR TITLE
UI: Improve routerVM tabs so Domain Admins can operate them

### DIFF
--- a/cosmic-client/src/main/webapp/css/cloudstack3.css
+++ b/cosmic-client/src/main/webapp/css/cloudstack3.css
@@ -1304,6 +1304,10 @@ div.panel div.list-view div.fixed-header {
     left: 25px !important;
 }
 
+.detail-view div#details-tab-virtualRoutersVPC div.fixed-header {
+    left: 22px !important;
+}
+
 .detail-view div.list-view div.fixed-header table {
     width: 100% !important;
 }

--- a/cosmic-client/src/main/webapp/index.html
+++ b/cosmic-client/src/main/webapp/index.html
@@ -1797,7 +1797,6 @@
         <script type="text/javascript" src="scripts/ui-custom/securityRules.js"></script>
         <script type="text/javascript" src="scripts/ui-custom/vpc.js"></script>
         <script type="text/javascript" src="scripts/vpc.js"></script>
-        <script type="text/javascript" src="scripts/network.js"></script>
         <script type="text/javascript" src="scripts/ui-custom/recurringSnapshots.js"></script>
         <script type="text/javascript" src="scripts/ui-custom/uploadVolume.js"></script>
         <script type="text/javascript" src="scripts/storage.js"></script>
@@ -1811,6 +1810,7 @@
         <script type="text/javascript" src="scripts/ui-custom/physicalResources.js"></script>
         <script type="text/javascript" src="scripts/ui-custom/zoneWizard.js"></script>
         <script type="text/javascript" src="scripts/system.js"></script>
+        <script type="text/javascript" src="scripts/network.js"></script>
         <script type="text/javascript" src="scripts/domains.js"></script>
         <script type="text/javascript" src="scripts/docs.js"></script>
         <script type="text/javascript" src="scripts/vm_snapshots.js"></script>

--- a/cosmic-client/src/main/webapp/scripts/network.js
+++ b/cosmic-client/src/main/webapp/scripts/network.js
@@ -894,7 +894,7 @@
 
                         tabFilter: function (args) {
                             var hiddenTabs = [];
-                            if (!isAdmin() && !isDomainAdmin()) hiddenTabs.push("router");
+                            if (!isAdmin() && !isDomainAdmin()) hiddenTabs.push("virtualRoutersVPC");
                             return hiddenTabs;
                         },
 
@@ -1024,81 +1024,6 @@
                                     });
                                 }
                             },
-                            router: {
-                                title: 'label.vpc.router.details',
-                                fields: [{
-                                    name: {
-                                        label: 'label.name'
-                                    }
-                                }, {
-                                    state: {
-                                        label: 'label.state'
-                                    },
-                                    hostname: {
-                                        label: 'label.host'
-                                    },
-                                    linklocalip: {
-                                        label: 'label.linklocal.ip'
-                                    },
-                                    isredundantrouter: {
-                                        label: 'label.redundant.router',
-                                        converter: function (booleanValue) {
-                                            if (booleanValue == true) {
-                                                return "Yes";
-                                            }
-                                            return "No";
-                                        }
-                                    },
-                                    redundantstate: {
-                                        label: 'label.redundant.state'
-                                    },
-                                    id: {
-                                        label: 'label.id'
-                                    },
-                                    serviceofferingname: {
-                                        label: 'label.service.offering'
-                                    },
-                                    zonename: {
-                                        label: 'label.zone'
-                                    },
-                                    gateway: {
-                                        label: 'label.gateway'
-                                    },
-                                    publicip: {
-                                        label: 'label.public.ip'
-                                    },
-                                    guestipaddress: {
-                                        label: 'label.guest.ip'
-                                    },
-                                    dns1: {
-                                        label: 'label.dns'
-                                    },
-                                    account: {
-                                        label: 'label.account'
-                                    },
-                                    domain: {
-                                        label: 'label.domain'
-                                    }
-                                }],
-
-                                dataProvider: function (args) {
-                                    $.ajax({
-                                        url: createURL("listRouters&listAll=true&vpcid=" + args.context.vpc[0].id),
-                                        dataType: "json",
-                                        async: true,
-                                        success: function (json) {
-                                            for (var i = 0; i < json.listroutersresponse.router.length; i++) {
-                                                var item = json.listroutersresponse.router[i];
-
-                                                args.response.success({
-                                                    actionFilter: cloudStack.sections.system.routerActionFilter,
-                                                    data: item
-                                                });
-                                            }
-                                        }
-                                    });
-                                }
-                            },
                             staticRoutes: {
                                 title: 'label.route.table',
                                 custom: function (args) {
@@ -1197,6 +1122,10 @@
                                         }
                                     });
                                 }
+                            },
+                            virtualRoutersVPC: {
+                                title: 'label.virtual.routers',
+                                listView: cloudStack.sections.system.subsections.virtualRouters.sections.routerNoGroup.listView
                             }
                         }
                     }

--- a/cosmic-client/src/main/webapp/scripts/network.js
+++ b/cosmic-client/src/main/webapp/scripts/network.js
@@ -1969,6 +1969,9 @@
                                 hiddenTabs.push('egressRules');
                             }
 
+                            if (!(isAdmin() || isDomainAdmin())) {
+                                hiddenTabs.push("virtualRouters");
+                            }
                             return hiddenTabs;
                         },
 
@@ -2199,7 +2202,6 @@
                                     });
                                 }
                             },
-
                             egressRules: {
                                 title: 'label.egress.rules',
                                 custom: function (args) {
@@ -2439,6 +2441,10 @@
                                     });
                                 }
                             },
+                            virtualRouters: {
+                                title: "label.virtual.routers",
+                                listView: cloudStack.sections.system.subsections.virtualRouters.sections.routerNoGroup.listView
+                            }
                         }
                     }
                 }

--- a/cosmic-client/src/main/webapp/scripts/system.js
+++ b/cosmic-client/src/main/webapp/scripts/system.js
@@ -5952,6 +5952,12 @@
                                             networkid: args.context.networks[0].id
                                         })
                                     }
+                                    if ("vpc" in args.context) {
+                                        $.extend(data2, {
+                                            vpcid: args.context.vpc[0].id
+                                        })
+                                    }
+
                                 }
 
                                 var routers = [];

--- a/cosmic-client/src/main/webapp/scripts/system.js
+++ b/cosmic-client/src/main/webapp/scripts/system.js
@@ -5947,6 +5947,11 @@
                                             domainid: args.context.routerGroupByAccount[0].domainid
                                         })
                                     }
+                                    if ("networks" in args.context) {
+                                        $.extend(data2, {
+                                            networkid: args.context.networks[0].id
+                                        })
+                                    }
                                 }
 
                                 var routers = [];

--- a/cosmic-client/src/main/webapp/scripts/system.js
+++ b/cosmic-client/src/main/webapp/scripts/system.js
@@ -13651,13 +13651,13 @@
 
         if (jsonObj.state == 'Running') {
             allowedActions.push("stop");
-
             allowedActions.push("restart");
             allowedActions.push("remove");
-            allowedActions.push("viewConsole");
 
-            if (isAdmin())
+            if (isAdmin()) {
+                allowedActions.push("viewConsole");
                 allowedActions.push("migrate");
+            }
         } else if (jsonObj.state == 'Stopped') {
             allowedActions.push("start");
 


### PR DESCRIPTION
The router tabs are now consistent in System, VPC and Networks pages. There was no way to see the routers for the Classic Networks before, this is now added. Also, operations on the routers, like Stop/Start could only be done from the System tab. Now it can be done right away from the Network tabs.

This allows Domain Admins to control their own routers. They can Stop/Start/Reboot/Delete their routers from the Network tab (and of course Restart+CLeanup the VPC also recreating the routers). This permission they already had via the API. It should provide enough permissions to not need a root admin account.

The only difference compared to the options in the System page are Live Migrates and ability to see the Console. Both of which are not allowed for Domain Admins, so these buttons have been removed.

Isolated Network:
![image](https://cloud.githubusercontent.com/assets/1630096/23581880/37b5379c-011e-11e7-8105-40732c785a87.png)

VPC Network:
![image](https://cloud.githubusercontent.com/assets/1630096/23581860/fb41069c-011d-11e7-9896-c93a67e284ad.png)

Root Admin:
![image](https://cloud.githubusercontent.com/assets/1630096/23581872/1a1c7d12-011e-11e7-8401-066a4220be21.png)

Domain Admin:
![image](https://cloud.githubusercontent.com/assets/1630096/23581921/e75a0d9e-011e-11e7-9fa9-61c4f0dc70aa.png)

Private Network:
This shows all the routers that have a private gateway plugged into this private network (and that the user is allowed to see).
![image](https://cloud.githubusercontent.com/assets/1630096/23581892/610d2136-011e-11e7-8cc4-b4bb78469170.png)

This work is based on ACS PR 1980 (classic router tab) and extended for VPCs and Private Networks.
