### PR TITLE
Remove option to make VPC redundant via Restart+Cleanup

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
@@ -33,7 +33,6 @@ public class ApiConstants {
     public static final String IP6_CIDR = "ip6cidr";
     public static final String CIDR_LIST = "cidrlist";
     public static final String CLEANUP = "cleanup";
-    public static final String MAKEREDUNDANTE = "makeredundant";
     public static final String CLUSTER_ID = "clusterid";
     public static final String CLUSTER_NAME = "clustername";
     public static final String CLUSTER_TYPE = "clustertype";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/RestartVPCCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/RestartVPCCmd.java
@@ -36,9 +36,6 @@ public class RestartVPCCmd extends BaseAsyncCmd {
     @Parameter(name = ApiConstants.CLEANUP, type = CommandType.BOOLEAN, required = false, description = "Cleanup old network elements (defaults to true)")
     private Boolean cleanup;
 
-    @Parameter(name = ApiConstants.MAKEREDUNDANTE, type = CommandType.BOOLEAN, required = false, description = "Turn a single VPC into a redundant one (defaults to false).")
-    private Boolean makeredundant;
-
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -46,7 +43,7 @@ public class RestartVPCCmd extends BaseAsyncCmd {
     @Override
     public void execute() {
         try {
-            final boolean result = _vpcService.restartVpc(getId(), getCleanup(), getMakeredundant());
+            final boolean result = _vpcService.restartVpc(getId(), getCleanup());
             if (result) {
                 final SuccessResponse response = new SuccessResponse(getCommandName());
                 setResponseObject(response);
@@ -92,13 +89,6 @@ public class RestartVPCCmd extends BaseAsyncCmd {
             return cleanup;
         }
         return true;
-    }
-
-    public Boolean getMakeredundant() {
-        if (makeredundant != null) {
-            return makeredundant;
-        }
-        return false;
     }
 
     @Override

--- a/cosmic-core/api/src/main/java/com/cloud/network/vpc/VpcService.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/vpc/VpcService.java
@@ -112,11 +112,10 @@ public interface VpcService {
      *
      * @param id
      * @param cleanUp
-     * @param makeredundant
      * @return
      * @throws InsufficientCapacityException
      */
-    boolean restartVpc(long id, boolean cleanUp, boolean makeredundant) throws ConcurrentOperationException, ResourceUnavailableException, InsufficientCapacityException;
+    boolean restartVpc(long id, boolean cleanUp) throws ConcurrentOperationException, ResourceUnavailableException, InsufficientCapacityException;
 
     /**
      * Returns a Private gateway found in the VPC by id


### PR DESCRIPTION
PR #300 provides a far better way to change service offerings of a VPC, including making it redundant. This legacy way can now be removed (as it used a hard-coded default offering).