### PR TITLE
Enable Restart+Cleanup of Isolated networks with NSX and implement Rolling Restart

### DIFF
--- a/cosmic-client/src/main/webapp/l10n/en.js
+++ b/cosmic-client/src/main/webapp/l10n/en.js
@@ -2059,7 +2059,7 @@ var dictionary = {
     "message.reset.password.warning.notStopped": "Your instance must be stopped before attempting to change its current password",
     "message.restart.mgmt.server": "Please restart your management server(s) for your new settings to take effect.",
     "message.restart.mgmt.usage.server": "Please restart your management server(s) and usage server(s) for your new settings to take effect.",
-    "message.restart.network": "All services provided by this network will be interrupted. Please confirm that you want to restart this network.",
+    "message.restart.network": "Please confirm that you want to restart the network with cleanup. This causes a few minutes of downtime.",
     "message.restart.vpc": "Please confirm that you want to restart the VPC with cleanup. This causes a few minutes of downtime.",
     "message.restoreVM": "Do you want to restore the VM ?",
     "message.security.group.usage": "(Use <strong>Ctrl-click</strong> to select all applicable security groups)",

--- a/cosmic-client/src/main/webapp/scripts/network.js
+++ b/cosmic-client/src/main/webapp/scripts/network.js
@@ -1836,10 +1836,6 @@
                                         args.$form.find('.form-item[rel=cleanup]').css('display', 'inline-block'); //shown
                                     },
                                     fields: {
-                                        cleanup: {
-                                            label: 'label.clean.up',
-                                            isBoolean: true
-                                        }
                                     }
                                 },
                                 messages: {
@@ -1849,9 +1845,8 @@
                                 },
                                 action: function (args) {
                                     var array1 = [];
-                                    array1.push("&cleanup=" + (args.data.cleanup == "on"));
                                     $.ajax({
-                                        url: createURL("restartNetwork&id=" + args.context.networks[0].id + array1.join("")),
+                                        url: createURL("restartNetwork&cleanup=true&id=" + args.context.networks[0].id + array1.join("")),
                                         dataType: "json",
                                         async: true,
                                         success: function (json) {

--- a/cosmic-core/engine/orchestration/src/main/java/com/cloud/engine/orchestration/NetworkOrchestrator.java
+++ b/cosmic-core/engine/orchestration/src/main/java/com/cloud/engine/orchestration/NetworkOrchestrator.java
@@ -75,6 +75,7 @@ import com.cloud.network.Networks.TrafficType;
 import com.cloud.network.PhysicalNetwork;
 import com.cloud.network.PhysicalNetworkSetupInfo;
 import com.cloud.network.RemoteAccessVpn;
+import com.cloud.network.VpcVirtualNetworkApplianceService;
 import com.cloud.network.addr.PublicIp;
 import com.cloud.network.dao.AccountGuestVlanMapDao;
 import com.cloud.network.dao.AccountGuestVlanMapVO;
@@ -103,6 +104,7 @@ import com.cloud.network.element.StaticNatServiceProvider;
 import com.cloud.network.element.UserDataServiceProvider;
 import com.cloud.network.guru.NetworkGuru;
 import com.cloud.network.lb.LoadBalancingRulesManager;
+import com.cloud.network.router.VirtualRouter.RedundantState;
 import com.cloud.network.rules.FirewallManager;
 import com.cloud.network.rules.FirewallRule;
 import com.cloud.network.rules.FirewallRule.Purpose;
@@ -150,6 +152,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import com.cloud.utils.fsm.NoTransitionException;
 import com.cloud.utils.fsm.StateMachine2;
 import com.cloud.utils.net.NetUtils;
+import com.cloud.vm.DomainRouterVO;
 import com.cloud.vm.Nic;
 import com.cloud.vm.Nic.ReservationStrategy;
 import com.cloud.vm.NicIpAlias;
@@ -162,6 +165,7 @@ import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachine.Type;
 import com.cloud.vm.VirtualMachineProfile;
+import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.NicDao;
 import com.cloud.vm.dao.NicIpAliasDao;
 import com.cloud.vm.dao.NicIpAliasVO;
@@ -297,6 +301,11 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
     PortableIpDao _portableIpDao;
     @Inject
     ConfigDepot _configDepot;
+    @Inject
+    DomainRouterDao _routerDao;
+    @Inject
+    VpcVirtualNetworkApplianceService _routerService;
+
     ScheduledExecutorService _executor;
     SearchBuilder<IPAddressVO> AssignIpAddressSearch;
     SearchBuilder<IPAddressVO> AssignIpAddressFromPodVlanSearch;
@@ -2322,6 +2331,12 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         final ReservationContext context = new ReservationContextImpl(null, null, callerUser, callerAccount);
 
         if (cleanup) {
+            if (_networkOfferingDao.findByIdIncludingRemoved(network.getNetworkOfferingId()).getRedundantRouter()) {
+                List<DomainRouterVO> routers = _routerDao.findByNetwork(network.getId());
+                if (routers != null && !routers.isEmpty())
+                    return rollingRestartIsolatedNetwork(network, routers, context);
+            }
+
             // shutdown the network
             s_logger.debug("Shutting down the network id=" + networkId + " as a part of network restart");
 
@@ -2348,6 +2363,62 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
             s_logger.warn("Failed to implement network " + network + " elements and resources as a part of network restart due to ", ex);
             return false;
         }
+    }
+
+    private boolean rollingRestartIsolatedNetwork(NetworkVO network, List<DomainRouterVO> routers, ReservationContext context) throws ResourceUnavailableException, ConcurrentOperationException, InsufficientCapacityException {
+        Account caller = CallContext.current().getCallingAccount();
+        long callerUserId = CallContext.current().getCallingUserId();
+
+        final int sleepTimeInMsAfterRouterStart = 10000;
+        final int numberOfRoutersWhenSingle = 1;
+        final int numberOfRoutersWhenRedundant = 2;
+
+        // check the master and backup redundant state
+        DomainRouterVO masterRouter = null;
+        DomainRouterVO backupRouter = null;
+        if (routers != null && routers.size() == numberOfRoutersWhenSingle) {
+            masterRouter = routers.get(0);
+        } if (routers != null && routers.size() == numberOfRoutersWhenRedundant) {
+            DomainRouterVO router1 = routers.get(0);
+            DomainRouterVO router2 = routers.get(1);
+            if (router1.getRedundantState() == RedundantState.MASTER || router2.getRedundantState() == RedundantState.BACKUP) {
+                masterRouter = router1;
+                backupRouter = router2;
+            } else if (router1.getRedundantState() == RedundantState.BACKUP || router2.getRedundantState() == RedundantState.MASTER) {
+                masterRouter = router2;
+                backupRouter = router1;
+            } else {
+                // both routers are in UNKNOWN state or in the same state. Order doesn't matter.
+                masterRouter = router1;
+                backupRouter = router2;
+            }
+        }
+
+        NetworkOfferingVO offering = _networkOfferingDao.findByIdIncludingRemoved(network.getNetworkOfferingId());
+        DeployDestination dest = new DeployDestination(_dcDao.findById(network.getDataCenterId()), null, null, null);
+        List<Provider> providersToImplement = getNetworkProviders(network.getId());
+
+        // destroy backup router
+        if (backupRouter != null) {
+            _routerService.destroyRouter(backupRouter.getId(), caller, callerUserId);
+        }
+        // create new backup router
+        implementNetworkElements(dest, context, network, offering, providersToImplement);
+
+        // destroy master router
+        if (masterRouter != null) {
+            try {
+                // wait for the keepalived/conntrackd on router
+                Thread.sleep(sleepTimeInMsAfterRouterStart);
+            } catch (InterruptedException e) {
+                s_logger.trace("Ignoring InterruptedException.", e);
+            }
+            _routerService.destroyRouter(masterRouter.getId(), caller, callerUserId);
+            // create a new router
+            implementNetworkElements(dest, context, network, offering, providersToImplement);
+        }
+
+        return true;
     }
 
     @Override
@@ -2440,29 +2511,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         }
         // get providers to implement
         final List<Provider> providersToImplement = getNetworkProviders(network.getId());
-        for (final NetworkElement element : networkElements) {
-            if (providersToImplement.contains(element.getProvider())) {
-                if (!_networkModel.isProviderEnabledInPhysicalNetwork(_networkModel.getPhysicalNetworkId(network), element.getProvider().getName())) {
-                    // The physicalNetworkId will not get translated into a uuid by the reponse serializer,
-                    // because the serializer would look up the NetworkVO class's table and retrieve the
-                    // network id instead of the physical network id.
-                    // So just throw this exception as is. We may need to TBD by changing the serializer.
-                    throw new CloudRuntimeException("Service provider " + element.getProvider().getName() + " either doesn't exist or is not enabled in physical network id: "
-                            + network.getPhysicalNetworkId());
-                }
-
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Asking " + element.getName() + " to implemenet " + network);
-                }
-
-                if (!element.implement(network, offering, dest, context)) {
-                    final CloudRuntimeException ex = new CloudRuntimeException("Failed to implement provider " + element.getProvider().getName() + " for network with specified " +
-                            "id");
-                    ex.addProxyObject(network.getUuid(), "networkId");
-                    throw ex;
-                }
-            }
-        }
+        implementNetworkElements(dest, context, network, offering, providersToImplement);
 
         for (final NetworkElement element : networkElements) {
             if (element instanceof AggregatedCommandExecutor && providersToImplement.contains(element.getProvider())) {
@@ -2498,6 +2547,32 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
             for (final NetworkElement element : networkElements) {
                 if (element instanceof AggregatedCommandExecutor && providersToImplement.contains(element.getProvider())) {
                     ((AggregatedCommandExecutor) element).cleanupAggregatedExecution(network, dest);
+                }
+            }
+        }
+    }
+
+    private void implementNetworkElements(final DeployDestination dest, final ReservationContext context, final Network network, final NetworkOffering offering, final List<Provider> providersToImplement) throws ResourceUnavailableException, InsufficientCapacityException {
+        for (final NetworkElement element : networkElements) {
+            if (providersToImplement.contains(element.getProvider())) {
+                if (!_networkModel.isProviderEnabledInPhysicalNetwork(_networkModel.getPhysicalNetworkId(network), element.getProvider().getName())) {
+                    // The physicalNetworkId will not get translated into a uuid by the reponse serializer,
+                    // because the serializer would look up the NetworkVO class's table and retrieve the
+                    // network id instead of the physical network id.
+                    // So just throw this exception as is. We may need to TBD by changing the serializer.
+                    throw new CloudRuntimeException("Service provider " + element.getProvider().getName() + " either doesn't exist or is not enabled in physical network id: "
+                            + network.getPhysicalNetworkId());
+                }
+
+                if (s_logger.isDebugEnabled()) {
+                    s_logger.debug("Asking " + element.getName() + " to implemenet " + network);
+                }
+
+                if (!element.implement(network, offering, dest, context)) {
+                    final CloudRuntimeException ex = new CloudRuntimeException("Failed to implement provider " + element.getProvider().getName() + " for network with specified " +
+                            "id");
+                    ex.addProxyObject(network.getUuid(), "networkId");
+                    throw ex;
                 }
             }
         }

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -1481,15 +1481,6 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
                     + Network.State.Setup);
         }
 
-        if (network.getBroadcastDomainType() == BroadcastDomainType.Lswitch) {
-            /**
-             * Unable to restart these networks now.
-             * TODO Restarting a SDN based network requires updating the nics and the configuration
-             * in the controller. This requires a non-trivial rewrite of the restart procedure.
-             */
-            throw new InvalidParameterException("Unable to restart a running SDN network.");
-        }
-
         _accountMgr.checkAccess(callerAccount, null, true, network);
 
         final boolean success = _networkMgr.restartNetwork(networkId, callerAccount, callerUser, cleanup);


### PR DESCRIPTION
Restarting an Isloated network with NSX failed with this message: `Unable to restart a running SDN network`. As it seems, back in 2012 this was a work-around for a bug. In the mean time, VPCs were developed and the issue of NSX and cleanups (basically reusing the same lswitch to keep connectivity) was resolved. When I removed this check it was working as expected.

Then I backported a patch from ACS PR 1198 that introduced a way to restart redundant routers one-by-one to minimise downtime. This works great!

Cleanup router-by-router:
![image](https://cloud.githubusercontent.com/assets/1630096/23586406/5bd0e47a-0194-11e7-821f-4c32e8be2635.png)

![image](https://cloud.githubusercontent.com/assets/1630096/23586407/70ca3840-0194-11e7-9a65-17bbd102734a.png)

![image](https://cloud.githubusercontent.com/assets/1630096/23586408/7a2ade08-0194-11e7-9857-f3a2e9b00b0e.png)

![image](https://cloud.githubusercontent.com/assets/1630096/23586413/9533159e-0194-11e7-97f4-5c95e50cd71f.png)

![image](https://cloud.githubusercontent.com/assets/1630096/23586417/9f61ec70-0194-11e7-9211-c6772018cd85.png)

![image](https://cloud.githubusercontent.com/assets/1630096/23586420/aa33ab48-0194-11e7-8568-15de4a922452.png)

![image](https://cloud.githubusercontent.com/assets/1630096/23586425/bdf103ba-0194-11e7-8676-ab15c069cf98.png)

Network connectivity kept working during cleanup:
![image](https://cloud.githubusercontent.com/assets/1630096/23586400/33b47d76-0194-11e7-8de6-8328e128e12d.png)

I also made a few tweaks to the UI to make it work like VPCs.

Next step is to implement this for VPCs as well, that will be handled in a separate PR.
