### PR TITLE
Implement IP exclusion list on networks

### DIFF
--- a/cosmic-client/src/main/webapp/l10n/en.js
+++ b/cosmic-client/src/main/webapp/l10n/en.js
@@ -822,6 +822,7 @@ var dictionary = {
     "label.ip.range": "IP Range",
     "label.ip.ranges": "IP Ranges",
     "label.ipaddress": "IP Address",
+    "label.ipexclusionlist": "IP Exclusion List",
     "label.ips": "IPs",
     "label.ipv4.cidr": "IPv4 CIDR",
     "label.ipv4.dns1": "IPv4 DNS1",

--- a/cosmic-client/src/main/webapp/scripts/docs.js
+++ b/cosmic-client/src/main/webapp/scripts/docs.js
@@ -883,6 +883,10 @@ cloudStack.docs = {
         externalLink: ''
     },
     // Add tier
+    helpTierIpExclusionList: {
+        desc: 'A comma separated list of IP addresses ("ip,ip,...") or ranges ("ip_start-ip_end,ip_start-ip_end,..."), or any combination. For example "10.0.0.1,10.0.0.3-10.0.0.5,10.0.0.8"',
+        externalLink: ''
+    },
     helpTierName: {
         desc: 'A unique name for the tier',
         externalLink: ''

--- a/cosmic-client/src/main/webapp/scripts/network.js
+++ b/cosmic-client/src/main/webapp/scripts/network.js
@@ -1642,6 +1642,12 @@
                                         });
                                     }
 
+                                    if (args.data.ipexclusionlist != null && args.data.ipexclusionlist != args.context.networks[0].ipexclusionlist) {
+                                        $.extend(data, {
+                                            ipexclusionlist: args.data.ipexclusionlist
+                                        });
+                                    }
+
                                     var oldcidr;
                                     $.ajax({
                                         url: createURL("listNetworks&id=" + args.context.networks[0].id + "&listAll=true"),
@@ -2063,6 +2069,11 @@
 
                                     networkcidr: {
                                         label: 'label.network.cidr'
+                                    },
+
+                                    ipexclusionlist: {
+                                        label: 'label.ipexclusionlist',
+                                        isEditable: true
                                     },
 
                                     ip6gateway: {

--- a/cosmic-client/src/main/webapp/scripts/sharedFunctions.js
+++ b/cosmic-client/src/main/webapp/scripts/sharedFunctions.js
@@ -227,6 +227,10 @@ var addPrivateNetworkDialog = {
                         required: true
                     }
                 },
+                ipexclusionlist: {
+                    label: 'label.ipexclusionlist',
+                    docID: 'helpTierIpExclusionList'
+                },
                 vlanId: {
                     label: 'label.vlan',
                 },
@@ -388,6 +392,7 @@ var addPrivateNetworkDialog = {
             array1.push("&networkOfferingId=" + args.data.networkOfferingId);
             array1.push("&name=" + todb(args.data.name));
             array1.push("&displayText=" + todb(args.data.name));
+            array1.push("&ipexclusionlist=" + args.data.ipexclusionlist);
 
             if (($form.find('.form-item[rel=vlanId]').css("display") != "none")
                 && (args.data.vlanId != null && args.data.vlanId.length > 0))

--- a/cosmic-client/src/main/webapp/scripts/vpc.js
+++ b/cosmic-client/src/main/webapp/scripts/vpc.js
@@ -2951,6 +2951,9 @@
                             if (args.data.networkdomain != null && args.data.networkdomain != args.context.networks[0].networkdomain)
                                 array1.push("&networkdomain=" + todb(args.data.networkdomain));
 
+                            if (args.data.ipexclusionlist != null && args.data.ipexclusionlist != args.context.networks[0].ipexclusionlist)
+                                array1.push("&ipexclusionlist=" + todb(args.data.ipexclusionlist));
+
                             //args.data.networkofferingid is null when networkofferingid field is hidden
                             if (args.data.networkofferingid != null && args.data.networkofferingid != args.context.networks[0].networkofferingid) {
                                 array1.push("&networkofferingid=" + todb(args.data.networkofferingid));
@@ -3286,6 +3289,10 @@
                             },
                             cidr: {
                                 label: 'label.cidr'
+                            },
+                            ipexclusionlist: {
+                                label: 'label.ipexclusionlist',
+                                isEditable: true
                             },
                             gateway: {
                                 label: 'label.gateway'
@@ -3790,6 +3797,10 @@
                                     required: true
                                 }
                             },
+                            ipexclusionlist: {
+                                label: 'label.ipexclusionlist',
+                                docID: 'helpTierIpExclusionList',
+                            },
 
                             aclid: {
                                 label: 'label.acl',
@@ -3871,6 +3882,7 @@
                             displayText: args.data.name,
                             cidr: args.data.cidr,
                             gateway: args.data.gateway,
+                            ipexclusionlist: args.data.ipexclusionlist,
                         };
 
                         if (args.context.regions)

--- a/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
@@ -120,6 +120,7 @@ public class ApiConstants {
     public static final String IP_ADDRESS_ID = "ipaddressid";
     public static final String IS_ASYNC = "isasync";
     public static final String IP_AVAILABLE = "ipavailable";
+    public static final String IP_EXCLUSION_LIST = "ipexclusionlist";
     public static final String IP_LIMIT = "iplimit";
     public static final String IP_TOTAL = "iptotal";
     public static final String IS_CLEANUP_REQUIRED = "iscleanuprequired";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/UpdateNetworkCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/UpdateNetworkCmdByAdmin.java
@@ -33,7 +33,7 @@ public class UpdateNetworkCmdByAdmin extends UpdateNetworkCmd {
 
         final Network result =
                 _networkService.updateGuestNetwork(getId(), getNetworkName(), getDisplayText(), callerAccount, callerUser, getNetworkDomain(), getNetworkOfferingId(),
-                        getChangeCidr(), getGuestVmCidr(), getDisplayNetwork(), getCustomId(), getDns1(), getDns2());
+                        getChangeCidr(), getGuestVmCidr(), getDisplayNetwork(), getCustomId(), getDns1(), getDns2(), getIpExclusionList());
 
         if (result != null) {
             final NetworkResponse response = _responseGenerator.createNetworkResponse(ResponseView.Full, result);

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/CreateNetworkCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/CreateNetworkCmd.java
@@ -26,6 +26,7 @@ import com.cloud.offering.NetworkOffering;
 import com.cloud.utils.exception.InvalidParameterValueException;
 import com.cloud.utils.net.NetUtils;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -138,6 +139,9 @@ public class CreateNetworkCmd extends BaseCmd {
 
     @Parameter(name = ApiConstants.DNS2, type = CommandType.STRING, description = "The second DNS server of the network")
     private String dns2;
+
+    @Parameter(name = ApiConstants.IP_EXCLUSION_LIST, type = CommandType.STRING, description = "IP exclusion list for private networks")
+    private String ipExclusionList;
 
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
@@ -282,6 +286,13 @@ public class CreateNetworkCmd extends BaseCmd {
 
     public String getDns2() {
         return dns2;
+    }
+
+    public String getIpExclusionList() {
+        if (StringUtils.isEmpty(ipExclusionList)) {
+            return ipExclusionList;
+        }
+        return ipExclusionList.replaceAll("\\s", "");
     }
 
     @Override

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/UpdateNetworkCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/UpdateNetworkCmd.java
@@ -23,6 +23,7 @@ import com.cloud.user.Account;
 import com.cloud.user.User;
 import com.cloud.utils.exception.InvalidParameterValueException;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,6 +71,9 @@ public class UpdateNetworkCmd extends BaseAsyncCustomIdCmd {
     @Parameter(name = ApiConstants.DNS2, type = CommandType.STRING, description = "The second DNS server of the network")
     private String dns2;
 
+    @Parameter(name = ApiConstants.IP_EXCLUSION_LIST, type = CommandType.STRING, description = "IP exclusion list for private networks")
+    private String ipExclusionList;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -85,7 +89,7 @@ public class UpdateNetworkCmd extends BaseAsyncCustomIdCmd {
 
         final Network result =
                 _networkService.updateGuestNetwork(getId(), getNetworkName(), getDisplayText(), callerAccount, callerUser, getNetworkDomain(), getNetworkOfferingId(),
-                        getChangeCidr(), getGuestVmCidr(), getDisplayNetwork(), getCustomId(), getDns1(), getDns2());
+                        getChangeCidr(), getGuestVmCidr(), getDisplayNetwork(), getCustomId(), getDns1(), getDns2(), getIpExclusionList());
 
         if (result != null) {
             final NetworkResponse response = _responseGenerator.createNetworkResponse(ResponseView.Restricted, result);
@@ -122,6 +126,13 @@ public class UpdateNetworkCmd extends BaseAsyncCustomIdCmd {
 
     public String getDns2() {
         return dns2;
+    }
+
+    public String getIpExclusionList() {
+        if (StringUtils.isEmpty(ipExclusionList)) {
+            return ipExclusionList;
+        }
+        return ipExclusionList.replaceAll("\\s", "");
     }
 
     public Boolean getChangeCidr() {

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/NetworkResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/NetworkResponse.java
@@ -192,6 +192,10 @@ public class NetworkResponse extends BaseResponse implements ControlledEntityRes
     @Param(description = "the cidr of IPv6 network")
     private String ip6Cidr;
 
+    @SerializedName(ApiConstants.IP_EXCLUSION_LIST)
+    @Param(description = "list of ip addresses and/or ranges of addresses to be excluded from the network for assignment")
+    private String ipExclusionList;
+
     @SerializedName(ApiConstants.DISPLAY_NETWORK)
     @Param(description = "an optional field, whether to the display the network to the end user or not.", authorized = {RoleType.Admin})
     private Boolean displayNetwork;
@@ -266,6 +270,10 @@ public class NetworkResponse extends BaseResponse implements ControlledEntityRes
 
     public void setDns2(final String dns2) {
         this.dns2 = dns2;
+    }
+
+    public void setIpExclusionList(final String ipExclusionList) {
+        this.ipExclusionList = ipExclusionList;
     }
 
     public void setType(final String type) {

--- a/cosmic-core/api/src/main/java/com/cloud/network/NetworkService.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/NetworkService.java
@@ -59,7 +59,7 @@ public interface NetworkService {
     IpAddress getIp(long id);
 
     Network updateGuestNetwork(long networkId, String name, String displayText, Account callerAccount, User callerUser, String domainSuffix, Long networkOfferingId,
-                               Boolean changeCidr, String guestVmCidr, Boolean displayNetwork, String newUUID, String dns1, String dns2);
+                               Boolean changeCidr, String guestVmCidr, Boolean displayNetwork, String newUUID, String dns1, String dns2, String ipExclusionList);
 
     PhysicalNetwork createPhysicalNetwork(Long zoneId, String vnetRange, String networkSpeed, List<String> isolationMethods, String broadcastDomainRange, Long domainId,
                                           List<String> tags, String name);

--- a/cosmic-core/db-scripts/src/main/resources/db/schema-533to534.sql
+++ b/cosmic-core/db-scripts/src/main/resources/db/schema-533to534.sql
@@ -2,3 +2,6 @@
 -- Schema upgrade from 5.3.3 to 5.3.4;
 --
 
+-- Add ip exclusion list
+ALTER TABLE `cloud`.`networks` ADD COLUMN `ip_exclusion_list` varchar(255) DEFAULT NULL COMMENT 'IP list excluded from assignment' AFTER `redundant`;
+

--- a/cosmic-core/engine/api/src/main/java/com/cloud/engine/orchestration/service/NetworkOrchestrationService.java
+++ b/cosmic-core/engine/api/src/main/java/com/cloud/engine/orchestration/service/NetworkOrchestrationService.java
@@ -73,7 +73,7 @@ public interface NetworkOrchestrationService {
     List<? extends Network> setupNetwork(Account owner, NetworkOffering offering, Network predefined, DeploymentPlan plan,
                                          String name, String displayText,
                                          boolean errorIfAlreadySetup, Long domainId, ACLType aclType, Boolean subdomainAccess, Long vpcId,
-                                         Boolean isDisplayNetworkEnabled, String dns1, String dns2)
+                                         Boolean isDisplayNetworkEnabled, String dns1, String dns2, final String ipExclusionList)
             throws ConcurrentOperationException;
 
     void allocate(VirtualMachineProfile vm, LinkedHashMap<? extends Network, List<? extends NicProfile>> networks)
@@ -134,7 +134,7 @@ public interface NetworkOrchestrationService {
     Network createGuestNetwork(long networkOfferingId, String name, String displayText, String gateway, String cidr,
                                String vlanId, String networkDomain, Account owner, Long domainId, PhysicalNetwork physicalNetwork,
                                long zoneId, ACLType aclType, Boolean subdomainAccess, Long vpcId, String ip6Gateway, String ip6Cidr,
-                               Boolean displayNetworkEnabled, String isolatedPvlan, String dns1, String dns2)
+                               Boolean displayNetworkEnabled, String isolatedPvlan, String dns1, String dns2, final String ipExclusionList)
             throws ConcurrentOperationException, InsufficientCapacityException, ResourceAllocationException;
 
     UserDataServiceProvider getPasswordResetProvider(Network network);

--- a/cosmic-core/engine/components-api/src/main/java/com/cloud/network/vpc/VpcManager.java
+++ b/cosmic-core/engine/components-api/src/main/java/com/cloud/network/vpc/VpcManager.java
@@ -84,6 +84,7 @@ public interface VpcManager {
      * @param vpcId
      * @param caller
      * @param displayNetworkEnabled
+     * @param ipExclusionList
      * @return
      * @throws ConcurrentOperationException
      * @throws InsufficientCapacityException
@@ -92,7 +93,7 @@ public interface VpcManager {
     Network
     createVpcGuestNetwork(long ntwkOffId, String name, String displayText, String gateway, String cidr, String vlanId, String networkDomain, Account owner,
                           Long domainId, PhysicalNetwork pNtwk, long zoneId, ACLType aclType, Boolean subdomainAccess, long vpcId, Long aclId, Account caller,
-                          Boolean displayNetworkEnabled, String dns1, String dns2)
+                          Boolean displayNetworkEnabled, String dns1, String dns2, final String ipExclusionList)
 
             throws ConcurrentOperationException, InsufficientCapacityException, ResourceAllocationException;
 

--- a/cosmic-core/engine/orchestration/src/main/java/com/cloud/engine/orchestration/NetworkOrchestrator.java
+++ b/cosmic-core/engine/orchestration/src/main/java/com/cloud/engine/orchestration/NetworkOrchestrator.java
@@ -576,14 +576,14 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
     public List<? extends Network> setupNetwork(final Account owner, final NetworkOffering offering, final DeploymentPlan plan, final String name, final String displayText,
                                                 final boolean isDefault)
             throws ConcurrentOperationException {
-        return setupNetwork(owner, offering, null, plan, name, displayText, false, null, null, null, null, true, null, null);
+        return setupNetwork(owner, offering, null, plan, name, displayText, false, null, null, null, null, true, null, null, null);
     }
 
     @Override
     @DB
     public List<? extends Network> setupNetwork(final Account owner, final NetworkOffering offering, final Network predefined, final DeploymentPlan plan, final String name,
                                                 final String displayText, final boolean errorIfAlreadySetup, final Long domainId, final ACLType aclType,
-                                                final Boolean subdomainAccess, final Long vpcId, final Boolean isDisplayNetworkEnabled, final String dns1, final String dns2)
+                                                final Boolean subdomainAccess, final Long vpcId, final Boolean isDisplayNetworkEnabled, final String dns1, final String dns2, final String ipExclusionList)
             throws ConcurrentOperationException {
         final Account locked = _accountDao.acquireInLockTable(owner.getId());
         if (locked == null) {
@@ -643,7 +643,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                     public void doInTransactionWithoutResult(final TransactionStatus status) {
                         final NetworkVO vo = new NetworkVO(id, network, offering.getId(), guru.getName(), owner.getDomainId(), owner.getId(), relatedFile, name, displayText,
                                 predefined.getNetworkDomain(), offering.getGuestType(), plan.getDataCenterId(), plan.getPhysicalNetworkId(), aclType, offering.getSpecifyIpRanges(),
-                                vpcId, offering.getRedundantRouter(), dns1, dns2);
+                                vpcId, offering.getRedundantRouter(), dns1, dns2, ipExclusionList);
                         vo.setDisplayNetwork(isDisplayNetworkEnabled == null ? true : isDisplayNetworkEnabled);
                         vo.setStrechedL2Network(offering.getSupportsStrechedL2());
                         networks.add(_networksDao.persist(vo, vo.getGuestType() == GuestType.Isolated,
@@ -1778,7 +1778,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
     public Network createGuestNetwork(final long networkOfferingId, final String name, final String displayText, final String gateway, final String cidr, String vlanId,
                                       String networkDomain, final Account owner, final Long domainId, final PhysicalNetwork pNtwk, final long zoneId, final ACLType aclType,
                                       Boolean subdomainAccess, final Long vpcId, final String ip6Gateway, final String ip6Cidr, final Boolean isDisplayNetworkEnabled,
-                                      final String isolatedPvlan, final String dns1, final String dns2) throws ConcurrentOperationException, InsufficientCapacityException,
+                                      final String isolatedPvlan, final String dns1, final String dns2, final String ipExclusionList) throws ConcurrentOperationException, InsufficientCapacityException,
             ResourceAllocationException {
         final NetworkOfferingVO ntwkOff = _networkOfferingDao.findById(networkOfferingId);
         // this method supports only guest network creation
@@ -2024,6 +2024,10 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                     userNetwork.setDns2(dns2);
                 }
 
+                if (ipExclusionList != null) {
+                    userNetwork.setIpExclusionList(ipExclusionList);
+                }
+
                 if (ip6Cidr != null && ip6Gateway != null) {
                     userNetwork.setIp6Cidr(ip6Cidr);
                     userNetwork.setIp6Gateway(ip6Gateway);
@@ -2048,7 +2052,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 }
 
                 final List<? extends Network> networks = setupNetwork(owner, ntwkOff, userNetwork, plan, name, displayText, true, domainId, aclType, subdomainAccessFinal, vpcId,
-                        isDisplayNetworkEnabled, dns1, dns2);
+                        isDisplayNetworkEnabled, dns1, dns2, ipExclusionList);
 
                 Network network = null;
                 if (networks == null || networks.isEmpty()) {

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/network/dao/NetworkVO.java
@@ -116,15 +116,18 @@ public class NetworkVO implements Network {
     @Column(name = "streched_l2")
     boolean strechedL2Network = false;
 
+    @Column(name = "ip_exclusion_list")
+    String ipExclusionList;
+
     public NetworkVO() {
         uuid = UUID.randomUUID().toString();
     }
 
     public NetworkVO(final long id, final Network that, final long offeringId, final String guruName, final long domainId, final long accountId, final long related,
                      final String name, final String displayText, final String networkDomain, final GuestType guestType, final long dcId, final Long physicalNetworkId,
-                     final ACLType aclType, final boolean specifyIpRanges, final Long vpcId, final boolean isRedundant, final String dns1, final String dns2) {
+                     final ACLType aclType, final boolean specifyIpRanges, final Long vpcId, final boolean isRedundant, final String dns1, final String dns2, final String ipExclusionList) {
         this(id, that.getTrafficType(), that.getMode(), that.getBroadcastDomainType(), offeringId, domainId, accountId, related, name, displayText, networkDomain, guestType,
-                dcId, physicalNetworkId, aclType, specifyIpRanges, vpcId, isRedundant, dns1, dns2);
+                dcId, physicalNetworkId, aclType, specifyIpRanges, vpcId, isRedundant, dns1, dns2, ipExclusionList);
         gateway = that.getGateway();
         cidr = that.getCidr();
         networkCidr = that.getNetworkCidr();
@@ -161,7 +164,7 @@ public class NetworkVO implements Network {
     public NetworkVO(final long id, final TrafficType trafficType, final Mode mode, final BroadcastDomainType broadcastDomainType, final long networkOfferingId,
                      final long domainId, final long accountId, final long related, final String name, final String displayText, final String networkDomain,
                      final GuestType guestType, final long dcId, final Long physicalNetworkId, final ACLType aclType, final boolean specifyIpRanges, final Long vpcId,
-                     final boolean isRedundant, final String dns1, final String dns2) {
+                     final boolean isRedundant, final String dns1, final String dns2, final String ipExclusionList) {
         this(trafficType, mode, broadcastDomainType, networkOfferingId, State.Allocated, dcId, physicalNetworkId, isRedundant);
         this.domainId = domainId;
         this.accountId = accountId;
@@ -177,6 +180,7 @@ public class NetworkVO implements Network {
         this.vpcId = vpcId;
         this.dns1 = dns1;
         this.dns2 = dns2;
+        this.ipExclusionList = ipExclusionList;
     }
 
     /**
@@ -560,5 +564,13 @@ public class NetworkVO implements Network {
 
     public void setIsRedundant(final boolean redundant) {
         this.isRedundant = redundant;
+    }
+
+    public void setIpExclusionList(final String ipExclusionList) {
+        this.ipExclusionList = ipExclusionList;
+    }
+
+    public String getIpExclusionList() {
+        return ipExclusionList;
     }
 }

--- a/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -1964,6 +1964,8 @@ public class ApiResponseHelper implements ResponseGenerator {
             response.setNetmask(NetUtils.cidr2Netmask(network.getCidr()));
         }
 
+        response.setIpExclusionList(((NetworkVO)network).getIpExclusionList());
+
         response.setIp6Gateway(network.getIp6Gateway());
         response.setIp6Cidr(network.getIp6Cidr());
 

--- a/cosmic-core/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -4167,7 +4167,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
                 userNetwork.setBroadcastDomainType(broadcastDomainType);
                 userNetwork.setNetworkDomain(networkDomain);
-                _networkMgr.setupNetwork(systemAccount, offering, userNetwork, plan, null, null, false, Domain.ROOT_DOMAIN, null, null, null, true, null, null);
+                _networkMgr.setupNetwork(systemAccount, offering, userNetwork, plan, null, null, false, Domain.ROOT_DOMAIN, null, null, null, true, null, null, null);
             }
         }
     }

--- a/cosmic-core/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
@@ -1545,7 +1545,7 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
                                     + " as a part of createVlanIpRange process");
                             guestNetwork = _networkMgr.createGuestNetwork(requiredOfferings.get(0).getId(), owner.getAccountName() + "-network", owner.getAccountName()
                                             + "-network", null, null, null, null, owner, null, physicalNetwork, zoneId, ACLType.Account,
-                                    null, null, null, null, true, null, null, null);
+                                    null, null, null, null, true, null, null, null, null);
                             if (guestNetwork == null) {
                                 s_logger.warn("Failed to create default Virtual network for the account " + accountId + "in zone " + zoneId);
                                 throw new CloudRuntimeException("Failed to create a Guest Isolated Networks with SourceNAT "

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -1804,17 +1804,26 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
     public SortedSet<Long> getAvailableIps(final Network network, final String requestedIp) {
         final String[] cidr = network.getCidr().split("/");
         final List<String> ips = getUsedIpsInNetwork(network);
+        final List<String> excludedIps = getExcludedIpsInNetwork(network);
         final SortedSet<Long> usedIps = new TreeSet<>();
 
         for (final String ip : ips) {
             if (requestedIp != null && requestedIp.equals(ip)) {
-                s_logger.warn("Requested ip address " + requestedIp + " is already in use in network" + network);
+                s_logger.warn("Requested ip address " + requestedIp + " is already in use in network " + network);
                 return null;
             }
 
             usedIps.add(NetUtils.ip2Long(ip));
         }
 
+        for (final String ip : excludedIps) {
+            if (requestedIp != null && requestedIp.equals(ip)) {
+                s_logger.warn("Requested ip address " + requestedIp + " is in excluded IPs range " + ((NetworkVO)network).getIpExclusionList());
+                return null;
+            }
+
+            usedIps.add(NetUtils.ip2Long(ip));
+        }
         final SortedSet<Long> allPossibleIps = NetUtils.getAllIpsFromCidr(cidr[0], Integer.parseInt(cidr[1]), usedIps);
 
         final String gateway = network.getGateway();
@@ -1823,6 +1832,10 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
         }
 
         return allPossibleIps;
+    }
+
+    public List<String> getExcludedIpsInNetwork(Network network) {
+        return NetUtils.getAllIpsFromRangeList(((NetworkVO) network).getIpExclusionList());
     }
 
     @Override

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -683,6 +683,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
         final String isolatedPvlan = cmd.getIsolatedPvlan();
         final String dns1 = cmd.getDns1();
         final String dns2 = cmd.getDns2();
+        final String ipExclusionList = cmd.getIpExclusionList();
 
         // Validate network offering
         final NetworkOfferingVO ntwkOff = _networkOfferingDao.findById(networkOfferingId);
@@ -967,7 +968,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
 
         Network network = commitNetwork(networkOfferingId, gateway, startIP, endIP, netmask, networkDomain, vlanId, name, displayText, caller, physicalNetworkId, zoneId, domainId,
                 isDomainSpecific, subdomainAccess, vpcId, startIPv6, endIPv6, ip6Gateway, ip6Cidr, displayNetwork, aclId, isolatedPvlan, ntwkOff, pNtwk, aclType, owner, cidr,
-                createVlan, dns1, dns2);
+                createVlan, dns1, dns2, ipExclusionList);
 
         // if the network offering has persistent set to true, implement the network
         if (ntwkOff.getIsPersistent()) {
@@ -1520,7 +1521,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
     @ActionEvent(eventType = EventTypes.EVENT_NETWORK_UPDATE, eventDescription = "updating network", async = true)
     public Network updateGuestNetwork(final long networkId, final String name, final String displayText, final Account callerAccount, final User callerUser,
                                       final String domainSuffix, final Long networkOfferingId, final Boolean changeCidr, final String guestVmCidr, final Boolean displayNetwork,
-                                      final String customId, final String dns1, final String dns2) {
+                                      final String customId, final String dns1, final String dns2, final String ipExclusionList) {
 
         boolean restartNetwork = false;
 
@@ -1577,6 +1578,10 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
         if (dns2 != null) {
             network.setDns2(dns2);
             restartNetwork = true;
+        }
+
+        if (ipExclusionList != null) {
+            network.setIpExclusionList(ipExclusionList);
         }
 
         // display flag is not null and has changed
@@ -3123,7 +3128,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
                         //create Guest network
                         privateNetwork = _networkMgr.createGuestNetwork(ntwkOffFinal.getId(), networkName, displayText, gateway, cidr, uriString, null, owner, null, pNtwk,
                                 pNtwk.getDataCenterId(), ACLType.Account, null, vpcId, null, null, true, null,
-                                dc.getDns1(), dc.getDns2());
+                                dc.getDns1(), dc.getDns2(), null);
                         if (privateNetwork != null) {
                             s_logger.debug("Successfully created guest network " + privateNetwork);
                         } else {
@@ -3834,7 +3839,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
                                   final Long domainId, final boolean isDomainSpecific, final Boolean subdomainAccessFinal, final Long vpcId, final String startIPv6,
                                   final String endIPv6, final String ip6Gateway, final String ip6Cidr, final Boolean displayNetwork, final Long aclId, final String isolatedPvlan,
                                   final NetworkOfferingVO ntwkOff, final PhysicalNetwork pNtwk, final ACLType aclType, final Account ownerFinal, final String cidr,
-                                  final boolean createVlan, final String dns1, final String dns2) throws InsufficientCapacityException,
+                                  final boolean createVlan, final String dns1, final String dns2, final String ipExclusionList) throws InsufficientCapacityException,
             ResourceAllocationException {
         try {
             final Network network = Transaction.execute(new TransactionCallbackWithException<Network, Exception>() {
@@ -3880,7 +3885,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
                             }
                         }
                         network = _vpcMgr.createVpcGuestNetwork(networkOfferingId, name, displayText, gateway, cidr, vlanId, networkDomain, owner, sharedDomainId, pNtwk, zoneId,
-                                aclType, subdomainAccess, vpcId, aclId, caller, displayNetwork, dns1, dns2);
+                                aclType, subdomainAccess, vpcId, aclId, caller, displayNetwork, dns1, dns2, ipExclusionList);
                     } else {
                         if (_configMgr.isOfferingForVpc(ntwkOff)) {
                             throw new InvalidParameterValueException("Network offering can be used for VPC networks only");
@@ -3890,7 +3895,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
                         }
 
                         network = _networkMgr.createGuestNetwork(networkOfferingId, name, displayText, gateway, cidr, vlanId, networkDomain, owner, sharedDomainId, pNtwk, zoneId,
-                                aclType, subdomainAccess, vpcId, ip6Gateway, ip6Cidr, displayNetwork, isolatedPvlan, dns1, dns2);
+                                aclType, subdomainAccess, vpcId, ip6Gateway, ip6Cidr, displayNetwork, isolatedPvlan, dns1, dns2, ipExclusionList);
                     }
 
                     if (_accountMgr.isRootAdmin(caller.getId()) && createVlan && network != null) {

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -2555,7 +2555,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     public Network createVpcGuestNetwork(final long ntwkOffId, final String name, final String displayText, final String gateway, final String cidr, final String vlanId,
                                          String networkDomain, final Account owner, final Long domainId, final PhysicalNetwork pNtwk, final long zoneId, final ACLType aclType,
                                          final Boolean subdomainAccess, final long vpcId, final Long aclId, final Account caller, final Boolean isDisplayNetworkEnabled,
-                                         final String dns1, final String dns2)
+                                         final String dns1, final String dns2, final String ipExclusionList)
             throws ConcurrentOperationException, InsufficientCapacityException,
             ResourceAllocationException {
 
@@ -2582,7 +2582,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         // 2) Create network
         final Network guestNetwork = _ntwkMgr.createGuestNetwork(ntwkOffId, name, displayText, gateway, cidr, vlanId,
                 networkDomain, owner, domainId, pNtwk, zoneId, aclType, subdomainAccess, vpcId, null, null,
-                isDisplayNetworkEnabled, null, dns1, dns2);
+                isDisplayNetworkEnabled, null, dns1, dns2, ipExclusionList);
 
         if (guestNetwork != null) {
             guestNetwork.setNetworkACLId(aclId);

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -120,6 +120,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -1543,6 +1544,12 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             throw new InvalidParameterValueException(
                     "The specified ip address for the private network " + ipAddress +
                             " should be within the CIDR of the private network " + privateNtwk.getCidr());
+        }
+
+        final SortedSet<Long> availableIps = _ntwkModel.getAvailableIps(privateNtwk, ipAddress);
+
+        if (availableIps == null || availableIps.isEmpty()) {
+            throw new InvalidParameterValueException("The requested ip address " + ipAddress + " is not available in private network " + privateNtwk.getName());
         }
 
         final Long privateNetworkId = privateNtwk.getId();

--- a/cosmic-core/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
@@ -689,7 +689,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                         final NetworkVO network =
                                 new NetworkVO(id, trafficType, mode, broadcastDomainType, networkOfferingId, domainId, accountId, related, null, null, networkDomain,
                                         Network.GuestType.Shared, zoneId, null, null, specifyIpRanges, null, offering.getRedundantRouter(),
-                                        zone.getDns1(), zone.getDns2());
+                                        zone.getDns1(), zone.getDns2(), null);
                         network.setGuruName(guruNames.get(network.getTrafficType()));
                         network.setState(State.Implemented);
                         _networkDao.persist(network, false, getServicesAndProvidersForNetwork(networkOfferingId));

--- a/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -2594,7 +2594,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                     final Network newNetwork = _networkMgr.createGuestNetwork(requiredOfferings.get(0).getId(), owner.getAccountName() + "-network", owner.getAccountName() +
                                     "-network",
                             null, null, null, null, owner, null, physicalNetwork, zone.getId(), ACLType.Account,
-                            null, null, null, null, true, null, null, null);
+                            null, null, null, null, true, null, null, null, null);
                     if (newNetwork != null) {
                         defaultNetwork = _networkDao.findById(newNetwork.getId());
                     }
@@ -3586,7 +3586,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                                     + " as a part of deployVM process");
                             Network newNetwork = _networkMgr.createGuestNetwork(requiredOfferings.get(0).getId(), newAccount.getAccountName() + "-network",
                                     newAccount.getAccountName() + "-network", null, null, null, null, newAccount, null, physicalNetwork, zone.getId(), ACLType.Account, null, null,
-                                    null, null, true, null, null, null);
+                                    null, null, true, null, null, null, null);
                             // if the network offering has persistent set to true, implement the network
                             if (requiredOfferings.get(0).getIsPersistent()) {
                                 final DeployDestination dest = new DeployDestination(zone, null, null, null);

--- a/cosmic-core/server/src/test/java/com/cloud/network/CreatePrivateNetworkTest.java
+++ b/cosmic-core/server/src/test/java/com/cloud/network/CreatePrivateNetworkTest.java
@@ -101,11 +101,11 @@ public class CreatePrivateNetworkTest {
 
         final Network net =
                 new NetworkVO(1L, TrafficType.Guest, Mode.None, BroadcastDomainType.Vlan, 1L, 1L, 1L, 1L, "bla", "fake", "eet.net", GuestType.Isolated, 1L, 1L,
-                        ACLType.Account, false, 1L, false, "1.2.3.4", null);
+                        ACLType.Account, false, 1L, false, "1.2.3.4", null, null);
         when(
                 networkService._networkMgr.createGuestNetwork(eq(ntwkOff.getId()), eq("bla"), eq("fake"), eq("10.1.1.1"), eq("10.1.1.0/24"), anyString(), anyString(),
                         eq(account), anyLong(), eq(physicalNetwork), eq(physicalNetwork.getDataCenterId()), eq(ACLType.Account), anyBoolean(), eq(1L), anyString(), anyString(),
-                        anyBoolean(), anyString(), eq("1.2.3.4"), eq(null))).thenReturn(net);
+                        anyBoolean(), anyString(), eq("1.2.3.4"), eq(null), eq(null))).thenReturn(net);
 
         when(networkService._privateIpDao.findByIpAndSourceNetworkId(net.getId(), "10.1.1.2")).thenReturn(null);
         when(networkService._privateIpDao.findByIpAndSourceNetworkIdAndVpcId(eq(1L), anyString(), eq(1L))).thenReturn(null);

--- a/cosmic-core/server/src/test/java/com/cloud/network/NetworkModelTest.java
+++ b/cosmic-core/server/src/test/java/com/cloud/network/NetworkModelTest.java
@@ -7,8 +7,10 @@ import static org.mockito.Mockito.when;
 
 import com.cloud.dc.VlanVO;
 import com.cloud.dc.dao.VlanDao;
+import com.cloud.lb.dao.ApplicationLoadBalancerRuleDao;
 import com.cloud.network.dao.IPAddressDao;
 import com.cloud.network.dao.IPAddressVO;
+import com.cloud.network.dao.NetworkVO;
 import com.cloud.user.Account;
 import com.cloud.utils.db.Filter;
 import com.cloud.utils.db.SearchBuilder;
@@ -17,20 +19,26 @@ import com.cloud.utils.net.Ip;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.SortedSet;
 
+import com.cloud.vm.NicSecondaryIp;
+import com.cloud.vm.dao.NicDao;
+import com.cloud.vm.dao.NicSecondaryIpDao;
 import junit.framework.Assert;
+import org.apache.bcel.generic.NEW;
 import org.junit.Before;
 import org.junit.Test;
 
 public class NetworkModelTest {
+    NetworkModelImpl modelImpl;
     @Before
     public void setUp() {
+        modelImpl = new NetworkModelImpl();
 
     }
 
     @Test
     public void testGetSourceNatIpAddressForGuestNetwork() {
-        final NetworkModelImpl modelImpl = new NetworkModelImpl();
         final IPAddressDao ipAddressDao = mock(IPAddressDao.class);
         modelImpl._ipAddressDao = ipAddressDao;
         final List<IPAddressVO> fakeList = new ArrayList<>();
@@ -56,5 +64,53 @@ public class NetworkModelTest {
         answer = modelImpl.getSourceNatIpAddressForGuestNetwork(fakeAccount, fakeNetwork);
         Assert.assertNotNull(answer);
         Assert.assertEquals(answer.getAddress().addr(), "76.75.75.75");
+    }
+
+    @Test
+    public void testGetExcludedIpsInNetwork() {
+        Network network = new NetworkVO(1L, null, null,null, 1L, 1L, 1L, 1L,
+                null, null, null,null, 1L, null, null,
+                false, null, false, null,null, "10.0.0.1-10.0.0.3,10.0.1.5");
+        List<String> res = modelImpl.getExcludedIpsInNetwork(network);
+        org.junit.Assert.assertTrue(!res.isEmpty());
+        org.junit.Assert.assertTrue(res.contains("10.0.0.2"));
+        org.junit.Assert.assertTrue(res.size() == 4);
+
+    }
+
+    @Test
+    public void testGetAvailableIps() {
+        Network network = new NetworkVO(1L, null, null,null, 1L, 1L, 1L, 1L,
+                null, null, null,null, 1L, null, null,
+                false, null, false, null,null, "10.0.0.1-10.0.0.3,10.0.0.5");
+        ((NetworkVO)network).setCidr("10.0.0.0/29");
+
+        final NicDao nicDao = mock(NicDao.class);
+        modelImpl._nicDao = nicDao;
+        final NicSecondaryIpDao nicSecondaryIpDao = mock(NicSecondaryIpDao.class);
+        modelImpl._nicSecondaryIpDao = nicSecondaryIpDao;
+        final ApplicationLoadBalancerRuleDao appLbRuleDao = mock(ApplicationLoadBalancerRuleDao.class);
+        modelImpl._appLbRuleDao = appLbRuleDao;
+
+        final List<String> fakeList = new ArrayList<>();
+        final SearchBuilder<IPAddressVO> fakeSearch = mock(SearchBuilder.class);
+        when(fakeSearch.create()).thenReturn(mock(SearchCriteria.class));
+        when(nicDao.search(any(SearchCriteria.class), (Filter) org.mockito.Matchers.isNull())).thenReturn(fakeList);
+        when(nicSecondaryIpDao.search(any(SearchCriteria.class), (Filter) org.mockito.Matchers.isNull())).thenReturn(fakeList);
+        when(appLbRuleDao.search(any(SearchCriteria.class), (Filter) org.mockito.Matchers.isNull())).thenReturn(fakeList);
+
+        SortedSet<Long> possibleAddresses = modelImpl.getAvailableIps(network, "10.0.0.5");
+        org.junit.Assert.assertNull(possibleAddresses);
+
+        possibleAddresses = modelImpl.getAvailableIps(network, "10.0.0.6");
+        org.junit.Assert.assertEquals(possibleAddresses.size(), 2);
+
+        network = new NetworkVO(1L, null, null,null, 1L, 1L, 1L, 1L,
+                null, null, null,null, 1L, null, null,
+                false, null, false, null,null, null);
+        ((NetworkVO)network).setCidr("10.0.0.0/29");
+        possibleAddresses = modelImpl.getAvailableIps(network, "10.0.0.6");
+        org.junit.Assert.assertEquals(possibleAddresses.size(), 6);
+
     }
 }

--- a/cosmic-core/server/src/test/java/com/cloud/vpc/MockNetworkManagerImpl.java
+++ b/cosmic-core/server/src/test/java/com/cloud/vpc/MockNetworkManagerImpl.java
@@ -241,7 +241,7 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
     @Override
     public Network updateGuestNetwork(final long networkId, final String name, final String displayText, final Account callerAccount, final User callerUser, final String
             domainSuffix, final Long networkOfferingId, final Boolean changeCidr, final String guestVmCidr, final Boolean displayNetwork, final String newUUID, final String
-                                              dns1, final String dns2) {
+                                              dns1, final String dns2, final String ipExclusionList) {
         // TODO Auto-generated method stub
         return null;
     }
@@ -548,7 +548,7 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
     @Override
     public List<NetworkVO> setupNetwork(final Account owner, final NetworkOffering offering, final Network predefined, final DeploymentPlan plan, final String name,
                                         final String displayText, final boolean errorIfAlreadySetup, final Long domainId, final ACLType aclType, final Boolean subdomainAccess,
-                                        final Long vpcId, final Boolean isNetworkDisplayEnabled, final String dns1, final String dns2)
+                                        final Long vpcId, final Boolean isNetworkDisplayEnabled, final String dns1, final String dns2, final String ipExclusionList)
             throws ConcurrentOperationException {
         // TODO Auto-generated method stub
         return null;
@@ -663,7 +663,7 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
     public Network createGuestNetwork(final long networkOfferingId, final String name, final String displayText, final String gateway, final String cidr, final String vlanId,
                                       final String networkDomain, final Account owner, final Long domainId, final PhysicalNetwork physicalNetwork, final long zoneId,
                                       final ACLType aclType, final Boolean subdomainAccess, final Long vpcId, final String gatewayv6, final String cidrv6,
-                                      final Boolean displayNetworkEnabled, final String isolatedPvlan, final String dns1, final String dns2) throws
+                                      final Boolean displayNetworkEnabled, final String isolatedPvlan, final String dns1, final String dns2, final String ipExclusionList) throws
             ConcurrentOperationException,
             InsufficientCapacityException,
             ResourceAllocationException {

--- a/cosmic-core/test/integration/smoke/test_ip_exclusion_list.py
+++ b/cosmic-core/test/integration/smoke/test_ip_exclusion_list.py
@@ -1,0 +1,341 @@
+import logging
+from marvin.cloudstackAPI import *
+from marvin.cloudstackTestCase import *
+from marvin.lib.base import *
+from marvin.lib.common import *
+from marvin.lib.utils import *
+from nose.plugins.attrib import attr
+
+class TestIpExclusionList(cloudstackTestCase):
+
+    attributes = {
+        'account': {
+            'email': 'e.cartman@southpark.com',
+            'firstname': 'Eric',
+            'lastname': 'Cartman',
+            'username': 'e.cartman',
+            'password': 'southpark'
+        },
+        'default_offerings': {
+            'vpc': 'Default VPC offering',
+            'redundant_vpc': 'Redundant VPC offering',
+            'network': 'DefaultIsolatedNetworkOfferingForVpcNetworks',
+            'virtual_machine': 'Small Instance'
+        },
+        'vpcs': {
+            'vpc1': {
+                'name': 'vpc1',
+                'displaytext': 'vpc1',
+                'cidr': '10.1.0.0/16'
+            }
+        },
+        'networks': {
+            'network1': {
+                'name': 'network1',
+                'displaytext': 'network1',
+                'gateway': '10.1.1.1',
+                'netmask': '255.255.255.0'
+            },
+            'network2': {
+                'name': 'network2',
+                'displaytext': 'network2',
+                'gateway': '10.1.2.1',
+                'netmask': '255.255.255.248'
+            }
+        },
+        'vms': {
+            'vm1': {
+                'name': 'vm1',
+                'displayname': 'vm1'
+            },
+            'vm2': {
+                'name': 'vm2',
+                'displayname': 'vm2',
+                'privateport': 22,
+                'publicport': 22,
+                'protocol': 'TCP'
+            },
+            'vm3': {
+                'name': 'vm3',
+                'displayname': 'vm3',
+                'privateport': 22,
+                'publicport': 22,
+                'protocol': 'TCP'
+            }
+        },
+        'nat_rule': {
+            'protocol': 'TCP',
+            'publicport': 22,
+            'privateport': 22
+        },
+        'acls': {
+            'acl1': {
+                'name': 'acl1',
+                'description': 'acl1',
+                'entries': {
+                    'entry1': {
+                        'protocol': 'TCP',
+                        'action': 'Allow',
+                        'traffictype': 'Ingress',
+                        'startport': 22,
+                        'endport': 22
+                    }
+                }
+            },
+            'acl2': {
+                'name': 'acl2',
+                'description': 'acl2',
+                'entries': {
+                    'entry2': {
+                        'protocol': 'TCP',
+                        'action': 'Deny',
+                        'traffictype': 'Ingress',
+                        'startport': 22,
+                        'endport': 22
+                    }
+                }
+            }
+        }
+    }
+
+    @classmethod
+    def setUpClass(cls):
+
+        cls.test_client = super(TestIpExclusionList, cls).getClsTestClient()
+        cls.api_client = cls.test_client.getApiClient()
+
+        cls.class_cleanup = []
+
+        cls.logger = logging.getLogger('TestIpExclusionList')
+        cls.logger.setLevel(logging.DEBUG)
+        cls.logger.addHandler(logging.StreamHandler())
+
+    @classmethod
+    def setup_infra(cls, redundant=False):
+
+        if len(cls.class_cleanup) > 0:
+            cleanup_resources(cls.api_client, cls.class_cleanup, cls.logger)
+            cls.class_cleanup = []
+
+        cls.zone = get_zone(cls.api_client, cls.test_client.getZoneForTests())
+        cls.logger.debug("[TEST] Zone '%s' selected" % cls.zone.name)
+
+        cls.domain = get_domain(cls.api_client)
+        cls.logger.debug("[TEST] Domain '%s' selected" % cls.domain.name)
+
+        cls.template = get_template(
+            cls.api_client,
+            cls.zone.id)
+        cls.logger.debug("[TEST] Template '%s' selected" % cls.template.name)
+
+        cls.account = Account.create(
+            cls.api_client,
+            cls.attributes['account'],
+            admin=True,
+            domainid=cls.domain.id)
+
+        cls.class_cleanup += [cls.account]
+        cls.logger.debug("[TEST] Account '%s' created", cls.account.name)
+
+        cls.vpc_offering = cls.get_default_redundant_vpc_offering() if redundant else cls.get_default_vpc_offering()
+        cls.logger.debug("[TEST] VPC Offering '%s' selected", cls.vpc_offering.name)
+
+        cls.network_offering = cls.get_default_network_offering()
+        cls.logger.debug("[TEST] Network Offering '%s' selected", cls.network_offering.name)
+
+        cls.virtual_machine_offering = cls.get_default_virtual_machine_offering()
+        cls.logger.debug("[TEST] Virtual Machine Offering '%s' selected", cls.virtual_machine_offering.name)
+
+        cls.default_allow_acl = cls.get_default_acl('default_allow')
+        cls.logger.debug("[TEST] ACL '%s' selected", cls.default_allow_acl.name)
+
+        cls.default_deny_acl = cls.get_default_acl('default_deny')
+        cls.logger.debug("[TEST] ACL '%s' selected", cls.default_deny_acl.name)
+
+        cls.vpc1 = VPC.create(cls.api_client,
+            cls.attributes['vpcs']['vpc1'],
+            vpcofferingid=cls.vpc_offering.id,
+            zoneid=cls.zone.id,
+            domainid=cls.domain.id,
+            account=cls.account.name)
+        cls.logger.debug("[TEST] VPC '%s' created, CIDR: %s", cls.vpc1.name, cls.vpc1.cidr)
+
+        cls.network1 = Network.create(cls.api_client,
+            cls.attributes['networks']['network1'],
+            networkofferingid=cls.network_offering.id,
+            aclid=cls.default_allow_acl.id,
+            vpcid=cls.vpc1.id,
+            zoneid=cls.zone.id,
+            domainid=cls.domain.id,
+            accountid=cls.account.name)
+        cls.logger.debug("[TEST] Network '%s' created, CIDR: %s, Gateway: %s", cls.network1.name, cls.network1.cidr, cls.network1.gateway)
+
+        cls.vm1 = VirtualMachine.create(cls.api_client,
+            cls.attributes['vms']['vm1'],
+            templateid=cls.template.id,
+            serviceofferingid=cls.virtual_machine_offering.id,
+            networkids=[cls.network1.id],
+            zoneid=cls.zone.id,
+            domainid=cls.domain.id,
+            accountid=cls.account.name)
+        cls.logger.debug("[TEST] VM '%s' created, Network: %s, IP %s", cls.vm1.name, cls.network1.name, cls.vm1.nic[0].ipaddress)
+
+        cls.public_ip1 = PublicIPAddress.create(cls.api_client,
+            zoneid=cls.zone.id,
+            domainid=cls.account.domainid,
+            accountid=cls.account.name,
+            vpcid=cls.vpc1.id,
+            networkid=cls.network1.id)
+        cls.logger.debug("[TEST] Public IP '%s' acquired, VPC: %s, Network: %s", cls.public_ip1.ipaddress.ipaddress, cls.vpc1.name, cls.network1.name)
+
+        cls.nat_rule1 = NATRule.create(cls.api_client,
+            cls.vm1,
+            cls.attributes['nat_rule'],
+            vpcid=cls.vpc1.id,
+            networkid=cls.network1.id,
+            ipaddressid=cls.public_ip1.ipaddress.id)
+        cls.logger.debug("[TEST] Port Forwarding Rule '%s (%s) %s => %s' created",
+            cls.nat_rule1.ipaddress,
+            cls.nat_rule1.protocol,
+            cls.nat_rule1.publicport,
+            cls.nat_rule1.privateport)
+
+    @classmethod
+    def tearDownClass(cls):
+
+        try:
+            cleanup_resources(cls.api_client, cls.class_cleanup, cls.logger)
+
+        except Exception as e:
+            raise Exception("Exception: %s" % e)
+
+    def setUp(self):
+
+        self.method_cleanup = []
+
+    def tearDown(self):
+
+        try:
+            cleanup_resources(self.api_client, self.method_cleanup, self.logger)
+
+        except Exception as e:
+            raise Exception("Exception: %s" % e)
+
+    @attr(tags=['advanced'], required_hardware='true')
+    def test_01(self):
+
+        self.setup_infra(redundant=False)
+        self.setup_new_network()
+        #
+        # Deploy and test new VM
+        #
+        self.vm2 = self.deploy_new_vm('vm2')
+        self.test_vm(self.vm2, '10.1.2.6')
+        #
+        # Try to deploy new VM without free IPs
+        # Test failure
+        #
+        self.vm3 = self.deploy_new_vm('vm3')
+        self.test_deploy_new_vm_failed(self.vm3)
+        #
+        # Update exlcluded IPs range
+        # Deploy and test new VM
+        #
+        self.expand_free_ips()
+        self.vm3 = self.deploy_new_vm('vm3')
+        self.test_vm(self.vm3, '10.1.2.5')
+
+    def setup_new_network(self):
+        self.network2 = Network.create(self.api_client,
+                                       self.attributes['networks']['network2'],
+                                       networkofferingid=self.network_offering.id,
+                                       aclid=self.default_allow_acl.id,
+                                       vpcid=self.vpc1.id,
+                                       zoneid=self.zone.id,
+                                       domainid=self.domain.id,
+                                       accountid=self.account.name,
+                                       ipexclusionlist='10.1.2.2-10.1.2.5')
+        self.logger.debug("[TEST] Network '%s' created, CIDR: %s, Gateway: %s, Excluded IPs: %s",
+                          self.network2.name, self.network2.cidr, self.network2.gateway,
+                          self.network2.ipexclusionlist)
+
+    def deploy_new_vm(self, vm_name):
+        self.logger.debug('[TEST] Try to deploy new VM')
+
+        try:
+            new_vm = VirtualMachine.create(self.api_client,
+                                           self.attributes['vms'][vm_name],
+                                           templateid=self.template.id,
+                                           serviceofferingid=self.virtual_machine_offering.id,
+                                           networkids=[self.network2.id],
+                                           zoneid=self.zone.id,
+                                           domainid=self.domain.id,
+                                           accountid=self.account.name,
+                                           mode='advanced')
+            self.logger.debug("[TEST] VM '%s' created, Network: %s, IP %s", new_vm.name, self.network2.name,
+                              new_vm.nic[0].ipaddress)
+            return new_vm
+        except Exception as e:
+            if not 'Unable to acquire Guest IP address for network Ntwk' in str(e):
+                self.logger.debug('[TEST] Unexpected Exception: %s', e)
+                raise Exception("Exception: %s" % e)
+            return None
+
+    def test_deploy_new_vm_failed(self, vm):
+        self.assertTrue(vm is None, "VM deployment should fail due to no IPs available")
+        self.logger.debug('[TEST] Check (fail) VM deployment without available IPs: OK')
+
+    def expand_free_ips(self):
+        self.network2.update(self.api_client,
+                             ipexclusionlist='10.1.2.2-10.1.2.4')
+        self.logger.debug('[TEST] IP list expanded')
+
+    def test_vm(self, vm, expected_value):
+        self.assertTrue(vm.nic[0].ipaddress == expected_value, "VM should be assigned the only IP available")
+        ssh_client = vm.get_ssh_client(reconnect=True, retries=10)
+        result = ssh_client.execute("/sbin/ip addr show")
+        self.assertTrue(expected_value in str(result),
+                        "VM should implement the only IP available, ip addr show: " + str(result))
+        self.logger.debug('[TEST] Check implemented IP: OK')
+
+    @classmethod
+    def get_default_vpc_offering(cls):
+
+        offerings = list_vpc_offerings(cls.api_client)
+        offerings = [offering for offering in offerings if offering.name == cls.attributes['default_offerings']['vpc']]
+        return next(iter(offerings or []), None)
+
+    @classmethod
+    def get_default_redundant_vpc_offering(cls):
+
+        offerings = list_vpc_offerings(cls.api_client)
+        offerings = [offering for offering in offerings if offering.name == cls.attributes['default_offerings']['redundant_vpc']]
+        return next(iter(offerings or []), None)
+
+    @classmethod
+    def get_default_network_offering(cls):
+
+        offerings = list_network_offerings(cls.api_client)
+        offerings = [offering for offering in offerings if offering.name == cls.attributes['default_offerings']['network']]
+        return next(iter(offerings or []), None)
+
+    @classmethod
+    def get_default_virtual_machine_offering(cls):
+
+        offerings = list_service_offering(cls.api_client)
+        offerings = [offering for offering in offerings if offering.name == cls.attributes['default_offerings']['virtual_machine']]
+        return next(iter(offerings or []), None)
+
+    @classmethod
+    def get_default_acl(cls, name):
+
+        acls = NetworkACLList.list(cls.api_client)
+        acls = [acl for acl in acls if acl.name == name]
+        return next(iter(acls or []), None)
+
+    @classmethod
+    def get_default_allow_vpc_acl(cls, vpc): # check if it's better to get the ACL from the VPC
+
+        acls = NetworkACLList.list(cls.api_client, vpcid=vpc.id)
+        acls = [acl for acl in acls if acl.name == 'default_allow']
+        return next(iter(acls or []), None)

--- a/cosmic-core/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/cosmic-core/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -16,6 +16,8 @@ import java.net.SocketException;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Formatter;
 import java.util.List;
 import java.util.Random;
@@ -1172,6 +1174,38 @@ public class NetUtils {
             return ip.toString();
         }
         return null;
+    }
+
+    public static List<String> getAllIpsFromRangeList(final String excludedIpsExpression) {
+
+        if (StringUtils.isEmpty(excludedIpsExpression)) {
+
+            return Collections.emptyList();
+        }
+
+        final List<String> ips = Arrays.asList(excludedIpsExpression.split(","));
+        List<String> result = new ArrayList<>();
+        for (String ip : ips) {
+            if (ip.contains("-")) {
+                result.addAll(getAllIpsFromRange(ip));
+            } else {
+                result.add(ip);
+            }
+        }
+        return result;
+    }
+
+    public static List<String> getAllIpsFromRange(final String range) {
+        String[] ips = range.split("-");
+        List<String> result = new ArrayList<>();
+        long startIp = ip2Long(ips[0]);
+        long endIp = ip2Long(ips[1]);
+
+        for (long tmpIp = startIp; tmpIp<=endIp; tmpIp++) {
+            result.add(long2Ip(tmpIp));
+        }
+
+        return result;
     }
 
     // Can cover 127 bits

--- a/cosmic-core/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/cosmic-core/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -552,23 +552,21 @@ public class NetUtils {
         return true;
     }
 
-    public static SortedSet<Long> getAllIpsFromCidr(final String cidr, final long size, final Set<Long> usedIps) {
-        assert size < MAX_CIDR : "You do know this is not for ipv6 right?  Keep it smaller than 32 but you have " + size;
+    public static SortedSet<Long> getAllIpsFromCidr(final String cidr, final Set<Long> usedIps) {
+        final String cidrIp = getCidr(cidr).first();
+        final Integer cidrSize = getCidr(cidr).second();
+
+        return getAllIpsFromCidr(cidrIp, cidrSize, usedIps);
+    }
+
+    public static SortedSet<Long> getAllIpsFromCidr(final String cidr_ip, final long size, final Set<Long> usedIps) {
         final SortedSet<Long> result = new TreeSet<>();
-        final long ip = ip2Long(cidr);
-        final long startNetMask = ip2Long(getCidrNetmask(size));
-        long start = (ip & startNetMask) + 1;
-        long end = start;
+        long start = ip2Long(getIpRangeStartIpFromCidr(cidr_ip, size));
+        long end = ip2Long(getIpRangeEndIpFromCidr(cidr_ip,size));
 
-        end = end >> MAX_CIDR - size;
-
-        end++;
-        end = (end << MAX_CIDR - size) - 2;
-        int maxIps = 255; // get 255 ips as maximum
-        while (start <= end && maxIps > 0) {
+        while (start <= end) {
             if (!usedIps.contains(start)) {
                 result.add(start);
-                maxIps--;
             }
             start++;
         }

--- a/cosmic-core/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
+++ b/cosmic-core/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
@@ -16,10 +16,12 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.NetUtils.SupersetOrSubset;
 
 import java.math.BigInteger;
+import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
 import com.googlecode.ipv6.IPv6Address;
+import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -572,5 +574,32 @@ public class NetUtilsTest {
 
         assertTrue(NetUtils.isNetworkorBroadcastIP("192.168.0.63", "255.255.255.192"));
         assertFalse(NetUtils.isNetworkorBroadcastIP("192.168.0.63", "255.255.255.128"));
+    }
+
+    @Test
+    public void testGetAllIpsFromRange() {
+        List<String> ips = NetUtils.getAllIpsFromRange("10.0.0.1-10.0.0.3");
+        Assert.assertEquals(ips.get(0), "10.0.0.1");
+        Assert.assertEquals(ips.get(1), "10.0.0.2");
+        Assert.assertEquals(ips.get(2), "10.0.0.3");
+        assertTrue(ips.size() == 3);
+
+        ips = NetUtils.getAllIpsFromRange("10.0.1.254-10.0.2.2");
+        assertTrue(ips.size() == 5);
+
+    }
+
+    @Test
+    public void testGetAllIpsFromRangeList() {
+        List<String> ips = NetUtils.getAllIpsFromRangeList("10.0.0.1-10.0.0.3,10.0.0.7");
+        Assert.assertEquals(ips.get(0), "10.0.0.1");
+        Assert.assertEquals(ips.get(1), "10.0.0.2");
+        Assert.assertEquals(ips.get(2), "10.0.0.3");
+        Assert.assertEquals(ips.get(3), "10.0.0.7");
+        assertTrue(ips.size() == 4);
+
+        ips = NetUtils.getAllIpsFromRangeList(null);
+        assertTrue(ips.isEmpty());
+
     }
 }

--- a/cosmic-core/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
+++ b/cosmic-core/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
@@ -16,6 +16,7 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.NetUtils.SupersetOrSubset;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -602,7 +603,6 @@ public class NetUtilsTest {
 
         ips = NetUtils.getAllIpsFromRange("10.0.1.254-10.0.2.2");
         assertTrue(ips.size() == 5);
-
     }
 
     @Test
@@ -616,6 +616,44 @@ public class NetUtilsTest {
 
         ips = NetUtils.getAllIpsFromRangeList(null);
         assertTrue(ips.isEmpty());
+    }
 
+    @Test
+    public void testValidIpRangeList() {
+
+        assertFalse(NetUtils.validIpRangeList(""));
+        assertFalse(NetUtils.validIpRangeList(null));
+
+        // Test (specifically/single) address
+        assertTrue(NetUtils.validIpRangeList("1.2.3.4"));
+        assertFalse(NetUtils.validIpRangeList("256.2.3.4"));
+
+        // Test range addresses
+        assertTrue(NetUtils.validIpRangeList("1.2.3.4-2.3.4.5"));
+        assertFalse(NetUtils.validIpRangeList("1.2.3.4-"));
+
+        //Test collection addresses
+        assertTrue(NetUtils.validIpRangeList("1.1.1.1,2.2.2.2-3.3.3.3,4.4.4.4"));
+    }
+
+    @Test
+    public void testIsIpRangeListInCidr() {
+        assertTrue(NetUtils.isIpRangeListInCidr("10.0.0.1,10.0.0.3-10.0.0.6", "10.0.0.0/29"));
+        assertFalse(NetUtils.isIpRangeListInCidr("10.0.0.1-10.0.0.8", "10.0.0.0/29"));
+    }
+
+    @Test
+    public void testListIp2LongList() {
+        List<String> stringList = new ArrayList<>();
+        stringList.add("10.0.0.1");
+        stringList.add("10.0.0.2");
+        stringList.add("10.0.0.3");
+
+        SortedSet<Long> longList = NetUtils.listIp2LongList(stringList);
+
+        assertTrue(stringList.size() == longList.size());
+        assertTrue(longList.contains(167772161L));
+        assertTrue(longList.contains(167772162L));
+        assertTrue(longList.contains(167772163L));
     }
 }

--- a/cosmic-core/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
+++ b/cosmic-core/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
@@ -16,7 +16,9 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.NetUtils.SupersetOrSubset;
 
 import java.math.BigInteger;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -239,6 +241,20 @@ public class NetUtilsTest {
         assertTrue(NetUtils.isValidCIDR(cidrFirst));
         assertTrue(NetUtils.isValidCIDR(cidrSecond));
         assertTrue(NetUtils.isValidCIDR(cidrThird));
+    }
+
+    @Test
+    public void testGetAllIpsFromCidr() throws Exception {
+        final Set<Long> emptyList = new HashSet<>();
+
+        assertTrue(NetUtils.getAllIpsFromCidr("10.0.0.0", 24L, emptyList).size() == 254);
+        assertTrue(NetUtils.getAllIpsFromCidr("10.0.0.0", 25L, emptyList).size() == 126);
+        assertTrue(NetUtils.getAllIpsFromCidr("10.0.0.0", 30L, emptyList).size() == 2);
+        assertTrue(NetUtils.getAllIpsFromCidr("10.0.0.0/31", emptyList).size() == 0);
+        assertTrue(NetUtils.getAllIpsFromCidr("10.0.0.0/32", emptyList).size() == 0);
+
+        assertTrue(NetUtils.getAllIpsFromCidr("10.0.0.0", 23L, emptyList).size() == 510);
+        assertTrue(NetUtils.getAllIpsFromCidr("10.0.0.0", 16L, emptyList).size() == 65534);
     }
 
     @Test

--- a/cosmic-marvin/marvin/lib/base.py
+++ b/cosmic-marvin/marvin/lib/base.py
@@ -2724,7 +2724,7 @@ class Network:
                networkofferingid=None, projectid=None,
                subdomainaccess=None, zoneid=None,
                gateway=None, netmask=None, cidr=None,
-               vpcid=None, aclid=None, vlan=None):
+               vpcid=None, aclid=None, vlan=None, ipexclusionlist=None):
         """Create Network for account"""
         cmd = createNetwork.createNetworkCmd()
         cmd.name = services["name"]
@@ -2739,6 +2739,11 @@ class Network:
             cmd.zoneid = zoneid
         elif "zoneid" in services:
             cmd.zoneid = services["zoneid"]
+
+        if ipexclusionlist:
+            cmd.ipexclusionlist = ipexclusionlist
+        elif "ipexclusionlist" in services:
+            cmd.ipexclusionlist = services["ipexclusionlist"]
 
         if subdomainaccess is not None:
             cmd.subdomainaccess = subdomainaccess


### PR DESCRIPTION
This PR adds the capability to configure an IP exclusion list for a tier, which will exclude respective addresses from being assigned to guests in that tier.

The IP exclusion list is a comma separated list of IP addresses or IP ranges.
An IP range is defined as two addresses, start and end, separated by a dash, e.g. `10.2.3.4-10.2.330` or `10.0.0.2-10.0.0.254`.
A few examples of valid lists:
- `10.0.0.2,10.0.0.4-10.0.0.7`; for a network defined as `10.0.0.0/29`, this allows assignment of the host addresses 10.0.0.1 and 10.0.0.3
- `10.0.0.2,10.0.0.3,10.0.0.5-10.0.0.254`; for a network defined as `10.0.0.0/24`, this allows assignment of the host addresses 10.0.0.1 and 10.0.0.4

The IP exclusion list can be defined when creating a tier (API `createNetwork`):
![ip_excl_list_create_tier](https://cloud.githubusercontent.com/assets/2699104/24489376/4a29cdb2-151d-11e7-8f7a-daca56a0210e.png)

The IP exclusion list can be created or changed by editing a tier (API `updateNetwork`):
![ip_excl_list_edit_tier](https://cloud.githubusercontent.com/assets/2699104/24489431/bcdb6c6c-151d-11e7-9dad-94e48e18eb81.png)


Following through on the example, only the IP addresses of `10.0.0.1` and `10.0.0.3` are available, where the first is assigned to the gateway and the second to the first VM. Deploying a second VM will not be possible in this example; no tiers available for deployment:
![ip_excl_list_2nd_vm](https://cloud.githubusercontent.com/assets/2699104/24489965/8df17cb8-1520-11e7-9bcf-5bf5c01ecbe6.png)

Or using cloudmonkey:
![image](https://cloud.githubusercontent.com/assets/2699104/24490812/9bf494b8-1524-11e7-9859-719774d7c948.png)


Changing the list, making address `10.0.0.4` available in this example,... 
![image](https://cloud.githubusercontent.com/assets/2699104/24490579/68b2a2da-1523-11e7-9f63-41b1e1e8f06e.png)

will enable deployment to the tier:
![image](https://cloud.githubusercontent.com/assets/2699104/24490699/12c41d94-1524-11e7-8782-34fc4b644121.png)

 