### PR TITLE
Add MOTD banner to console and SSH sessions

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/cosmic-core/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -678,11 +678,46 @@ setup_sshd(){
   local ip=$1
   local eth=$2
   [ -f /etc/ssh/sshd_config ] && sed -i -e "s/^[#]*ListenAddress.*$/ListenAddress $ip/" /etc/ssh/sshd_config
+  [ -f /etc/ssh/sshd_config ] && sed -i -e "s/^[#]*PrintMotd.*$/PrintMotd no/" /etc/ssh/sshd_config
   sed -i "/3922/s/eth./$eth/" /etc/iptables/rules.v4
   sed -i "/3922/s/eth./$eth/" /etc/iptables/rules
   /etc/init.d/ssh force-reload
+
+  setup_motd $ip
 }
 
+setup_motd(){
+  local ip=$1
+
+  cat >/etc/issue <<EOL
+
+Debian GNU/Linux 7 \n \l
+  ____________________________________________
+ ( Void 100% of your warranty @ $ip )
+  --------------------------------------------
+        \   ^__^
+         \  (oo)\_______
+           (__)\       )\/
+             ||----w |
+             ||     ||
+
+EOL
+
+  cat >/etc/motd <<EOL
+
+Cosmiccloud.io SystemVM powered by Debian GNU/Linux 7
+  ______________________________________
+ ( Booo! 0% of your warranty remaining! )
+  --------------------------------------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/
+               ||----w |
+               ||     ||
+
+EOL
+
+}
 
 setup_apache2() {
   log_it "Setting up apache web server"


### PR DESCRIPTION
This adds two banners:

1) To the console allowing easy access to the link local ip and warning you shouldn't be there
![image](https://cloud.githubusercontent.com/assets/1630096/24064711/56ee6d34-0b66-11e7-9586-267ec8948638.png)
(console version doesn't display `\`)

2) After SSH login (warranty void)
![image](https://cloud.githubusercontent.com/assets/1630096/24064699/428bd62e-0b66-11e7-849e-879c441dd6f8.png)

