### PR TITLE
Limit source CIDRs that can do API calls (configurable globally and per account)

### DIFF
--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyResource.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyResource.java
@@ -315,12 +315,12 @@ public class ConsoleProxyResource extends ServerResourceBase implements ServerRe
             s_logger.debug("addRouteToInternalIp: destIp is null");
             return;
         }
-        if (!NetUtils.isValidIp(destIpOrCidr) && !NetUtils.isValidCIDR(destIpOrCidr)) {
+        if (!NetUtils.isValidIp4(destIpOrCidr) && !NetUtils.isValidIp4Cidr(destIpOrCidr)) {
             s_logger.warn(" destIp is not a valid ip address or cidr destIp=" + destIpOrCidr);
             return;
         }
         boolean inSameSubnet = false;
-        if (NetUtils.isValidIp(destIpOrCidr)) {
+        if (NetUtils.isValidIp4(destIpOrCidr)) {
             if (eth1ip != null && eth1mask != null) {
                 inSameSubnet = NetUtils.sameSubnet(eth1ip, destIpOrCidr, eth1mask);
             } else {

--- a/cosmic-client/src/main/resources/commands.properties
+++ b/cosmic-client/src/main/resources/commands.properties
@@ -194,8 +194,8 @@ migrateSystemVm=1
 changeServiceForSystemVm=1
 scaleSystemVm=1
 #### configuration commands
-updateConfiguration=1
-listConfigurations=1
+updateConfiguration=7
+listConfigurations=7
 listCapabilities=15
 listDeploymentPlanners=1
 cleanVMReservations=1

--- a/cosmic-client/src/main/webapp/l10n/en.js
+++ b/cosmic-client/src/main/webapp/l10n/en.js
@@ -7,7 +7,7 @@ var dictionary = {
     "error.could.not.change.your.password.because.ldap.is.enabled": "Error could not change your password because LDAP is enabled.",
     "error.could.not.enable.zone": "Could not enable zone",
     "error.installWizard.message": "Something went wrong; you may go back and correct any errors",
-    "error.invalid.username.password": "Invalid username or password",
+    "error.invalid.username.password": "Invalid username or password.<br/><br/>This could also be a restriction on the IP address you're connecting from.",
     "error.login": "Your username/password does not match our records.",
     "error.menu.select": "Unable to perform action due to no items being selected.",
     "error.mgmt.server.inaccessible": "The Management Server is unaccessible.  Please try again later.",

--- a/cosmic-client/src/main/webapp/scripts/accounts.js
+++ b/cosmic-client/src/main/webapp/scripts/accounts.js
@@ -623,7 +623,7 @@
 
                         tabFilter: function (args) {
                             var hiddenTabs = [];
-                            if (!isAdmin()) {
+                            if (!isAdmin() && !isDomainAdmin()) {
                                 hiddenTabs.push('settings');
                             }
                             return hiddenTabs;

--- a/cosmic-core/api/src/main/java/com/cloud/api/ApiServerService.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/ApiServerService.java
@@ -7,7 +7,7 @@ import java.net.InetAddress;
 import java.util.Map;
 
 public interface ApiServerService {
-    public boolean verifyRequest(Map<String, Object[]> requestParameters, Long userId) throws ServerApiException;
+    public boolean verifyRequest(Map<String, Object[]> requestParameters, Long userId, String remoteAddress) throws ServerApiException;
 
     public Long fetchDomainId(String domainUUID);
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/CreateEgressFirewallRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/CreateEgressFirewallRuleCmd.java
@@ -257,10 +257,10 @@ public class CreateEgressFirewallRuleCmd extends BaseAsyncCreateCmd implements F
             final String guestCidr = _networkService.getNetwork(getNetworkId()).getCidr();
 
             for (final String cidr : getSourceCidrList()) {
-                if (!NetUtils.isValidCIDR(cidr)) {
+                if (!NetUtils.isValidIp4Cidr(cidr) && !NetUtils.isValidIp6Cidr(cidr)) {
                     throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Source cidrs formatting error " + cidr);
                 }
-                if (cidr.equals(NetUtils.ALL_CIDRS)) {
+                if (cidr.equals(NetUtils.ALL_IP4_CIDRS)) {
                     continue;
                 }
                 if (!NetUtils.isNetworkAWithinNetworkB(cidr, guestCidr)) {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/CreateFirewallRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/CreateFirewallRuleCmd.java
@@ -229,7 +229,7 @@ public class CreateFirewallRuleCmd extends BaseAsyncCreateCmd implements Firewal
             return cidrlist;
         } else {
             final List<String> oneCidrList = new ArrayList<>();
-            oneCidrList.add(NetUtils.ALL_CIDRS);
+            oneCidrList.add(NetUtils.ALL_IP4_CIDRS);
             return oneCidrList;
         }
     }
@@ -273,7 +273,7 @@ public class CreateFirewallRuleCmd extends BaseAsyncCreateCmd implements Firewal
     public void create() {
         if (getSourceCidrList() != null) {
             for (final String cidr : getSourceCidrList()) {
-                if (!NetUtils.isValidCIDR(cidr)) {
+                if (!NetUtils.isValidIp4Cidr(cidr)) {
                     throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Source CIDRs formatting error " + cidr);
                 }
             }

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/CreatePortForwardingRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/CreatePortForwardingRuleCmd.java
@@ -364,7 +364,7 @@ public class CreatePortForwardingRuleCmd extends BaseAsyncCreateCmd implements P
 
         final Ip privateIp = getVmSecondaryIp();
         if (privateIp != null) {
-            if (!NetUtils.isValidIp(privateIp.toString())) {
+            if (!NetUtils.isValidIp4(privateIp.toString())) {
                 throw new InvalidParameterValueException("Invalid vm ip address");
             }
         }

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/AssignToLoadBalancerRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/AssignToLoadBalancerRuleCmd.java
@@ -158,7 +158,7 @@ public class AssignToLoadBalancerRuleCmd extends BaseAsyncCmd {
                 }
 
                 //check wether the given ip is valid ip or not
-                if (vmIp == null || !NetUtils.isValidIp(vmIp)) {
+                if (vmIp == null || !NetUtils.isValidIp4(vmIp)) {
                     throw new InvalidParameterValueException("Invalid ip address " + vmIp + " passed in vmidipmap for " +
                             "vmid " + vmId);
                 }

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/CreateNetworkACLCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/CreateNetworkACLCmd.java
@@ -99,7 +99,7 @@ public class CreateNetworkACLCmd extends BaseAsyncCreateCmd {
             return cidrlist;
         } else {
             final List<String> oneCidrList = new ArrayList<>();
-            oneCidrList.add(NetUtils.ALL_CIDRS);
+            oneCidrList.add(NetUtils.ALL_IP4_CIDRS);
             return oneCidrList;
         }
     }

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/AddIpToVmNicCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/AddIpToVmNicCmd.java
@@ -150,7 +150,7 @@ public class AddIpToVmNicCmd extends BaseAsyncCreateCmd {
         final NicSecondaryIp result;
         final String secondaryIp = null;
         if ((ip = getIpaddress()) != null) {
-            if (!NetUtils.isValidIp(ip)) {
+            if (!NetUtils.isValidIp4(ip)) {
                 throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Invalid ip address " + ip);
             }
         }

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/UpdateVmNicIpCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/UpdateVmNicIpCmd.java
@@ -126,7 +126,7 @@ public class UpdateVmNicIpCmd extends BaseAsyncCmd {
         CallContext.current().setEventDetails("Nic Id: " + getNicId());
         final String ip;
         if ((ip = getIpaddress()) != null) {
-            if (!NetUtils.isValidIp(ip)) {
+            if (!NetUtils.isValidIp4(ip)) {
                 throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Invalid ip address " + ip);
             }
         }

--- a/cosmic-core/api/src/main/java/com/cloud/config/ApiServiceConfiguration.java
+++ b/cosmic-core/api/src/main/java/com/cloud/config/ApiServiceConfiguration.java
@@ -12,8 +12,10 @@ public class ApiServiceConfiguration implements Configurable {
             "API end point. Can be used by CS components/services deployed remotely, for sending CS API requests", true);
     public static final ConfigKey<Long> DefaultUIPageSize = new ConfigKey<>("Advanced", Long.class, "default.ui.page.size", "20",
             "The default pagesize to be used by UI and other clients when making list* API calls", true, ConfigKey.Scope.Global);
-    public static final ConfigKey<String> ManagementAdminCidr = new ConfigKey<String>("Advanced", String.class, "management.admin.cidr",
-            "0.0.0.0/0,::/0", "Comma separated list of IPv4/IPv6 CIDRs from which ROOT Admin accounts can perform API calls", true, ConfigKey.Scope.Global);
+    public static final ConfigKey<Boolean> ApiSourceCidrChecksEnabled = new ConfigKey<>("Advanced", Boolean.class, "api.source.cidr.checks.enabled",
+            "true", "Are the source checks on API calls enabled (true) or not (false)? See api.allowed.source.cidr.list", true, ConfigKey.Scope.Global);
+    public static final ConfigKey<String> ApiAllowedSourceCidrList = new ConfigKey<String>("Advanced", String.class, "api.allowed.source.cidr.list",
+            "0.0.0.0/0,::/0", "Comma separated list of IPv4/IPv6 CIDRs from which API calls can be performed. Can be set on Global and Account levels.", true, ConfigKey.Scope.Account);
 
     @Override
     public String getConfigComponentName() {
@@ -22,6 +24,6 @@ public class ApiServiceConfiguration implements Configurable {
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[]{ManagementHostIPAdr, ApiServletPath, DefaultUIPageSize, ManagementAdminCidr};
+        return new ConfigKey<?>[]{ManagementHostIPAdr, ApiServletPath, DefaultUIPageSize, ApiSourceCidrChecksEnabled, ApiAllowedSourceCidrList};
     }
 }

--- a/cosmic-core/api/src/main/java/com/cloud/config/ApiServiceConfiguration.java
+++ b/cosmic-core/api/src/main/java/com/cloud/config/ApiServiceConfiguration.java
@@ -12,6 +12,8 @@ public class ApiServiceConfiguration implements Configurable {
             "API end point. Can be used by CS components/services deployed remotely, for sending CS API requests", true);
     public static final ConfigKey<Long> DefaultUIPageSize = new ConfigKey<>("Advanced", Long.class, "default.ui.page.size", "20",
             "The default pagesize to be used by UI and other clients when making list* API calls", true, ConfigKey.Scope.Global);
+    public static final ConfigKey<String> ManagementAdminCidr = new ConfigKey<String>("Advanced", String.class, "management.admin.cidr",
+            "0.0.0.0/0,::/0", "Comma separated list of IPv4/IPv6 CIDRs from which ROOT Admin accounts can perform API calls", true, ConfigKey.Scope.Global);
 
     @Override
     public String getConfigComponentName() {
@@ -20,6 +22,6 @@ public class ApiServiceConfiguration implements Configurable {
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[]{ManagementHostIPAdr, ApiServletPath, DefaultUIPageSize};
+        return new ConfigKey<?>[]{ManagementHostIPAdr, ApiServletPath, DefaultUIPageSize, ManagementAdminCidr};
     }
 }

--- a/cosmic-core/nucleo/src/main/java/com/cloud/network/HAProxyConfigurator.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/network/HAProxyConfigurator.java
@@ -74,7 +74,7 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
     private List<String> getRulesForPool(final String poolName, final List<PortForwardingRuleTO> fwRules) {
         final PortForwardingRuleTO firstRule = fwRules.get(0);
         final String publicIP = firstRule.getSrcIp();
-        final String publicPort = Integer.toString(firstRule.getSrcPortRange()[0]);
+        final int publicPort = firstRule.getSrcPortRange()[0];
 
         final List<String> result = new ArrayList<>();
         // Add line like this: "listen  65_37_141_30-80 65.37.141.30:80"
@@ -84,7 +84,7 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
         sb = new StringBuilder();
         // FIXME sb.append("\t").append("balance ").append(algorithm);
         result.add(sb.toString());
-        if (publicPort.equals(NetUtils.HTTP_PORT)) {
+        if (publicPort == NetUtils.HTTP_PORT) {
             sb = new StringBuilder();
             sb.append("\t").append("mode http");
             result.add(sb.toString());
@@ -204,7 +204,7 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
         StringBuilder sb = new StringBuilder();
         final String poolName = sb.append(lbTO.getSrcIp().replace(".", "_")).append('-').append(lbTO.getSrcPort()).toString();
         final String publicIP = lbTO.getSrcIp();
-        final String publicPort = Integer.toString(lbTO.getSrcPort());
+        final int publicPort = lbTO.getSrcPort();
         final String algorithm = lbTO.getAlgorithm();
 
         final List<String> result = new ArrayList<>();
@@ -274,7 +274,7 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
         if (stickinessSubRule != null && !destsAvailable) {
             s_logger.warn("Haproxy stickiness policy for lb rule: " + lbTO.getSrcIp() + ":" + lbTO.getSrcPort() + ": Not Applied, cause:  backends are unavailable");
         }
-        if (publicPort.equals(NetUtils.HTTP_PORT) && !keepAliveEnabled || httpbasedStickiness) {
+        if (publicPort == NetUtils.HTTP_PORT && !keepAliveEnabled || httpbasedStickiness) {
             sb = new StringBuilder();
             sb.append("\t").append("mode http");
             result.add(sb.toString());

--- a/cosmic-core/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -635,7 +635,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     throw new InvalidParameterValueException("Error parsing ip address");
                 }
             } else if (range.equals("netmask")) {
-                if (!NetUtils.isValidNetmask(value)) {
+                if (!NetUtils.isValidIp4Netmask(value)) {
                     s_logger.error("netmask " + value + " is not a valid net mask for configuration variable " + name);
                     return "Please enter a valid netmask.";
                 }
@@ -667,7 +667,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                 for (final String route : routes) {
                     if (route != null) {
                         final String routeToVerify = route.trim();
-                        if (!NetUtils.isValidCIDR(routeToVerify)) {
+                        if (!NetUtils.isValidIp4Cidr(routeToVerify)) {
                             throw new InvalidParameterValueException("Invalid value for blacklisted route: " + route + ". Valid format is list"
                                     + " of cidrs separated by coma. Example: 10.1.1.0/24,192.168.0.0/24");
                         }
@@ -1209,11 +1209,11 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     @Override
     public Pod createPod(final long zoneId, final String name, final String startIp, final String endIp, final String gateway, final String netmask, String allocationState) {
         // Check if the gateway is a valid IP address
-        if (!NetUtils.isValidIp(gateway)) {
+        if (!NetUtils.isValidIp4(gateway)) {
             throw new InvalidParameterValueException("The gateway is invalid");
         }
 
-        if (!NetUtils.isValidNetmask(netmask)) {
+        if (!NetUtils.isValidIp4Netmask(netmask)) {
             throw new InvalidParameterValueException("The netmask is invalid");
         }
 
@@ -1970,7 +1970,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             if (IpRange[0] == null || IpRange[1] == null) {
                 continue;
             }
-            if (!NetUtils.isValidIp(IpRange[0]) || !NetUtils.isValidIp(IpRange[1])) {
+            if (!NetUtils.isValidIp4(IpRange[0]) || !NetUtils.isValidIp4(IpRange[1])) {
                 continue;
             }
             if (NetUtils.ipRangesOverlap(startIp, endIp, IpRange[0], IpRange[1])) {
@@ -2044,11 +2044,11 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
     private void checkPublicIpRangeErrors(final long zoneId, final String vlanId, final String vlanGateway, final String vlanNetmask, final String startIP, final String endIP) {
         // Check that the start and end IPs are valid
-        if (!NetUtils.isValidIp(startIP)) {
+        if (!NetUtils.isValidIp4(startIP)) {
             throw new InvalidParameterValueException("Please specify a valid start IP");
         }
 
-        if (endIP != null && !NetUtils.isValidIp(endIP)) {
+        if (endIP != null && !NetUtils.isValidIp4(endIP)) {
             throw new InvalidParameterValueException("Please specify a valid end IP");
         }
 
@@ -3981,18 +3981,18 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
         if (ipv4) {
             // Make sure the gateway is valid
-            if (!NetUtils.isValidIp(vlanGateway)) {
+            if (!NetUtils.isValidIp4(vlanGateway)) {
                 throw new InvalidParameterValueException("Please specify a valid gateway");
             }
 
             // Make sure the netmask is valid
-            if (!NetUtils.isValidNetmask(vlanNetmask)) {
+            if (!NetUtils.isValidIp4Netmask(vlanNetmask)) {
                 throw new InvalidParameterValueException("Please specify a valid netmask");
             }
         }
 
         if (ipv6) {
-            if (!NetUtils.isValidIpv6(vlanIp6Gateway)) {
+            if (!NetUtils.isValidIp6(vlanIp6Gateway)) {
                 throw new InvalidParameterValueException("Please specify a valid IPv6 gateway");
             }
             if (!NetUtils.isValidIp6Cidr(vlanIp6Cidr)) {
@@ -4584,7 +4584,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             throw new InvalidParameterValueException("Invalid region ID: " + regionId);
         }
 
-        if (!NetUtils.isValidIp(startIP) || !NetUtils.isValidIp(endIP) || !NetUtils.validIpRange(startIP, endIP)) {
+        if (!NetUtils.isValidIp4(startIP) || !NetUtils.isValidIp4(endIP) || !NetUtils.validIpRange(startIP, endIP)) {
             throw new InvalidParameterValueException("Invalid portable ip  range: " + startIP + "-" + endIP);
         }
 
@@ -4742,27 +4742,27 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
         // Check IP validity for DNS addresses
         // Empty strings is a valid input -- hence the length check
-        if (dns1 != null && dns1.length() > 0 && !NetUtils.isValidIp(dns1)) {
+        if (dns1 != null && dns1.length() > 0 && !NetUtils.isValidIp4(dns1)) {
             throw new InvalidParameterValueException("Please enter a valid IP address for DNS1");
         }
 
-        if (dns2 != null && dns2.length() > 0 && !NetUtils.isValidIp(dns2)) {
+        if (dns2 != null && dns2.length() > 0 && !NetUtils.isValidIp4(dns2)) {
             throw new InvalidParameterValueException("Please enter a valid IP address for DNS2");
         }
 
-        if (internalDns1 != null && internalDns1.length() > 0 && !NetUtils.isValidIp(internalDns1)) {
+        if (internalDns1 != null && internalDns1.length() > 0 && !NetUtils.isValidIp4(internalDns1)) {
             throw new InvalidParameterValueException("Please enter a valid IP address for internal DNS1");
         }
 
-        if (internalDns2 != null && internalDns2.length() > 0 && !NetUtils.isValidIp(internalDns2)) {
+        if (internalDns2 != null && internalDns2.length() > 0 && !NetUtils.isValidIp4(internalDns2)) {
             throw new InvalidParameterValueException("Please enter a valid IP address for internal DNS2");
         }
 
-        if (ip6Dns1 != null && ip6Dns1.length() > 0 && !NetUtils.isValidIpv6(ip6Dns1)) {
+        if (ip6Dns1 != null && ip6Dns1.length() > 0 && !NetUtils.isValidIp6(ip6Dns1)) {
             throw new InvalidParameterValueException("Please enter a valid IPv6 address for IP6 DNS1");
         }
 
-        if (ip6Dns2 != null && ip6Dns2.length() > 0 && !NetUtils.isValidIpv6(ip6Dns2)) {
+        if (ip6Dns2 != null && ip6Dns2.length() > 0 && !NetUtils.isValidIp6(ip6Dns2)) {
             throw new InvalidParameterValueException("Please enter a valid IPv6 address for IP6 DNS2");
         }
 
@@ -4872,7 +4872,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         final long cidrSize;
         // Get the individual cidrAddress and cidrSize values, if the CIDR is
         // valid. If it's not valid, return an error.
-        if (NetUtils.isValidCIDR(cidr)) {
+        if (NetUtils.isValidIp4Cidr(cidr)) {
             cidrAddress = getCidrAddress(cidr);
             cidrSize = getCidrSize(cidr);
         } else {
@@ -4886,7 +4886,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         checkOverlapPublicIpRange(zoneId, startIp, endIp);
 
         // Check if the gateway is a valid IP address
-        if (!NetUtils.isValidIp(gateway)) {
+        if (!NetUtils.isValidIp4(gateway)) {
             throw new InvalidParameterValueException("The gateway is not a valid IP address.");
         }
 
@@ -4939,11 +4939,11 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     }
 
     private void checkIpRange(final String startIp, final String endIp, final String cidrAddress, final long cidrSize) {
-        if (!NetUtils.isValidIp(startIp)) {
+        if (!NetUtils.isValidIp4(startIp)) {
             throw new InvalidParameterValueException("The start address of the IP range is not a valid IP address.");
         }
 
-        if (endIp != null && !NetUtils.isValidIp(endIp)) {
+        if (endIp != null && !NetUtils.isValidIp4(endIp)) {
             throw new InvalidParameterValueException("The end address of the IP range is not a valid IP address.");
         }
 

--- a/cosmic-core/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
@@ -609,7 +609,7 @@ public class ConsoleProxyManagerImpl extends SystemVmManagerBase implements Cons
 
             if (nic.getTrafficType() == TrafficType.Management) {
                 final String mgmt_cidr = _configDao.getValue(Config.ManagementNetwork.key());
-                if (NetUtils.isValidCIDR(mgmt_cidr)) {
+                if (NetUtils.isValidIp4Cidr(mgmt_cidr)) {
                     buf.append(" mgmtcidr=").append(mgmt_cidr);
                 }
                 buf.append(" localgw=").append(dest.getPod().getGateway());

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -2036,10 +2036,10 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
 
     @Override
     public void checkIp6Parameters(final String startIPv6, final String endIPv6, final String ip6Gateway, final String ip6Cidr) throws InvalidParameterValueException {
-        if (!NetUtils.isValidIpv6(startIPv6)) {
+        if (!NetUtils.isValidIp6(startIPv6)) {
             throw new InvalidParameterValueException("Invalid format for the startIPv6 parameter");
         }
-        if (!NetUtils.isValidIpv6(endIPv6)) {
+        if (!NetUtils.isValidIp6(endIPv6)) {
             throw new InvalidParameterValueException("Invalid format for the endIPv6 parameter");
         }
 
@@ -2047,7 +2047,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
             throw new InvalidParameterValueException("ip6Gateway and ip6Cidr should be defined when startIPv6/endIPv6 are passed in");
         }
 
-        if (!NetUtils.isValidIpv6(ip6Gateway)) {
+        if (!NetUtils.isValidIp6(ip6Gateway)) {
             throw new InvalidParameterValueException("Invalid ip6Gateway");
         }
         if (!NetUtils.isValidIp6Cidr(ip6Cidr)) {
@@ -2073,13 +2073,13 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
     @Override
     public void checkRequestedIpAddresses(final long networkId, final String ip4, final String ip6) throws InvalidParameterValueException {
         if (ip4 != null) {
-            if (!NetUtils.isValidIp(ip4)) {
+            if (!NetUtils.isValidIp4(ip4)) {
                 throw new InvalidParameterValueException("Invalid specified IPv4 address " + ip4);
             }
             //Other checks for ipv4 are done in assignPublicIpAddress()
         }
         if (ip6 != null) {
-            if (!NetUtils.isValidIpv6(ip6)) {
+            if (!NetUtils.isValidIp6(ip6)) {
                 throw new InvalidParameterValueException("Invalid specified IPv6 address " + ip6);
             }
             if (_ipv6Dao.findByNetworkIdAndIp(networkId, ip6) != null) {

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -159,7 +159,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -825,7 +824,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
 
         if (ipv4) {
             // validate the CIDR
-            if (cidr != null && !NetUtils.isValidCIDR(cidr)) {
+            if (cidr != null && !NetUtils.isValidIp4Cidr(cidr)) {
                 throw new InvalidParameterValueException("Invalid format for the CIDR parameter");
             }
             // validate gateway with cidr
@@ -834,12 +833,12 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
             }
             // if end ip is not specified, default it to startIp
             if (startIP != null) {
-                if (!NetUtils.isValidIp(startIP)) {
+                if (!NetUtils.isValidIp4(startIP)) {
                     throw new InvalidParameterValueException("Invalid format for the startIp parameter");
                 }
                 if (endIP == null) {
                     endIP = startIP;
-                } else if (!NetUtils.isValidIp(endIP)) {
+                } else if (!NetUtils.isValidIp4(endIP)) {
                     throw new InvalidParameterValueException("Invalid format for the endIp parameter");
                 }
             }
@@ -858,10 +857,10 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
                     throw new InvalidParameterValueException("Invalid gateway IP provided. Either the IP is broadcast or network IP.");
                 }
 
-                if (!NetUtils.isValidIp(gateway)) {
+                if (!NetUtils.isValidIp4(gateway)) {
                     throw new InvalidParameterValueException("Invalid gateway");
                 }
-                if (!NetUtils.isValidNetmask(netmask)) {
+                if (!NetUtils.isValidIp4Netmask(netmask)) {
                     throw new InvalidParameterValueException("Invalid netmask");
                 }
 
@@ -873,7 +872,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
 
         if (ipv6) {
             // validate the ipv6 CIDR
-            if (ip6Cidr != null && !NetUtils.isValidCIDR(ip6Cidr)) {
+            if (ip6Cidr != null && !NetUtils.isValidIp4Cidr(ip6Cidr)) {
                 throw new InvalidParameterValueException("Invalid format for the CIDR parameter");
             }
 
@@ -1751,7 +1750,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
                 throw new InvalidParameterValueException("The network must be in " + Network.State.Implemented + " state. IP Reservation cannot be applied in "
                         + network.getState() + " state");
             }
-            if (!NetUtils.isValidCIDR(guestVmCidr)) {
+            if (!NetUtils.isValidIp4Cidr(guestVmCidr)) {
                 throw new InvalidParameterValueException("Invalid format of Guest VM CIDR.");
             }
             if (!NetUtils.validateGuestCidr(guestVmCidr)) {
@@ -3135,19 +3134,19 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
 
         // VALIDATE IP INFO
         // if end ip is not specified, default it to startIp
-        if (!NetUtils.isValidIp(startIp)) {
+        if (!NetUtils.isValidIp4(startIp)) {
             throw new InvalidParameterValueException("Invalid format for the ip address parameter");
         }
         if (endIp == null) {
             endIp = startIp;
-        } else if (!NetUtils.isValidIp(endIp)) {
+        } else if (!NetUtils.isValidIp4(endIp)) {
             throw new InvalidParameterValueException("Invalid format for the endIp address parameter");
         }
 
-        if (!NetUtils.isValidIp(gateway)) {
+        if (!NetUtils.isValidIp4(gateway)) {
             throw new InvalidParameterValueException("Invalid gateway");
         }
-        if (!NetUtils.isValidNetmask(netmask)) {
+        if (!NetUtils.isValidIp4Netmask(netmask)) {
             throw new InvalidParameterValueException("Invalid netmask");
         }
 

--- a/cosmic-core/server/src/main/java/com/cloud/network/StorageNetworkManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/StorageNetworkManagerImpl.java
@@ -68,7 +68,7 @@ public class StorageNetworkManagerImpl extends ManagerBase implements StorageNet
             endIp = startIp;
         }
 
-        if (!NetUtils.isValidNetmask(netmask)) {
+        if (!NetUtils.isValidIp4Netmask(netmask)) {
             throw new CloudRuntimeException("Invalid netmask:" + netmask);
         }
 
@@ -183,7 +183,7 @@ public class StorageNetworkManagerImpl extends ManagerBase implements StorageNet
         String endIp = cmd.getEndIp();
         final String netmask = cmd.getNetmask();
 
-        if (netmask != null && !NetUtils.isValidNetmask(netmask)) {
+        if (netmask != null && !NetUtils.isValidIp4Netmask(netmask)) {
             throw new CloudRuntimeException("Invalid netmask:" + netmask);
         }
 
@@ -256,7 +256,7 @@ public class StorageNetworkManagerImpl extends ManagerBase implements StorageNet
             throw new CloudRuntimeException("Cannot find pod " + podId);
         }
         final String[] IpRange = pod.getDescription().split("-");
-        if ((IpRange[0] == null || IpRange[1] == null) || (!NetUtils.isValidIp(IpRange[0]) || !NetUtils.isValidIp(IpRange[1]))) {
+        if ((IpRange[0] == null || IpRange[1] == null) || (!NetUtils.isValidIp4(IpRange[0]) || !NetUtils.isValidIp4(IpRange[1]))) {
             return;
         }
         if (NetUtils.ipRangesOverlap(startIp, endIp, IpRange[0], IpRange[1])) {

--- a/cosmic-core/server/src/main/java/com/cloud/network/firewall/FirewallManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/firewall/FirewallManagerImpl.java
@@ -792,7 +792,7 @@ public class FirewallManagerImpl extends ManagerBase implements FirewallService,
         }
 
         final List<String> oneCidr = new ArrayList<>();
-        oneCidr.add(NetUtils.ALL_CIDRS);
+        oneCidr.add(NetUtils.ALL_IP4_CIDRS);
         return createFirewallRule(ipAddrId, caller, null, startPort, endPort, protocol, oneCidr, icmpCode, icmpType, relatedRuleId, FirewallRule.FirewallRuleType.User,
                 networkId, FirewallRule.TrafficType.Ingress, true);
     }
@@ -917,7 +917,7 @@ public class FirewallManagerImpl extends ManagerBase implements FirewallService,
         final NetworkVO network = _networkDao.findById(networkId);
         final List<String> sourceCidr = new ArrayList<>();
 
-        sourceCidr.add(NetUtils.ALL_CIDRS);
+        sourceCidr.add(NetUtils.ALL_IP4_CIDRS);
         final FirewallRuleVO ruleVO =
                 new FirewallRuleVO(null, null, null, null, "all", networkId, network.getAccountId(), network.getDomainId(), Purpose.Firewall, sourceCidr, null, null, null,
                         FirewallRule.TrafficType.Egress, FirewallRuleType.System);

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -1667,7 +1667,7 @@ public class VirtualNetworkApplianceManagerImpl extends ManagerBase implements V
         if (defaultEgressPolicy) {
             final List<String> sourceCidr = new ArrayList<>();
 
-            sourceCidr.add(NetUtils.ALL_CIDRS);
+            sourceCidr.add(NetUtils.ALL_IP4_CIDRS);
             final FirewallRule rule = new FirewallRuleVO(null, null, null, null, "all", networkId, network.getAccountId(), network.getDomainId(), Purpose.Firewall, sourceCidr,
                     null, null, null, FirewallRule.TrafficType.Egress, FirewallRule.FirewallRuleType.System);
 

--- a/cosmic-core/server/src/main/java/com/cloud/network/security/SecurityGroupManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/security/SecurityGroupManagerImpl.java
@@ -354,7 +354,7 @@ public class SecurityGroupManagerImpl extends ManagerBase implements SecurityGro
 
         if (cidrList != null) {
             for (final String cidr : cidrList) {
-                if (!NetUtils.isValidCIDR(cidr)) {
+                if (!NetUtils.isValidIp4Cidr(cidr) && !NetUtils.isValidIp6Cidr(cidr)) {
                     throw new InvalidParameterValueException("Invalid cidr " + cidr);
                 }
             }

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpc/NetworkACLServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpc/NetworkACLServiceImpl.java
@@ -395,7 +395,7 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
 
         if (sourceCidrList != null) {
             for (final String cidr : sourceCidrList) {
-                if (!NetUtils.isValidCIDR(cidr)) {
+                if (!NetUtils.isValidIp4Cidr(cidr)) {
                     throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Source cidrs formatting error " + cidr);
                 }
             }

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -845,7 +845,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     protected Vpc createVpc(final Boolean displayVpc, final VpcVO vpc) {
         final String cidr = vpc.getCidr();
         // Validate CIDR
-        if (!NetUtils.isValidCIDR(cidr)) {
+        if (!NetUtils.isValidIp4Cidr(cidr)) {
             throw new InvalidParameterValueException("Invalid CIDR specified " + cidr);
         }
 
@@ -1846,11 +1846,11 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         }
         _accountMgr.checkAccess(caller, null, false, vpc);
 
-        if (!NetUtils.isValidCIDR(cidr)) {
+        if (!NetUtils.isValidIp4Cidr(cidr)) {
             throw new InvalidParameterValueException("Invalid format for cidr " + cidr);
         }
 
-        if (!NetUtils.isValidIp(gwIpAddress)) {
+        if (!NetUtils.isValidIp4(gwIpAddress)) {
             throw new InvalidParameterValueException("Invalid format for ip address " + gwIpAddress);
         }
 

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
@@ -174,7 +174,7 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
         if (range.length != 2) {
             throw new InvalidParameterValueException("Invalid ip range");
         }
-        if (!NetUtils.isValidIp(range[0]) || !NetUtils.isValidIp(range[1])) {
+        if (!NetUtils.isValidIp4(range[0]) || !NetUtils.isValidIp4(range[1])) {
             throw new InvalidParameterValueException("Invalid ip in range specification " + ipRange);
         }
         if (!NetUtils.validIpRange(range[0], range[1])) {
@@ -714,7 +714,7 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
         if (range.length != 2) {
             throw new ConfigurationException("Remote Access VPN: Invalid ip range " + ipRange);
         }
-        if (!NetUtils.isValidIp(range[0]) || !NetUtils.isValidIp(range[1])) {
+        if (!NetUtils.isValidIp4(range[0]) || !NetUtils.isValidIp4(range[1])) {
             throw new ConfigurationException("Remote Access VPN: Invalid ip in range specification " + ipRange);
         }
         if (!NetUtils.validIpRange(range[0], range[1])) {

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
@@ -148,7 +148,7 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
 
         String name = cmd.getName();
         final String gatewayIp = cmd.getGatewayIp();
-        if (!NetUtils.isValidIp(gatewayIp)) {
+        if (!NetUtils.isValidIp4(gatewayIp)) {
             throw new InvalidParameterValueException("The customer gateway ip " + gatewayIp + " is invalid!");
         }
         if (name == null) {
@@ -215,7 +215,7 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
         if (peerList != null && !peerList.isEmpty()) {
             for (String cidr : peerList) {
                 cidr = cidr.trim();
-                if (!NetUtils.isValidCIDR(cidr)) {
+                if (!NetUtils.isValidIp4Cidr(cidr)) {
                     wrongCidrs.add(cidr);
                     continue;
                 }
@@ -638,7 +638,7 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
 
         String name = cmd.getName();
         final String gatewayIp = cmd.getGatewayIp();
-        if (!NetUtils.isValidIp(gatewayIp)) {
+        if (!NetUtils.isValidIp4(gatewayIp)) {
             throw new InvalidParameterValueException("The customer gateway ip " + gatewayIp + " is invalid!");
         }
         if (name == null) {

--- a/cosmic-core/server/src/main/java/com/cloud/storage/secondary/SecondaryStorageManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/storage/secondary/SecondaryStorageManagerImpl.java
@@ -408,7 +408,7 @@ public class SecondaryStorageManagerImpl extends SystemVmManagerBase implements 
             }
             if (nic.getTrafficType() == TrafficType.Management) {
                 final String mgmt_cidr = _configDao.getValue(Config.ManagementNetwork.key());
-                if (NetUtils.isValidCIDR(mgmt_cidr)) {
+                if (NetUtils.isValidIp4Cidr(mgmt_cidr)) {
                     buf.append(" mgmtcidr=").append(mgmt_cidr);
                 }
                 buf.append(" localgw=").append(dest.getPod().getGateway());
@@ -974,7 +974,7 @@ public class SecondaryStorageManagerImpl extends SystemVmManagerBase implements 
         final List<String> allowedCidrs = new ArrayList<>();
         final String[] cidrs = cidrList.split(",");
         for (final String cidr : cidrs) {
-            if (NetUtils.isValidCIDR(cidr) || NetUtils.isValidIp(cidr) || !cidr.startsWith("0.0.0.0")) {
+            if (NetUtils.isValidIp4Cidr(cidr) || NetUtils.isValidIp4(cidr) || !cidr.startsWith("0.0.0.0")) {
                 allowedCidrs.add(cidr);
             }
         }

--- a/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1867,7 +1867,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         NicProfile profile = new NicProfile(null, null);
         if (ipAddress != null) {
-            if (!(NetUtils.isValidIp(ipAddress) || NetUtils.isValidIpv6(ipAddress))) {
+            if (!(NetUtils.isValidIp4(ipAddress) || NetUtils.isValidIp6(ipAddress))) {
                 throw new InvalidParameterValueException("Invalid format for IP address parameter: " + ipAddress);
             }
             profile = new NicProfile(ipAddress, null);
@@ -5235,7 +5235,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 if (answer.getResult()) {
                     final String vmIp = answer.getDetails();
 
-                    if (NetUtils.isValidIp(vmIp)) {
+                    if (NetUtils.isValidIp4(vmIp)) {
                         // set this vm ip addr in vm nic.
                         if (nic != null) {
                             nic.setIPv4Address(vmIp);

--- a/cosmic-core/server/src/test/java/com/cloud/api/ApiServletTest.java
+++ b/cosmic-core/server/src/test/java/com/cloud/api/ApiServletTest.java
@@ -155,7 +155,7 @@ public class ApiServletTest {
     public void processRequestInContextUnauthorizedGET() {
         Mockito.when(request.getMethod()).thenReturn("GET");
         Mockito.when(
-                apiServer.verifyRequest(Mockito.anyMap(), Mockito.anyLong()))
+                apiServer.verifyRequest(Mockito.anyMap(), Mockito.anyLong(), Mockito.anyString()))
                .thenReturn(false);
         servlet.processRequestInContext(request, response);
         Mockito.verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
@@ -168,7 +168,7 @@ public class ApiServletTest {
     public void processRequestInContextAuthorizedGet() {
         Mockito.when(request.getMethod()).thenReturn("GET");
         Mockito.when(
-                apiServer.verifyRequest(Mockito.anyMap(), Mockito.anyLong()))
+                apiServer.verifyRequest(Mockito.anyMap(), Mockito.anyLong(), Mockito.anyString()))
                .thenReturn(true);
         servlet.processRequestInContext(request, response);
         Mockito.verify(response).setStatus(HttpServletResponse.SC_OK);

--- a/cosmic-core/services/secondary-storage-server/src/main/java/com/cloud/storage/resource/NfsSecondaryStorageResource.java
+++ b/cosmic-core/services/secondary-storage-server/src/main/java/com/cloud/storage/resource/NfsSecondaryStorageResource.java
@@ -2173,12 +2173,12 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
             s_logger.debug("addRouteToInternalIp: destIp is null");
             return;
         }
-        if (!NetUtils.isValidIp(destIpOrCidr) && !NetUtils.isValidCIDR(destIpOrCidr)) {
+        if (!NetUtils.isValidIp4(destIpOrCidr) && !NetUtils.isValidIp4Cidr(destIpOrCidr)) {
             s_logger.warn(" destIp is not a valid ip address or cidr destIp=" + destIpOrCidr);
             return;
         }
         boolean inSameSubnet = false;
-        if (NetUtils.isValidIp(destIpOrCidr)) {
+        if (NetUtils.isValidIp4(destIpOrCidr)) {
             if (eth1ip != null && eth1mask != null) {
                 inSameSubnet = NetUtils.sameSubnet(eth1ip, destIpOrCidr, eth1mask);
             } else {

--- a/cosmic-core/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
+++ b/cosmic-core/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
@@ -16,6 +16,8 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.NetUtils.SupersetOrSubset;
 
 import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -24,6 +26,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 import com.googlecode.ipv6.IPv6Address;
+import com.googlecode.ipv6.IPv6Network;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -170,10 +173,10 @@ public class NetUtilsTest {
 
     @Test
     public void testIsValidIpv6() {
-        assertTrue(NetUtils.isValidIpv6("fc00::1"));
-        assertFalse(NetUtils.isValidIpv6(""));
-        assertFalse(NetUtils.isValidIpv6(null));
-        assertFalse(NetUtils.isValidIpv6("1234:5678::1/64"));
+        assertTrue(NetUtils.isValidIp6("fc00::1"));
+        assertFalse(NetUtils.isValidIp6(""));
+        assertFalse(NetUtils.isValidIp6(null));
+        assertFalse(NetUtils.isValidIp6("1234:5678::1/64"));
     }
 
     @Test
@@ -186,10 +189,10 @@ public class NetUtilsTest {
 
     @Test
     public void testIsIp6InNetwork() {
-        assertFalse(NetUtils.isIp6InNetwork("1234:5678:abcd::1", "1234:5678::/64"));
-        assertTrue(NetUtils.isIp6InNetwork("1234:5678::1", "1234:5678::/64"));
-        assertTrue(NetUtils.isIp6InNetwork("1234:5678::ffff:ffff:ffff:ffff", "1234:5678::/64"));
-        assertTrue(NetUtils.isIp6InNetwork("1234:5678::", "1234:5678::/64"));
+        assertFalse(NetUtils.isIp6InNetwork(IPv6Address.fromString("1234:5678:abcd::1"), IPv6Network.fromString("1234:5678::/64")));
+        assertTrue(NetUtils.isIp6InNetwork(IPv6Address.fromString("1234:5678::1"), IPv6Network.fromString("1234:5678::/64")));
+        assertTrue(NetUtils.isIp6InNetwork(IPv6Address.fromString("1234:5678::ffff:ffff:ffff:ffff"), IPv6Network.fromString("1234:5678::/64")));
+        assertTrue(NetUtils.isIp6InNetwork(IPv6Address.fromString("1234:5678::"), IPv6Network.fromString("1234:5678::/64")));
     }
 
     @Test
@@ -239,9 +242,9 @@ public class NetUtilsTest {
         final String cidrSecond = "10.0.151.0/20";
         final String cidrThird = "10.0.144.0/21";
 
-        assertTrue(NetUtils.isValidCIDR(cidrFirst));
-        assertTrue(NetUtils.isValidCIDR(cidrSecond));
-        assertTrue(NetUtils.isValidCIDR(cidrThird));
+        assertTrue(NetUtils.isValidIp4Cidr(cidrFirst));
+        assertTrue(NetUtils.isValidIp4Cidr(cidrSecond));
+        assertTrue(NetUtils.isValidIp4Cidr(cidrThird));
     }
 
     @Test
@@ -436,49 +439,49 @@ public class NetUtilsTest {
     public void testGetCidrNetMask() {
         final String cidr = "10.10.0.0/16";
         final String netmask = NetUtils.getCidrNetmask("10.10.10.10/16");
-        assertTrue(cidr + " does not generate valid netmask " + netmask, NetUtils.isValidNetmask(netmask));
+        assertTrue(cidr + " does not generate valid netmask " + netmask, NetUtils.isValidIp4Netmask(netmask));
     }
 
     @Test
     public void testGetCidrHostAddress() {
         final String cidr = "10.10.0.1/24";
         final String address = NetUtils.getCidrHostAddress(cidr);
-        assertTrue(cidr + " does not generate valid gateway address.", NetUtils.isValidIp(address));
+        assertTrue(cidr + " does not generate valid gateway address.", NetUtils.isValidIp4(address));
     }
 
     @Test
     public void testGetCidrHostAddressNetworkAddress() {
         final String cidr = "10.10.0.0/24";
         final String address = NetUtils.getCidrHostAddress(cidr);
-        assertFalse(address + " is a not the network address of CIDR:" + cidr, NetUtils.isValidIp(address));
+        assertFalse(address + " is a not the network address of CIDR:" + cidr, NetUtils.isValidIp4(address));
     }
 
     @Test
     public void testGetCidrHostAddressBroadcastAddress() {
         final String cidr = "10.10.0.255/24";
         final String address = NetUtils.getCidrHostAddress(cidr);
-        assertFalse(address + " is a not the broadcast address of CIDR:" + cidr, NetUtils.isValidIp(address));
+        assertFalse(address + " is a not the broadcast address of CIDR:" + cidr, NetUtils.isValidIp4(address));
     }
 
     @Test
     public void testGetCidrHostAddressIPv6() {
         final String cidr = "2a00:16:a::1/64";
         final String address = NetUtils.getCidrHostAddress6(cidr);
-        assertTrue(cidr + " does not generate valid gateway address.", NetUtils.isValidIpv6(address));
+        assertTrue(cidr + " does not generate valid gateway address.", NetUtils.isValidIp6(address));
     }
 
     @Test
     public void testGetCidrHostAddressNetworkAddressIPv6() {
         final String cidr = "2a00:16:a::/64";
         final String address = NetUtils.getCidrHostAddress6(cidr);
-        assertFalse(address + " is a not the network address of CIDR:" + cidr, NetUtils.isValidIpv6(address));
+        assertFalse(address + " is a not the network address of CIDR:" + cidr, NetUtils.isValidIp6(address));
     }
 
     @Test
     public void testGetCidrHostAddressBroadcastAddressIPv6() {
         final String cidr = "2a00:16:a::ffff:ffff:ffff:ffff/64";
         final String address = NetUtils.getCidrHostAddress6(cidr);
-        assertFalse(address + " is a not the broadcast address of CIDR:" + cidr, NetUtils.isValidIpv6(address));
+        assertFalse(address + " is a not the broadcast address of CIDR:" + cidr, NetUtils.isValidIp6(address));
     }
 
     @Test
@@ -655,5 +658,75 @@ public class NetUtilsTest {
         assertTrue(longList.contains(167772161L));
         assertTrue(longList.contains(167772162L));
         assertTrue(longList.contains(167772163L));
+    }
+    @Test
+    public void testIsIpInCidrList() throws UnknownHostException {
+        String[] cidrs = "0.0.0.0/0,::/0".split(",");
+        System.out.println(NetUtils.isIpInCidrList(InetAddress.getByName("192.168.1.1"), cidrs));
+        assertTrue(NetUtils.isIpInCidrList(InetAddress.getByName("192.168.1.1"), cidrs));
+        assertTrue(NetUtils.isIpInCidrList(InetAddress.getByName("172.16.8.9"), cidrs));
+        assertTrue(NetUtils.isIpInCidrList(InetAddress.getByName("127.0.0.1"), cidrs));
+        assertTrue(NetUtils.isIpInCidrList(InetAddress.getByName("2001:db8:100::1"), cidrs));
+        assertTrue(NetUtils.isIpInCidrList(InetAddress.getByName("::1"), cidrs));
+        assertTrue(NetUtils.isIpInCidrList(InetAddress.getByName("2a01:4f8:130:2192::2"), cidrs));
+
+        assertTrue(NetUtils.isIpInCidrList(InetAddress.getByName("127.0.0.1"), "127.0.0.1/8".split(",")));
+        assertFalse(NetUtils.isIpInCidrList(InetAddress.getByName("192.168.1.1"), "127.0.0.1/8".split(",")));
+
+        assertTrue(NetUtils.isIpInCidrList(InetAddress.getByName("127.0.0.1"), "127.0.0.1/8,::1/128".split(",")));
+        assertTrue(NetUtils.isIpInCidrList(InetAddress.getByName("::1"), "127.0.0.1/8,::1/128".split(",")));
+
+        assertFalse(NetUtils.isIpInCidrList(InetAddress.getByName("192.168.29.47"), "127.0.0.1/8,::1/128".split(",")));
+        assertFalse(NetUtils.isIpInCidrList(InetAddress.getByName("2001:db8:1938:3ff1::1"), "127.0.0.1/8,::1/128".split(",")));
+
+        assertTrue(NetUtils.isIpInCidrList(InetAddress.getByName("2a01:4f8:130:2192::2"), "::/0,127.0.0.1".split(",")));
+        assertTrue(NetUtils.isIpInCidrList(InetAddress.getByName("2001:db8:200:300::1"), "2001:db8:200::/48,127.0.0.1".split(",")));
+        assertFalse(NetUtils.isIpInCidrList(InetAddress.getByName("2001:db8:200:300::1"), "2001:db8:300::/64,127.0.0.1".split(",")));
+        assertFalse(NetUtils.isIpInCidrList(InetAddress.getByName("2a01:4f8:130:2192::2"), "2001:db8::/64,127.0.0.1".split(",")));
+    }
+
+    @Test
+    public void testIsSiteLocalAddress() {
+        assertTrue(NetUtils.isSiteLocalAddress("192.168.0.1"));
+        assertTrue(NetUtils.isSiteLocalAddress("10.0.0.1"));
+        assertTrue(NetUtils.isSiteLocalAddress("172.16.0.1"));
+        assertTrue(NetUtils.isSiteLocalAddress("192.168.254.56"));
+        assertTrue(NetUtils.isSiteLocalAddress("10.254.254.254"));
+        assertFalse(NetUtils.isSiteLocalAddress("8.8.8.8"));
+        assertFalse(NetUtils.isSiteLocalAddress("8.8.4.4"));
+        assertFalse(NetUtils.isSiteLocalAddress(""));
+        assertFalse(NetUtils.isSiteLocalAddress(null));
+    }
+
+    @Test
+    public void testStaticVariables() {
+        assertEquals(80, NetUtils.HTTP_PORT);
+        assertEquals(443, NetUtils.HTTPS_PORT);
+        assertEquals(500, NetUtils.VPN_PORT);
+        assertEquals(4500, NetUtils.VPN_NATT_PORT);
+        assertEquals(1701, NetUtils.VPN_L2TP_PORT);
+        assertEquals(8081, NetUtils.HAPROXY_STATS_PORT);
+
+        assertEquals("udp", NetUtils.UDP_PROTO);
+        assertEquals("tcp", NetUtils.TCP_PROTO);
+        assertEquals("any", NetUtils.ANY_PROTO);
+        assertEquals("icmp", NetUtils.ICMP_PROTO);
+        assertEquals("http", NetUtils.HTTP_PROTO);
+        assertEquals("ssl", NetUtils.SSL_PROTO);
+
+        assertEquals("0.0.0.0/0", NetUtils.ALL_IP4_CIDRS);
+        assertEquals("::/0", NetUtils.ALL_IP6_CIDRS);
+    }
+
+    @Test
+    public void testIsValidPort() {
+        assertTrue(NetUtils.isValidPort(80));
+        assertTrue(NetUtils.isValidPort("80"));
+        assertTrue(NetUtils.isValidPort(443));
+        assertTrue(NetUtils.isValidPort("443"));
+        assertTrue(NetUtils.isValidPort(0));
+        assertTrue(NetUtils.isValidPort(65535));
+        assertFalse(NetUtils.isValidPort(-1));
+        assertFalse(NetUtils.isValidPort(65536));
     }
 }


### PR DESCRIPTION
Makes it possible to limit the source CIDR networks from which one can do API calls to a certain account.

Originally based on backported PR 2046 of ACS, added option to enable/disable feature and made it work for all accounts using a Global setting that can be overridden per account.