### PR TITLE
Performance improvement of SSHHelper

### DIFF
--- a/cosmic-core/utils/src/main/java/com/cloud/utils/ssh/SshHelper.java
+++ b/cosmic-core/utils/src/main/java/com/cloud/utils/ssh/SshHelper.java
@@ -16,12 +16,6 @@ public class SshHelper {
     private static final int DEFAULT_CONNECT_TIMEOUT = 180000;
     private static final int DEFAULT_KEX_TIMEOUT = 60000;
 
-    /**
-     * Waiting time to check if the SSH session was successfully opened. This value (of 1000
-     * milliseconds) represents one (1) second.
-     */
-    private static final long WAITING_OPEN_SSH_SESSION = 1000;
-
     private static final Logger s_logger = LoggerFactory.getLogger(SshHelper.class);
 
     public static Pair<Boolean, String> sshExecute(final String host, final int port, final String user, final File pemKeyFile, final String password, final String command)
@@ -119,15 +113,8 @@ public class SshHelper {
         }
     }
 
-    /**
-     * It gets a {@link Session} from the given {@link Connection}; then, it waits
-     * {@value #WAITING_OPEN_SSH_SESSION} milliseconds before returning the session, given a time to
-     * ensure that the connection is open before proceeding the execution.
-     */
-    protected static Session openConnectionSession(final Connection conn) throws IOException, InterruptedException {
-        final Session sess = conn.openSession();
-        Thread.sleep(WAITING_OPEN_SSH_SESSION);
-        return sess;
+    protected static Session openConnectionSession(final Connection conn) throws IOException {
+        return conn.openSession();
     }
 
     /**

--- a/cosmic-core/utils/src/test/java/com/cloud/utils/ssh/SshHelperTest.java
+++ b/cosmic-core/utils/src/test/java/com/cloud/utils/ssh/SshHelperTest.java
@@ -126,6 +126,5 @@ public class SshHelperTest {
         Mockito.verify(conn).openSession();
 
         PowerMockito.verifyStatic();
-        Thread.sleep(Mockito.anyLong());
     }
 }


### PR DESCRIPTION
Backport of ACS PR 2015:

> A delay of 1 sec has been introduced in SSHHelper Class. This is a fail safe code. Removing this will improves the performance of deployVm by 4 sec, createFirewallRule by 1 sec and createPortForwardingRule by 1 sec.

> We have not faced any issues after removing the delay. This was introduced when we were using older version of Trilead library.

Let's see if the tests still pass..