### PR TITLE
Rolling Restart when Restart+Cleanup a Redundant VPC

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
@@ -437,7 +437,7 @@ public class NetworkHelperImpl implements NetworkHelper {
         }
 
         ServiceOfferingVO routerOffering = _serviceOfferingDao.findById(routerDeploymentDefinition.getServiceOfferingId());
-        if (isRedundant && routers.size() % 2 == 0) {
+        if (isRedundant && routers != null && routers.size() == 1 && routers.get(0).getServiceOfferingId() == routerDeploymentDefinition.getServiceOfferingId()) {
             routerOffering = _serviceOfferingDao.findById(routerDeploymentDefinition.getSecondaryServiceOfferingId());
         }
 

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -5,7 +5,6 @@ import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ServerApiException;
 import com.cloud.api.command.user.vpc.ListPrivateGatewaysCmd;
 import com.cloud.api.command.user.vpc.ListStaticRoutesCmd;
-import com.cloud.api.response.SuccessResponse;
 import com.cloud.configuration.Config;
 import com.cloud.configuration.ConfigurationManager;
 import com.cloud.configuration.Resource.ResourceType;
@@ -51,6 +50,8 @@ import com.cloud.network.dao.PhysicalNetworkDao;
 import com.cloud.network.dao.Site2SiteVpnGatewayDao;
 import com.cloud.network.element.NetworkElement;
 import com.cloud.network.element.VpcProvider;
+import com.cloud.network.router.VirtualRouter;
+import com.cloud.network.router.VpcVirtualNetworkApplianceManager;
 import com.cloud.network.vpc.VpcOffering.State;
 import com.cloud.network.vpc.dao.NetworkACLDao;
 import com.cloud.network.vpc.dao.PrivateIpDao;
@@ -98,8 +99,10 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.exception.ExceptionUtil;
 import com.cloud.utils.exception.InvalidParameterValueException;
 import com.cloud.utils.net.NetUtils;
+import com.cloud.vm.DomainRouterVO;
 import com.cloud.vm.ReservationContext;
 import com.cloud.vm.ReservationContextImpl;
+import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.dao.DomainRouterDao;
 
 import javax.annotation.PostConstruct;
@@ -207,6 +210,8 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     ConfigDepot _configDepot;
     @Inject
     ServiceOfferingDao _serviceOfferingDao;
+    @Inject
+    VpcVirtualNetworkApplianceManager _routerMgr;
     int _cleanupInterval;
     int _maxNetworks;
     SearchBuilder<IPAddressVO> IpAddressSearch;
@@ -1271,7 +1276,9 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             throws ConcurrentOperationException, ResourceUnavailableException,
             InsufficientCapacityException {
 
-        final Account caller = CallContext.current().getCallingAccount();
+        final Account callerAccount = CallContext.current().getCallingAccount();
+        final User callerUser = _accountMgr.getActiveUser(CallContext.current().getCallingUserId());
+        final ReservationContext context = new ReservationContextImpl(null, null, callerUser, callerAccount);
 
         // Verify input parameters
         final Vpc vpc = getActiveVpc(vpcId);
@@ -1282,17 +1289,31 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             throw ex;
         }
 
-        _accountMgr.checkAccess(caller, null, false, vpc);
+        _accountMgr.checkAccess(callerAccount, null, false, vpc);
 
         s_logger.debug("Restarting VPC " + vpc);
         boolean restartRequired = false;
         try {
             if (cleanUp) {
-                s_logger.debug("Shutting down VPC " + vpc + " as a part of VPC restart process");
-                if (!shutdownVpc(vpcId)) {
-                    s_logger.warn("Failed to shutdown vpc as a part of VPC " + vpc + " restart process");
-                    restartRequired = true;
-                    return false;
+                List<DomainRouterVO> routers = _routerDao.listByVpcId(vpc.getId());
+                if (routers != null && !routers.isEmpty()) {
+                    s_logger.debug("Shutting down VPC " + vpc + " as a part of VPC restart process");
+                    // Get rid of any non-Running routers
+                    for (final DomainRouterVO router : routers) {
+                        if (router.getState() != VirtualMachine.State.Running) {
+                            s_logger.debug("Destroying " + router + " as it is not in Running state anyway");
+                            _routerMgr.destroyRouter(router.getId(), context.getAccount(), context.getCaller().getId());
+                        }
+                    }
+                    // Refresh the list of routers
+                    routers = _routerDao.listByVpcId(vpc.getId());
+                    if (routers != null && !routers.isEmpty()) {
+                        if (!rollingRestartVpc(vpc, routers, context)) {
+                            s_logger.warn("Failed to execute a rolling restart as a part of VPC " + vpc + " restart process");
+                            restartRequired = true;
+                            return false;
+                        }
+                    }
                 }
             } else {
                 s_logger.info("Will not shutdown vpc as a part of VPC " + vpc + " restart process.");
@@ -1312,6 +1333,84 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             vo.setRestartRequired(restartRequired);
             _vpcDao.update(vpc.getId(), vo);
         }
+    }
+
+    private boolean rollingRestartVpc(Vpc vpc, List<DomainRouterVO> routers, ReservationContext context) throws ResourceUnavailableException, ConcurrentOperationException, InsufficientCapacityException {
+        final int sleepTimeInMsAfterRouterStart = 10000;
+        final int numberOfRoutersWhenSingle = 1;
+        final int numberOfRoutersWhenRedundant = 2;
+
+        // check the master and backup redundant state
+        DomainRouterVO mainRouter = null;
+        DomainRouterVO secondaryRouter = null;
+        if (routers != null && routers.size() == numberOfRoutersWhenSingle) {
+            mainRouter = routers.get(0);
+            s_logger.debug("Rolling restart found a single router " + mainRouter.getInstanceName() + " as part of rolling restart of VPC " + vpc);
+        } if (routers != null && routers.size() == numberOfRoutersWhenRedundant) {
+            DomainRouterVO router1 = routers.get(0);
+            DomainRouterVO router2 = routers.get(1);
+            if (router1.getRedundantState() == VirtualRouter.RedundantState.MASTER || router2.getRedundantState() == VirtualRouter.RedundantState.BACKUP) {
+                mainRouter = router1;
+                secondaryRouter = router2;
+            } else if (router1.getRedundantState() == VirtualRouter.RedundantState.BACKUP || router2.getRedundantState() == VirtualRouter.RedundantState.MASTER) {
+                mainRouter = router2;
+                secondaryRouter = router1;
+            } else {
+                // both routers are in UNKNOWN state or in the same state. Order doesn't matter.
+                mainRouter = router1;
+                secondaryRouter = router2;
+            }
+            s_logger.debug("Rolling restart of VPC " + vpc + " will first replace router " + secondaryRouter.getInstanceName() + " and then router " + mainRouter.getInstanceName());
+        }
+
+        DeployDestination dest = new DeployDestination(_dcDao.findById(vpc.getZoneId()), null, null, null);
+
+        // If we are supposed to be redundant, let's replace the backup router
+        // We do this even when backupRouter is null, so we first spin a new router before replacing the other router
+        if (vpc.isRedundant()) {
+            if (!replaceRouter(vpc, context, sleepTimeInMsAfterRouterStart, secondaryRouter, dest)) {
+                s_logger.debug("Recreating the secondary router for VPC " + vpc + " failed.");
+                return false;
+            }
+        }
+
+        // If we have a single router, replace it here
+        if (mainRouter != null) {
+            if (!replaceRouter(vpc, context, sleepTimeInMsAfterRouterStart, mainRouter, dest)) {
+                s_logger.debug("Recreating the main router for VPC " + vpc + " failed.");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean replaceRouter(final Vpc vpc, final ReservationContext context, final int sleepTimeInMsAfterRouterStart, final DomainRouterVO routerToReplace, final DeployDestination dest) throws ResourceUnavailableException, InsufficientCapacityException {
+        if (routerToReplace != null) {
+            s_logger.debug("Destroying router " + routerToReplace.getInstanceName() + " as part of rolling restart of VPC " + vpc);
+            _routerMgr.destroyRouter(routerToReplace.getId(), context.getAccount(), context.getCaller().getId());
+        }
+        s_logger.debug("Triggering new router create as part of rolling restart of VPC " + vpc);
+        startVpc(vpc, dest, context);
+        try {
+            // wait for the keepalived/conntrackd on router
+            Thread.sleep(sleepTimeInMsAfterRouterStart);
+        } catch (InterruptedException e) {
+            s_logger.trace("Ignoring InterruptedException.", e);
+        }
+
+        // Routers after this action
+        List<DomainRouterVO> routers = _routerDao.listByVpcId(vpc.getId());
+        for (final DomainRouterVO router : routers) {
+            // Both should be in state Running, or else the provisioning went wrong somehow as we started with destroying non-Running routers
+            // In order not to kill both routers, we'll stop the procedure.
+            if (router.getState() != VirtualMachine.State.Running) {
+                s_logger.debug("Found router " + router.getInstanceName() + " part of VPC " + vpc + " to be in non-Running state " + router.getState() + ", so not proceeding with" +
+                        "next router to prevent downtime. Please try again.");
+                return false;
+            }
+        }
+        return true;
     }
 
     protected boolean startVpc(final Vpc vpc, final DeployDestination dest, final ReservationContext context)


### PR DESCRIPTION
Restarting VPC router-by-router to minimise downtime:
![image](https://cloud.githubusercontent.com/assets/1630096/23588248/fba753c8-01ba-11e7-94b9-b4d8edbbe6db.png)

![image](https://cloud.githubusercontent.com/assets/1630096/23588257/1ae00bea-01bb-11e7-8e71-73ad4cbc12f0.png)

![image](https://cloud.githubusercontent.com/assets/1630096/23588262/25c1d188-01bb-11e7-89b8-cf1547ff918b.png)

![image](https://cloud.githubusercontent.com/assets/1630096/23588286/ac2b39d0-01bb-11e7-88b8-d70a5dbf0763.png)

![image](https://cloud.githubusercontent.com/assets/1630096/23588287/b81eba28-01bb-11e7-9445-6684f03e6a5a.png)

![image](https://cloud.githubusercontent.com/assets/1630096/23588290/c2c50446-01bb-11e7-841b-9c50440bff88.png)

![image](https://cloud.githubusercontent.com/assets/1630096/23588298/e430f108-01bb-11e7-822e-cedf2cf93e34.png)

No packets lost:
![image](https://cloud.githubusercontent.com/assets/1630096/23588316/1b1964a2-01bc-11e7-9f9f-0a6f04922a31.png)

Same idea as #314 but now for VPC routers.