### PR TITLE
Add filter on HV name and shorten HV name

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/instances.js
+++ b/cosmic-client/src/main/webapp/scripts/instances.js
@@ -119,6 +119,9 @@
                 stopped: {
                     label: 'state.Stopped'
                 },
+                hostname: {
+                    label: 'label.hypervisor'
+                },
                 destroyed: {
                     preFilter: function (args) {
                         if (isAdmin() || isDomainAdmin())
@@ -149,7 +152,13 @@
                     label: 'label.ip.address'
                 },
                 hostname: {
-                        label: 'label.hypervisor'
+                        label: 'label.hypervisor',
+                        converter: function(args) {
+                            if (args)
+                                return args.split('.')[0];
+                            else
+                                return '';
+                        }
                 },
                 state: {
                     label: 'label.state',


### PR DESCRIPTION
Now it's possible to click on the Hypervisor column to sort HV's. FQDN's will be split by the first dot so only the hostname will be displayed in the column.