### PR TITLE
Fix StrongSwan test failures due to blocking connection thread

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -484,18 +484,10 @@ class CsSite2SiteVpn(CsDataBag):
         esppolicy=obj['esp_policy'].replace(';','-')
 
         strokefile='/etc/strongswan.d/charon/stroke.conf'
-        ipsecconf='/etc/ipsec.conf'
 
         # Set timeout to 30s
         file = CsFile(strokefile)
         file.greplace("# timeout = 0", "timeout = 30000")
-        file.commit()
-
-        # Handle ipsec.conf
-        file = CsFile(ipsecconf)
-        file.empty()
-        file.addeq("# ipsec.conf - strongSwan IPsec configuration file")
-        file.addeq("include /etc/ipsec.d/*.conf")
         file.commit()
 
         pfs='no'

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -529,10 +529,8 @@ class CsSite2SiteVpn(CsDataBag):
             logging.info("Configured vpn %s %s", leftpeer, rightpeer)
             CsHelper.execute("ipsec rereadsecrets")
 
+        # This will load the new config and start the connection when needed since auto=start in the config
         CsHelper.execute("ipsec reload")
-        if not obj['passive']:
-            CsHelper.execute("sudo nohup ipsec down vpn-%s" % rightpeer)
-            CsHelper.execute("sudo nohup ipsec up vpn-%s &" % rightpeer)
         os.chmod(vpnsecretsfile, 0400)
 
     def convert_sec_to_h(self, val):
@@ -1142,7 +1140,7 @@ class IpTablesExecutor:
         fwd = CsForwardingRules("forwardingrules", self.config)
         fwd.process()
 
-        # Strongswan is included in the systemvm template 17.3.12 and newer
+        # Strongswan is included in the systemvm template 17.3.13 and newer
         if get_systemvm_version() > 170312:
             logging.debug("Found StrongSwan compatible systemvm template so let's configure VPN with it")
             vpns = CsSite2SiteVpn("site2sitevpn", self.config)

--- a/cosmic-core/systemvm/patches/debian/vpn/etc/ipsec.conf
+++ b/cosmic-core/systemvm/patches/debian/vpn/etc/ipsec.conf
@@ -1,9 +1,1 @@
-# Manual:     ipsec.conf.5
-version	2.0	
-
-config setup
-	nat_traversal=yes
-	virtual_private=%v4:10.0.0.0/8,%v4:192.168.0.0/16,%v4:172.16.0.0/12
-	protostack=auto
-	
 include /etc/ipsec.d/*.conf


### PR DESCRIPTION
The StrongSwan VPN config would be rewritten too often. We removed `ipsec.conf` editing, as this file can be changed directly on the `systemvm.iso` which is more efficient.

Next to that the StrongSwan code would kick in on any command that would also require iptables config. That isn't a problem on its own, but it was executing a stop/start of the connection all the time. This results in downtime of the VPN connection, but more important it leads to a blocking thread (for 30s max). That resulted `sometimes` in a timeout when processing a non-VPN json file (as we've seen with the cleanup failures) because this timeout was also 30s. 

First I changed it to a non-blocking start, but then realised since we have `auto=start` we simply have to `reload` the config and ipsec will take care of the rest on its own. Fast & easy!

BTW, it's now clear why we only saw it on the routers with Strongswan. Furthermore, the reason we only saw it on one of the two routers is due to the `passive` flag. It would only execute the restart when `passive=false`.

Thanks @eliasgomes for your help debugging this :-)