### PR TITLE
Allow passing rootDiskController detail to a VM to specify type on per vm basis

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/templates.js
+++ b/cosmic-client/src/main/webapp/scripts/templates.js
@@ -200,15 +200,15 @@
                                                     $form.find('.form-item[rel=rootDiskControllerType]').hide();
                                                     $form.find('.form-item[rel=nicAdapterType]').hide();
                                                     $form.find('.form-item[rel=keyboardType]').hide();
-
+                                                    $form.find('.form-item[rel=rootDiskControllerTypeKVM]').hide();
                                                     if (isAdmin())
                                                         $form.find('.form-item[rel=xenserverToolsVersion61plus]').css('display', 'inline-block');
                                                 } else {
                                                     $form.find('.form-item[rel=rootDiskControllerType]').hide();
                                                     $form.find('.form-item[rel=nicAdapterType]').hide();
                                                     $form.find('.form-item[rel=keyboardType]').hide();
-
                                                     $form.find('.form-item[rel=xenserverToolsVersion61plus]').hide();
+                                                    $form.find('.form-item[rel=rootDiskControllerTypeKVM]').css('display', 'inline-block');
                                                 }
                                             });
 
@@ -238,6 +238,39 @@
                                             return b;
                                         },
                                         isHidden: true
+                                    },
+
+
+                                    //fields for hypervisor == "KVM" (starts here)
+                                    rootDiskControllerTypeKVM: {
+                                        label: 'label.root.disk.controller',
+                                        isHidden: true,
+                                        select: function(args) {
+                                            var items = []
+                                            items.push({
+                                                id: "",
+                                                description: ""
+                                            });
+                                            items.push({
+                                                id: "ide",
+                                                description: "ide"
+                                            });
+                                            items.push({
+                                                id: "osdefault",
+                                                description: "osdefault"
+                                            });
+                                            items.push({
+                                                id: "scsi",
+                                                description: "virtio-scsi"
+                                            });
+                                            items.push({
+                                                id: "virtio",
+                                                description: "virtio"
+                                            });
+                                            args.response.success({
+                                                data: items
+                                            });
+                                        }
                                     },
 
                                     format: {
@@ -394,6 +427,14 @@
                                     });
                                 }
                                 //XenServer only (ends here)
+
+                                // KVM only (starts here)
+                                if (args.$form.find('.form-item[rel=rootDiskControllerTypeKVM]').css("display") != "none" && args.data.rootDiskControllerTypeKVM != "") {
+                                    $.extend(data, {
+                                        'details[0].rootDiskController': args.data.rootDiskControllerTypeKVM
+                                    });
+                                }
+                                // KVM only (ends here)
 
                                 $.ajax({
                                     url: createURL('registerTemplate'),

--- a/cosmic-core/api/src/main/java/com/cloud/vm/VmDetailConstants.java
+++ b/cosmic-core/api/src/main/java/com/cloud/vm/VmDetailConstants.java
@@ -3,7 +3,7 @@ package com.cloud.vm;
 public interface VmDetailConstants {
     public static final String KEYBOARD = "keyboard";
     public static final String NIC_ADAPTER = "nicAdapter";
-    public static final String ROOK_DISK_CONTROLLER = "rootDiskController";
+    public static final String ROOT_DISK_CONTROLLER = "rootDiskController";
     public static final String NESTED_VIRTUALIZATION_FLAG = "nestedVirtualizationFlag";
     public static final String HYPERVISOR_TOOLS_VERSION = "hypervisortoolsversion";
     public static final String DATA_DISK_CONTROLLER = "dataDiskController";

--- a/cosmic-core/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1043,7 +1043,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             }
             _userVmDao.loadDetails(vm);
             final Map<String, String> controllerInfo = new HashMap<>();
-            controllerInfo.put(VmDetailConstants.ROOK_DISK_CONTROLLER, vm.getDetail(VmDetailConstants.ROOK_DISK_CONTROLLER));
+            controllerInfo.put(VmDetailConstants.ROOT_DISK_CONTROLLER, vm.getDetail(VmDetailConstants.ROOT_DISK_CONTROLLER));
             controllerInfo.put(VmDetailConstants.DATA_DISK_CONTROLLER, vm.getDetail(VmDetailConstants.DATA_DISK_CONTROLLER));
             cmd.setControllerInfo(controllerInfo);
 


### PR DESCRIPTION
PR #296 adds support for virtIO-SCSI controllers. It allows to get a SCSI controller when setting the `OSType` to anything with `virtIO-SCSI` in its name.

This PR allows specifying the `rootDiskController` to `scsi` by using resource details. It's possible to specify details on the template and directly to any VM. When set to the template, any VM started from this template will inherit the property and also get a `scsi` controller.

Setting at template:
![image](https://cloud.githubusercontent.com/assets/1630096/23716237/cd8ca156-042f-11e7-8ca1-895e337b2020.png)

```
(local) 🐵 > list virtualmachines filter=id,name
count = 1
virtualmachine:
+--------------------------------------+-----------------------------------------+
|                  id                  |                   name                  |
+--------------------------------------+-----------------------------------------+
| 96eb7bee-443a-45a6-99b6-5fec2c8081f5 | VM-96eb7bee-443a-45a6-99b6-5fec2c8081f5 |
+--------------------------------------+-----------------------------------------+
(local) 🐵 > list resourcedetails resourceid=96eb7bee-443a-45a6-99b6-5fec2c8081f5 resourcetype=uservm
count = 1
resourcedetail:
+--------------+------------+-------+--------------------+------------+
| resourcetype | resourceid | value |        key         | fordisplay |
+--------------+------------+-------+--------------------+------------+
|    UserVm    |     6      |  scsi | rootDiskController |    True    |
+--------------+------------+-------+--------------------+------------+
```

Using the `setResourceDetail` API call (type=userVm) you can set it on individual VMs and after stop/start they will get a `rootDiskController` of the specified type.

![image](https://cloud.githubusercontent.com/assets/1630096/23716495/c2f7ccb0-0430-11e7-83e6-5ace3e467324.png)

Backport from ACS PR 1955