### PR TITLE
VirtIO-SCSI: Implement unmap discard option to free diskspace

### DIFF
--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -56,6 +56,7 @@ import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.CpuTuneDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.DevicesDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.DiskDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.DiskDef.DeviceType;
+import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.DiskDef.DiscardType;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.DiskDef.DiskProtocol;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.FeaturesDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.GraphicDef;
@@ -1705,7 +1706,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         final InputDef input = new InputDef("tablet", "usb");
         devices.addDevice(input);
 
-        DiskDef.DiskBus diskBusType = getDiskModelFromVMDetail(vmTo);
+        DiskDef.DiskBus diskBusType = getDiskModelFromVmDetail(vmTo);
         if (diskBusType == null) {
             diskBusType = getGuestDiskModel(vmTo.getPlatformEmulator());
         }
@@ -1867,7 +1868,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             }
 
             // if params contains a rootDiskController key, use its value (this is what other HVs are doing)
-            DiskDef.DiskBus diskBusType = getDiskModelFromVMDetail(vmSpec);
+            DiskDef.DiskBus diskBusType = getDiskModelFromVmDetail(vmSpec);
 
             if (diskBusType == null) {
                 diskBusType = getGuestDiskModel(vmSpec.getPlatformEmulator());
@@ -1883,6 +1884,11 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 }
             } else {
                 final int devId = volume.getDiskSeq().intValue();
+
+                if (diskBusType == DiskDef.DiskBus.SCSI ) {
+                    disk.setQemuDriver(true);
+                    disk.setDiscard(DiscardType.UNMAP);
+                }
 
                 if (pool.getType() == StoragePoolType.RBD) {
           /*
@@ -1952,7 +1958,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         return Type.Routing;
     }
 
-    public DiskDef.DiskBus getDiskModelFromVMDetail(final VirtualMachineTO vmTO) {
+    public DiskDef.DiskBus getDiskModelFromVmDetail(final VirtualMachineTO vmTO) {
         Map<String, String> details = vmTO.getDetails();
         if (details == null) {
             return null;

--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVmDef.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVmDef.java
@@ -521,6 +521,15 @@ public class LibvirtVmDef {
         private DiskCacheMode diskCacheMode;
         private String serial;
         private boolean qemuDriver = true;
+        private DiscardType discard = DiscardType.IGNORE;
+
+        public DiscardType getDiscard() {
+            return discard;
+        }
+
+        public void setDiscard(DiscardType discard) {
+            this.discard = discard;
+        }
 
         public void defFileBasedDisk(final String filePath, final String diskLabel, final DiskBus bus, final DiskFmtType diskFmtType) {
             diskType = DiskType.FILE;
@@ -807,6 +816,22 @@ public class LibvirtVmDef {
             }
         }
 
+        public enum DiscardType {
+            IGNORE("ignore"), UNMAP("unmap");
+            String _discardType;
+            DiscardType(String discardType) {
+                _discardType = discardType;
+            }
+
+            @Override
+            public String toString() {
+                if (_discardType == null) {
+                    return "ignore";
+                }
+                return _discardType;
+            }
+        }
+
         @Override
         public String toString() {
             final StringBuilder diskBuilder = new StringBuilder();
@@ -818,7 +843,11 @@ public class LibvirtVmDef {
             diskBuilder.append(">\n");
             if (qemuDriver) {
                 diskBuilder.append("<driver name='qemu'" + " type='" + diskFmtType
-                        + "' cache='" + diskCacheMode + "' " + "/>\n");
+                        + "' cache='" + diskCacheMode + "' ");
+                if(discard != null && discard != DiscardType.IGNORE) {
+                    diskBuilder.append("discard='" + discard.toString() + "' ");
+                }
+                diskBuilder.append("/>\n");
             }
 
             if (diskType == DiskType.FILE) {

--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KvmStorageProcessor.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KvmStorageProcessor.java
@@ -16,6 +16,7 @@ import com.cloud.hypervisor.kvm.resource.LibvirtConnection;
 import com.cloud.hypervisor.kvm.resource.LibvirtDomainXmlParser;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.DiskDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.DiskDef.DeviceType;
+import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.DiskDef.DiscardType;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.DiskDef.DiskProtocol;
 import com.cloud.storage.JavaStorageLayer;
 import com.cloud.storage.Storage.ImageFormat;
@@ -1154,6 +1155,10 @@ public class KvmStorageProcessor implements StorageProcessor {
                     }
                 }
                 diskdef = new DiskDef();
+                if (diskBusType == DiskDef.DiskBus.SCSI) {
+                    diskdef.setQemuDriver(true);
+                    diskdef.setDiscard(DiscardType.UNMAP);
+                }
                 diskdef.setSerial(serial);
                 if (attachingPool.getType() == StoragePoolType.RBD) {
                     diskdef.defNetworkBasedDisk(attachingDisk.getPath(), attachingPool.getSourceHost(),


### PR DESCRIPTION
Need to test if it will work in our setup. At least the VM gets provisioned correctly:

```
    <disk type='file' device='disk'>
      <driver name='qemu' type='qcow2' cache='none' discard='unmap'/>
      <source file='/mnt/812ea6a3-7ad0-30f4-9cab-01e3f2985b98/d58100ba-a08c-4984-8728-baa4ec3450cb'/>
      <target dev='sda' bus='scsi'/>
      <serial>0-d58100baa08c49848728</serial>
      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
    </disk>
```

And the OS sees it can discard space:

```
[root@centos7 ~]# sudo lsblk -o MOUNTPOINT,DISC-MAX,FSTYPE
MOUNTPOINT DISC-MAX FSTYPE
                 1G
/                1G ext4
                 0B
```

```
[root@centos7 ~]# fstrim -v /
/: 6.9 GiB (7418638336 bytes) trimmed
```

I just don't see the space actually being returned, but that could be the test setup.

Backported from ACS PR 1955