### PR TITLE
Disable hypervisor fencing when storage pool is unavailable.

### DIFF
--- a/cosmic-core/scripts/src/main/resources/scripts/vm/hypervisor/kvm/kvmheartbeat.sh
+++ b/cosmic-core/scripts/src/main/resources/scripts/vm/hypervisor/kvm/kvmheartbeat.sh
@@ -142,7 +142,7 @@ then
   /usr/bin/logger -t heartbeat "kvmheartbeat.sh rebooted system because it was unable to write the heartbeat to the storage."
   sync &
   sleep 5
-  echo b > /proc/sysrq-trigger
+  /usr/bin/logger -t heartbeat "kvmheartbeat.sh would have rebooted this box"
   exit $?
 else
   write_hbLog


### PR DESCRIPTION
ZWPS pool failure should not result in fencing all hypervisors in the zone.