### PR TITLE
Support both OpenSwan and StrongSwan VPN

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/network.js
+++ b/cosmic-client/src/main/webapp/scripts/network.js
@@ -5864,6 +5864,18 @@
                                                 id: 'sha1',
                                                 description: 'sha1'
                                             });
+                                            items.push({
+                                                id: 'sha256',
+                                                description: 'sha256'
+                                            });
+                                            items.push({
+                                                id: 'sha384',
+                                                description: 'sha384'
+                                            });
+                                            items.push({
+                                                id: 'sha512',
+                                                description: 'sha512'
+                                            });
                                             args.response.success({
                                                 data: items
                                             });
@@ -5885,6 +5897,26 @@
                                             items.push({
                                                 id: 'modp1536',
                                                 description: 'Group 5(modp1536)'
+                                            });
+                                            items.push({
+                                                id: 'modp2048',
+                                                description: 'Group 14(modp2048)'
+                                            });
+                                            items.push({
+                                                id: 'modp3072',
+                                                description: 'Group 15(modp3072)'
+                                            });
+                                            items.push({
+                                                id: 'modp4096',
+                                                description: 'Group 16(modp4096)'
+                                            });
+                                            items.push({
+                                                id: 'modp6144',
+                                                description: 'Group 17(modp6144)'
+                                            });
+                                            items.push({
+                                                id: 'modp8192',
+                                                description: 'Group 18(modp8192)'
                                             });
                                             args.response.success({
                                                 data: items
@@ -5932,6 +5964,18 @@
                                                 id: 'sha1',
                                                 description: 'sha1'
                                             });
+                                            items.push({
+                                                id: 'sha256',
+                                                description: 'sha256'
+                                            });
+                                            items.push({
+                                                id: 'sha384',
+                                                description: 'sha384'
+                                            });
+                                            items.push({
+                                                id: 'sha512',
+                                                description: 'sha512'
+                                            });
                                             args.response.success({
                                                 data: items
                                             });
@@ -5953,6 +5997,26 @@
                                             items.push({
                                                 id: 'modp1536',
                                                 description: 'Group 5(modp1536)'
+                                            });
+                                           items.push({
+                                                id: 'modp2048',
+                                                description: 'Group 14(modp2048)'
+                                            });
+                                            items.push({
+                                                id: 'modp3072',
+                                                description: 'Group 15(modp3072)'
+                                            });
+                                            items.push({
+                                                id: 'modp4096',
+                                                description: 'Group 16(modp4096)'
+                                            });
+                                            items.push({
+                                                id: 'modp6144',
+                                                description: 'Group 17(modp6144)'
+                                            });
+                                            items.push({
+                                                id: 'modp8192',
+                                                description: 'Group 18(modp8192)'
                                             });
                                             args.response.success({
                                                 data: items

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
@@ -158,11 +158,11 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
         final String ipsecPsk = cmd.getIpsecPsk();
         final String ikePolicy = cmd.getIkePolicy();
         final String espPolicy = cmd.getEspPolicy();
-        if (!NetUtils.isValidS2SVpnPolicy(ikePolicy)) {
-            throw new InvalidParameterValueException("The customer gateway IKE policy " + ikePolicy + " is invalid!");
+        if (!NetUtils.isValidS2SVpnPolicy("ike", ikePolicy)) {
+            throw new InvalidParameterValueException("The customer gateway IKE policy " + ikePolicy + " is invalid! Verify the required Diffie Hellman (DH) group is specified.");
         }
-        if (!NetUtils.isValidS2SVpnPolicy(espPolicy)) {
-            throw new InvalidParameterValueException("The customer gateway ESP policy " + espPolicy + " is invalid!");
+        if (!NetUtils.isValidS2SVpnPolicy("esp", espPolicy)) {
+            throw new InvalidParameterValueException("The customer gateway ESP policy " + espPolicy + " is invalid! Verify the required Diffie Hellman (DH) group is specified.");
         }
         Long ikeLifetime = cmd.getIkeLifetime();
         if (ikeLifetime == null) {
@@ -443,10 +443,6 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
             throw new CloudRuntimeException("Unable to acquire lock on " + conn);
         }
         try {
-            if (conn.getState() != State.Connected && conn.getState() != State.Error) {
-                throw new InvalidParameterValueException("Site to site VPN connection with specified id is not in correct state(connected) to process disconnect!");
-            }
-
             conn.setState(State.Disconnected);
             _vpnConnectionDao.persist(conn);
 
@@ -652,10 +648,10 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
         final String ipsecPsk = cmd.getIpsecPsk();
         final String ikePolicy = cmd.getIkePolicy();
         final String espPolicy = cmd.getEspPolicy();
-        if (!NetUtils.isValidS2SVpnPolicy(ikePolicy)) {
+        if (!NetUtils.isValidS2SVpnPolicy("ike", ikePolicy)) {
             throw new InvalidParameterValueException("The customer gateway IKE policy" + ikePolicy + " is invalid!");
         }
-        if (!NetUtils.isValidS2SVpnPolicy(espPolicy)) {
+        if (!NetUtils.isValidS2SVpnPolicy("esp", espPolicy)) {
             throw new InvalidParameterValueException("The customer gateway ESP policy" + espPolicy + " is invalid!");
         }
         Long ikeLifetime = cmd.getIkeLifetime();

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/checks2svpn.sh
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/checks2svpn.sh
@@ -1,12 +1,39 @@
 #!/bin/bash
 
-
 if [ -z $1 ]
 then
     echo "Fail to find VPN peer address!"
     exit 1
 fi
 
+if [ -f /etc/cloudstack-release ]
+  then
+    VERSION_DATA=$(cat /etc/cloudstack-release | cut -d" " -f3)
+    export IFS="."
+    for part in ${VERSION_DATA}; do
+        SYSTEMVM_VERSION=${SYSTEMVM_VERSION}$(printf "%02d" ${part})
+    done
+    export IFS=";"
+fi
+
+# Strongswan check
+if (( "${SYSTEMVM_VERSION}" > "170312" )); then
+    ipsec status  vpn-$1 > /tmp/vpn-$1.status
+
+    cat /tmp/vpn-$1.status | grep "ESTABLISHED" > /dev/null
+    ipsecok=$?
+    if [ $ipsecok -ne 0 ]
+    then
+        echo -n "IPsec SA not found;"
+        echo "Site-to-site VPN have not connected"
+        exit 11
+    fi
+    echo -n "IPsec SA found;"
+    echo "Site-to-site VPN have connected"
+    exit 0
+fi
+
+# Openswan check
 ipsec auto --status | grep vpn-$1 > /tmp/vpn-$1.status
 
 cat /tmp/vpn-$1.status | grep "ISAKMP SA established" > /dev/null

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -451,13 +451,13 @@ class CsSite2SiteVpn(CsDataBag):
 
     def deletevpn(self, ip):
         logging.info("Removing VPN configuration for %s", ip)
-        CsHelper.execute("ipsec auto --down vpn-%s" % ip)
-        CsHelper.execute("ipsec auto --delete vpn-%s" % ip)
+        CsHelper.execute("ipsec down vpn-%s" % ip)
+        CsHelper.execute("ipsec down vpn-%s" % ip)
         vpnconffile = "%s/ipsec.vpn-%s.conf" % (self.VPNCONFDIR, ip)
         vpnsecretsfile = "%s/ipsec.vpn-%s.secrets" % (self.VPNCONFDIR, ip)
         os.remove(vpnconffile)
         os.remove(vpnsecretsfile)
-        CsHelper.execute("ipsec auto --rereadall")
+        CsHelper.execute("ipsec reload")
 
     def configure_iptables(self, dev, obj):
         self.fw.append(["", "front", "-A INPUT -i %s -p udp -m udp --dport 500 -s %s -d %s -j ACCEPT" % (dev, obj['peer_gateway_ip'], obj['local_public_ip'])])
@@ -477,46 +477,71 @@ class CsSite2SiteVpn(CsDataBag):
     def configure_ipsec(self, obj):
         leftpeer = obj['local_public_ip']
         rightpeer = obj['peer_gateway_ip']
-        peerlist = obj['peer_guest_cidr_list'].lstrip().rstrip().replace(',', ' ')
+        peerlist = obj['peer_guest_cidr_list'].replace(' ', '')
         vpnconffile = "%s/ipsec.vpn-%s.conf" % (self.VPNCONFDIR, rightpeer)
         vpnsecretsfile = "%s/ipsec.vpn-%s.secrets" % (self.VPNCONFDIR, rightpeer)
+        ikepolicy=obj['ike_policy'].replace(';','-')
+        esppolicy=obj['esp_policy'].replace(';','-')
+
+        strokefile='/etc/strongswan.d/charon/stroke.conf'
+        ipsecconf='/etc/ipsec.conf'
+
+        # Set timeout to 30s
+        file = CsFile(strokefile)
+        file.greplace("# timeout = 0", "timeout = 30000")
+        file.commit()
+
+        # Handle ipsec.conf
+        file = CsFile(ipsecconf)
+        file.empty()
+        file.addeq("# ipsec.conf - strongSwan IPsec configuration file")
+        file.addeq("include /etc/ipsec.d/*.conf")
+        file.commit()
+
+        pfs='no'
+        if 'modp' in esppolicy:
+            pfs='yes'
+
         if rightpeer in self.confips:
             self.confips.remove(rightpeer)
         file = CsFile(vpnconffile)
+        file.add("#conn for vpn-%s" % rightpeer, 0)
         file.search("conn ", "conn vpn-%s" % rightpeer)
         file.addeq(" left=%s" % leftpeer)
         file.addeq(" leftsubnet=%s" % obj['local_guest_cidr'])
         file.addeq(" leftnexthop=%s" % obj['local_public_gateway'])
         file.addeq(" right=%s" % rightpeer)
-        file.addeq(" rightsubnets={%s}" % peerlist)
+        file.addeq(" rightsubnet=%s" % peerlist)
         file.addeq(" type=tunnel")
         file.addeq(" authby=secret")
         file.addeq(" keyexchange=ike")
-        file.addeq(" ike=%s" % obj['ike_policy'])
+        file.addeq(" ike=%s" % ikepolicy)
         file.addeq(" ikelifetime=%s" % self.convert_sec_to_h(obj['ike_lifetime']))
-        file.addeq(" esp=%s" % obj['esp_policy'])
-        file.addeq(" salifetime=%s" % self.convert_sec_to_h(obj['esp_lifetime']))
-        file.addeq(" pfs=%s" % CsHelper.bool_to_yn(obj['dpd']))
-        file.addeq(" keyingtries=%forever")
+        file.addeq(" esp=%s" % esppolicy)
+        file.addeq(" lifetime=%s" % self.convert_sec_to_h(obj['esp_lifetime']))
+        file.addeq(" pfs=%s" % pfs)
+        file.addeq(" keyingtries=2")
         file.addeq(" auto=start")
-        if not obj.has_key('encap'):
-            obj['encap'] = False
+        if 'encap' not in obj:
+            obj['encap']=False
         file.addeq(" forceencaps=%s" % CsHelper.bool_to_yn(obj['encap']))
         if obj['dpd']:
-            file.addeq("  dpddelay=30")
-            file.addeq("  dpdtimeout=120")
-            file.addeq("  dpdaction=restart")
+            file.addeq(" dpddelay=30")
+            file.addeq(" dpdtimeout=120")
+            file.addeq(" dpdaction=restart")
         secret = CsFile(vpnsecretsfile)
-        secret.search("%s " % leftpeer, "%s %s: PSK \"%s\"" % (leftpeer, rightpeer, obj['ipsec_psk']))
+        secret.search("%s " % leftpeer, "%s %s : PSK \"%s\"" % (leftpeer, rightpeer, obj['ipsec_psk']))
         if secret.is_changed() or file.is_changed():
             secret.commit()
             file.commit()
             logging.info("Configured vpn %s %s", leftpeer, rightpeer)
-            CsHelper.execute("ipsec auto --rereadall")
-            CsHelper.execute("ipsec auto --add vpn-%s" % rightpeer)
-            if not obj['passive']:
-                CsHelper.execute("ipsec auto --up vpn-%s" % rightpeer)
-        os.chmod(vpnsecretsfile, 0o400)
+            CsHelper.execute("ipsec rereadsecrets")
+
+        CsHelper.execute("ipsec reload")
+        if not obj['passive']:
+            CsHelper.execute("sudo nohup ipsec down vpn-%s" % rightpeer)
+            CsHelper.execute("sudo nohup ipsec up vpn-%s &" % rightpeer)
+        os.chmod(vpnsecretsfile, 0400)
 
     def convert_sec_to_h(self, val):
         hrs = int(val) / 3600
@@ -694,6 +719,132 @@ class CsVpnUser(CsDataBag):
 
 
 class CsRemoteAccessVpn(CsDataBag):
+    VPNCONFDIR = "/etc/ipsec.d"
+
+    def process(self):
+        self.confips = []
+
+        logging.debug(self.dbag)
+        for public_ip in self.dbag:
+            if public_ip == "id":
+                continue
+            vpnconfig=self.dbag[public_ip]
+
+            # Enable remote access vpn
+            if vpnconfig['create']:
+                logging.debug("Enabling  remote access vpn  on "+ public_ip)
+                CsHelper.start_if_stopped("ipsec")
+                self.configure_l2tpIpsec(public_ip, self.dbag[public_ip])
+                logging.debug("Remote accessvpn  data bag %s",  self.dbag)
+                self.remoteaccessvpn_iptables(public_ip, self.dbag[public_ip])
+
+                CsHelper.execute("ipsec down L2TP-PSK")
+                CsHelper.execute("ipsec update")
+                CsHelper.execute("service xl2tpd stop")
+                CsHelper.execute("service xl2tpd start")
+                CsHelper.execute("ipsec rereadsecrets")
+            else:
+                logging.debug("Disabling remote access vpn .....")
+                # disable remote access vpn
+                CsHelper.execute("ipsec down L2TP-PSK")
+                CsHelper.execute("service xl2tpd stop")
+
+    def configure_l2tpIpsec(self, left,  obj):
+        l2tpconffile="%s/l2tp.conf" % (self.VPNCONFDIR)
+        vpnsecretfilte="%s/ipsec.any.secrets" % (self.VPNCONFDIR)
+        xl2tpdconffile="/etc/xl2tpd/xl2tpd.conf"
+        xl2tpoptionsfile='/etc/ppp/options.xl2tpd'
+        strokefile='/etc/strongswan.d/charon/stroke.conf'
+        ipsecconf='/etc/ipsec.conf'
+
+        file = CsFile(l2tpconffile)
+        localip=obj['local_ip']
+        iprange=obj['ip_range']
+        psk=obj['preshared_key']
+
+        # l2tp config options
+        file.search("pfs=", "        pfs=no")
+        file.search("rekey=", "        rekey=no")
+        file.search("keyingtries=", "        keyingtries=3")
+        file.search("keyexchange=", "        keyexchange=ikev1")
+        file.search("forceencaps=", "        forceencaps=yes")
+        file.search("leftfirewall=", "        leftfirewall=yes")
+        file.search("leftnexthop=", "        leftnexthop=%defaultroute")
+        file.search("type=", "        type=transport")
+        file.search("leftprotoport=", "        leftprotoport=17/1701")
+        file.search("right=", "        right=%any")
+        file.search("rightprotoport=", "        rightprotoport=17/%any")
+        file.search("auto=", "        auto=add")
+        file.search("rightsubnetwithin=", "        rightsubnetwithin=0.0.0.0/0")
+        file.search("left=", "        left=%s" % left)
+        file.search("authby=", "        authby=psk")
+        file.commit()
+
+        # Set timeout to 30s
+        file = CsFile(strokefile)
+        file.greplace("# timeout = 0", "timeout = 30000")
+        file.commit()
+
+        # Handle ipsec.conf
+        file = CsFile(ipsecconf)
+        file.empty()
+        file.addeq("# ipsec.conf - strongSwan IPsec configuration file")
+        file.addeq("include /etc/ipsec.d/*.conf")
+        file.commit()
+
+        # Secrets
+        secret = CsFile(vpnsecretfilte)
+        secret.addeq(": PSK \"%s\"" %psk)
+        secret.commit()
+
+        xl2tpdconf = CsFile(xl2tpdconffile)
+        xl2tpdconf.addeq("ip range = %s" %iprange)
+        xl2tpdconf.addeq("local ip = %s" %localip)
+        xl2tpdconf.commit()
+
+        xl2tpoptions=CsFile(xl2tpoptionsfile)
+        xl2tpoptions.search("ms-dns ", "ms-dns %s" %localip)
+        xl2tpoptions.commit()
+
+    def remoteaccessvpn_iptables(self, publicip, obj):
+        publicdev=obj['public_interface']
+        localcidr=obj['local_cidr']
+        local_ip=obj['local_ip']
+
+        self.fw.append(["", "", "-A INPUT -i %s --dst %s -p udp -m udp --dport 500 -j ACCEPT" % (publicdev, publicip)])
+        self.fw.append(["", "", "-A INPUT -i %s --dst %s -p udp -m udp --dport 4500 -j ACCEPT" % (publicdev, publicip)])
+        self.fw.append(["", "", "-A INPUT -i %s --dst %s -p udp -m udp --dport 1701 -j ACCEPT" % (publicdev, publicip)])
+        self.fw.append(["", "", "-A INPUT -i %s -p ah -j ACCEPT" % publicdev])
+        self.fw.append(["", "", "-A INPUT -i %s -p esp -j ACCEPT" % publicdev])
+
+        if self.config.is_vpc():
+            self.fw.append(["", ""," -N VPN_FORWARD"])
+            self.fw.append(["", "","-I FORWARD -i ppp+ -j VPN_FORWARD"])
+            self.fw.append(["", "","-I FORWARD -o ppp+ -j VPN_FORWARD"])
+            self.fw.append(["", "","-I FORWARD -o ppp+ -j VPN_FORWARD"])
+            self.fw.append(["", "","-A VPN_FORWARD -s  %s -j RETURN" %localcidr])
+            self.fw.append(["", "","-A VPN_FORWARD -i ppp+ -d %s -j RETURN" %localcidr])
+            self.fw.append(["", "","-A VPN_FORWARD -i ppp+  -o ppp+ -j RETURN"])
+        else:
+            self.fw.append(["", "","-A FORWARD -i ppp+ -o  ppp+ -j ACCEPT"])
+            self.fw.append(["", "","-A FORWARD -s %s -o  ppp+ -j ACCEPT" % localcidr])
+            self.fw.append(["", "","-A FORWARD -i ppp+ -d %s  -j ACCEPT" % localcidr])
+
+        self.fw.append(["", "","-A INPUT -i ppp+ -m udp -p udp --dport 53 -j ACCEPT"])
+        self.fw.append(["", "","-A INPUT -i ppp+ -m tcp -p tcp --dport 53 -j ACCEPT"])
+        self.fw.append(["nat", "","-I PREROUTING -i ppp+ -m tcp --dport 53 -j DNAT --to-destination %s" % local_ip])
+
+        if self.config.is_vpc():
+            return
+
+        self.fw.append(["mangle", "","-N  VPN_%s " %publicip])
+        self.fw.append(["mangle", "","-A VPN_%s -j RETURN " % publicip])
+        self.fw.append(["mangle", "","-I VPN_%s -p ah  -j ACCEPT " % publicip])
+        self.fw.append(["mangle", "","-I VPN_%s -p esp  -j ACCEPT " % publicip])
+        self.fw.append(["mangle", "","-I PREROUTING  -d %s -j VPN_%s " % (publicip, publicip)])
+
+
+class CsRemoteAccessVpnOpenSwan(CsDataBag):
     VPNCONFDIR = "/etc/ipsec.d"
 
     def process(self):
@@ -999,18 +1150,19 @@ class IpTablesExecutor:
         fwd = CsForwardingRules("forwardingrules", self.config)
         fwd.process()
 
-        # Strongswan is included in the systemvm template 17.3.9 and newer
-        if get_systemvm_version() > 170309:
-            logging.debug("Configuring Strongswan VPN")
+        # Strongswan is included in the systemvm template 17.3.12 and newer
+        if get_systemvm_version() > 170312:
+            logging.debug("Found StrongSwan compatible systemvm template so let's configure VPN with it")
             vpns = CsSite2SiteVpn("site2sitevpn", self.config)
             vpns.process()
+            rvpn = CsRemoteAccessVpn("remoteaccessvpn", self.config)
+            rvpn.process()
         else:
-            logging.debug("Configuring Openswan VPN")
+            logging.debug("Found OpenSwan compatible systemvm template so let's configure VPN with it")
             vpns = CsSite2SiteVpnOpenSwan("site2sitevpn", self.config)
             vpns.process()
-
-        rvpn = CsRemoteAccessVpn("remoteaccessvpn", self.config)
-        rvpn.process()
+            rvpn = CsRemoteAccessVpnOpenSwan("remoteaccessvpn", self.config)
+            rvpn.process()
 
         lb = CsLoadBalancer("loadbalancer", self.config)
         lb.process()

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
@@ -57,7 +57,7 @@ def get_systemvm_version():
         for line in version_data.split("."):
             version += str(line).zfill(2)
         logging.info("This systemvm has version " + str(version))
-        return version
+        return int(version)
     except:
         logging.info("Got an exception while trying to find systemvm version. Returning version 0")
         return 0

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
@@ -48,6 +48,20 @@ def get_device_from_mac_address(macaddress):
     return device[0]
 
 
+def get_systemvm_version():
+    try:
+        with open("/etc/cloudstack-release") as file:
+            content = file.readlines()
+        version_data = content[0].split(" ")[2]
+        version = ""
+        for line in version_data.split("."):
+            version += str(line).zfill(2)
+        logging.info("This systemvm has version " + str(version))
+        return version
+    except:
+        logging.info("Got an exception while trying to find systemvm version. Returning version 0")
+        return 0
+
 def is_mounted(name):
     for i in execute("mount"):
         vals = i.lstrip().split()

--- a/cosmic-core/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/cosmic-core/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -1005,7 +1005,10 @@ public class NetUtils {
         return false;
     }
 
-    public static boolean isValidS2SVpnPolicy(final String policys) {
+    public static boolean isValidS2SVpnPolicy(final String policyType, final String policys) {
+        if (policyType == null || policyType.isEmpty()) {
+            return false;
+        }
         if (policys == null || policys.isEmpty()) {
             return false;
         }
@@ -1026,14 +1029,17 @@ public class NetUtils {
             if (!cipher.matches("3des|aes128|aes192|aes256")) {
                 return false;
             }
-            if (!hash.matches("md5|sha1")) {
+            if (!hash.matches("md5|sha1|sha256|sha384|sha512")) {
                 return false;
             }
-            String pfsGroup = null;
+            String group = null;
             if (!policy.equals(cipherHash)) {
-                pfsGroup = policy.split(";")[1];
+                group = policy.split(";")[1];
             }
-            if (pfsGroup != null && !pfsGroup.matches("modp1024|modp1536")) {
+            if (group == null && policyType.toLowerCase().matches("ike")) {
+                return false; // StrongSwan requires a DH group for the IKE policy
+            }
+            if (group != null && !group.matches("modp1024|modp1536|modp2048|modp3072|modp4096|modp6144|modp8192")) {
                 return false;
             }
         }

--- a/cosmic-core/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
+++ b/cosmic-core/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
@@ -90,18 +90,25 @@ public class NetUtilsTest {
 
     @Test
     public void testIsValidS2SVpnPolicy() {
-        assertTrue(NetUtils.isValidS2SVpnPolicy("aes128-sha1"));
-        assertTrue(NetUtils.isValidS2SVpnPolicy("3des-sha1"));
-        assertTrue(NetUtils.isValidS2SVpnPolicy("3des-sha1,aes256-sha1"));
-        assertTrue(NetUtils.isValidS2SVpnPolicy("3des-md5;modp1024"));
-        assertTrue(NetUtils.isValidS2SVpnPolicy("3des-sha1,aes128-sha1;modp1536"));
-        assertFalse(NetUtils.isValidS2SVpnPolicy("des-md5;modp1024,aes128-sha1;modp1536"));
-        assertFalse(NetUtils.isValidS2SVpnPolicy("des-sha1"));
-        assertFalse(NetUtils.isValidS2SVpnPolicy("abc-123,ase-sha1"));
-        assertFalse(NetUtils.isValidS2SVpnPolicy("de-sh,aes-sha1"));
-        assertFalse(NetUtils.isValidS2SVpnPolicy(""));
-        assertFalse(NetUtils.isValidS2SVpnPolicy(";modp1536"));
-        assertFalse(NetUtils.isValidS2SVpnPolicy(",aes;modp1536,,,"));
+        assertTrue(NetUtils.isValidS2SVpnPolicy("esp", "aes128-sha1"));
+        assertTrue(NetUtils.isValidS2SVpnPolicy("esp", "3des-sha1"));
+        assertTrue(NetUtils.isValidS2SVpnPolicy("esp", "3des-sha1,aes256-sha1"));
+        assertTrue(NetUtils.isValidS2SVpnPolicy("esp", "3des-md5;modp1024"));
+        assertTrue(NetUtils.isValidS2SVpnPolicy("esp", "3des-sha256,aes128-sha512;modp1536"));
+        assertTrue(NetUtils.isValidS2SVpnPolicy("ike", "3des-sha1;modp3072,aes128-sha1;modp1536"));
+        assertTrue(NetUtils.isValidS2SVpnPolicy("ike", "3des-md5;modp1024"));
+        assertTrue(NetUtils.isValidS2SVpnPolicy("ike", "3des-sha1;modp3072,aes128-sha1;modp1536"));
+        assertTrue(NetUtils.isValidS2SVpnPolicy("ike", "3des-sha256;modp3072,aes128-sha512;modp1536"));
+        assertFalse(NetUtils.isValidS2SVpnPolicy("ike", "aes128-sha1"));
+        assertFalse(NetUtils.isValidS2SVpnPolicy("ike", "3des-sha1"));
+        assertFalse(NetUtils.isValidS2SVpnPolicy("ike", "3des-sha1,aes256-sha1"));
+        assertFalse(NetUtils.isValidS2SVpnPolicy("esp", "des-md5;modp1024,aes128-sha1;modp1536"));
+        assertFalse(NetUtils.isValidS2SVpnPolicy("esp", "des-sha1"));
+        assertFalse(NetUtils.isValidS2SVpnPolicy("esp", "abc-123,ase-sha1"));
+        assertFalse(NetUtils.isValidS2SVpnPolicy("esp", "de-sh,aes-sha1"));
+        assertFalse(NetUtils.isValidS2SVpnPolicy("esp", ""));
+        assertFalse(NetUtils.isValidS2SVpnPolicy("esp", ";modp1536"));
+        assertFalse(NetUtils.isValidS2SVpnPolicy("esp", ",aes;modp1536,,,"));
     }
 
     @Test


### PR DESCRIPTION
This PR switches to StrongSwan when the systemvm version is newer than `17.3.12` (to be decided what version exactly). It provides a seamless upgrade from OpenSwan to StrongSwan (just Restart+Cleanup VPC) and prevents having to do a massive replace of all running routers in one go.

The UI supports both options for OpenSwan and StrongSwan.

The current build tests for OpenSwan which should still be green. We also provided test results for a run with a StrongSwan template in the comments below.

First merge the systemvm change: https://github.com/MissionCriticalCloud/systemvm-packer/pull/25 and then make sure all build slaves have this template (all other builds will fail the vpn tests). Then merge this PR and have master turn green. Finally all other open PRs should rebase on master to be able to turn green again.

Based on ACS PR 1741.