### PR TITLE
Prevent VM deployments in networks of type Private

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/DeployVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/DeployVMCmd.java
@@ -337,6 +337,9 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd {
                 final HashMap<String, String> ips = (HashMap<String, String>) iter.next();
                 final Long networkId;
                 final Network network = _networkService.getNetwork(ips.get("networkid"));
+                if (Network.GuestType.Private.equals(network.getGuestType())) {
+                    throw new InvalidParameterValueException("Deploying VMs in a network of type " + Network.GuestType.Private + " is not possible.");
+                }
                 if (network != null) {
                     networkId = network.getId();
                 } else {

--- a/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -2616,6 +2616,9 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 if (network == null) {
                     throw new InvalidParameterValueException("Unable to find network by id " + networkIdList.get(0).longValue());
                 }
+                if (Network.GuestType.Private.equals(network.getGuestType())) {
+                    throw new InvalidParameterValueException("Deploying VMs in a network of type " + Network.GuestType.Private + " is not possible.");
+                }
                 if (network.getVpcId() != null) {
                     // Only ISOs, XenServer, KVM and template types are
                     // supported for vpc networks


### PR DESCRIPTION
Networks of type `Private` are supposed to be a transport network, so only `Private Gateways` are allowed. This blocks deploying VMs in `Private` networks.