### PR TITLE
Make GetDomRVersionCommand more reliable

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/get_template_version.sh
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/get_template_version.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
-
 # As the last command send to router before any rules operation, wait until boot up done
 
 __TIMEOUT=240
 __FLAGFILE=/var/cache/cloud/boot_up_done
 done=0
-for i in `seq 1 $(($__TIMEOUT * 10))`
+for i in `seq 1 $((${__TIMEOUT} * 10))`
 do
-    if [ -e $__FLAGFILE ]
+    if [ -e ${__FLAGFILE} ]
     then
         done=1
         break
@@ -20,12 +19,13 @@ do
     fi
 done
 
-if [ -z $done ]
+if [ -z ${done} ]
 then
     # declare we failed booting process
     echo "Waited 60 seconds but boot up haven't been completed"
     exit
 fi
 
-echo -n `cat /etc/cloudstack-release`'&'
-cat /var/cache/cloud/cloud-scripts-signature
+release=$(cat /etc/cloudstack-release)
+sig=$(cat /var/cache/cloud/cloud-scripts-signature)
+echo "${release}&${sig}"


### PR DESCRIPTION
It was reported that in some cases the proxy script didn't return the GetDomRVersionCommand output properly resulting in a failed systemvm boot.

Backport of ACS PR 1995