### PR TITLE
Gather all S2S vpn statuses before outputting

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/checkbatchs2svpn.sh
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/checkbatchs2svpn.sh
@@ -5,6 +5,7 @@ for i in $*
 do
     info=`/opt/cloud/bin/checks2svpn.sh $i`
     ret=$?
-    echo -n "$i:$ret:$info&"
+    batchInfo+="$i:$ret:$info&"
 done
 
+echo -n ${batchInfo}


### PR DESCRIPTION
Backport of ACS PR 2040:

>The checkbatchs2svpn.sh VR script returns ("via echo") that status of each requested S2S VPN check one-at-a-time.  If there is even a slight delay between VPN checks, the sshExecutor stops monitoring stdout and assumes it has all of the output.

>When checking the management server logs, we see a request to check _X_ number of VPNs, but the response is occasionally less than _X_ number... The rest of the Cloudstack code assumes "isConnected" as false if the VPN is not included in the response.

>We've noticed that if an account had more than 3 site-to-site VPNs, that there are many errors per day stating that a S2S VPN is down.

>Example where a request was to check 4x S2S VPN connections, but only 3x responses were returned.
```
2017-04-11 17:05:40,444 DEBUG [c.c.h.x.r.CitrixResourceBase] (DirectAgent-190:ctx-e894af45) (logid:cbbccfaa) Executing command in VR: /opt/cloud/bin/router_proxy.sh checkbatchs2svpn.sh 169.254.2.130 67.41.109.167 65.100.18.183 67.41.109.165 67.41.109.166

2017-04-11 17:05:41,836 DEBUG [c.c.a.t.Request] (DirectAgent-190:ctx-e894af45) (logid:cbbccfaa) Seq 51-772085861117329631: Processing:  { Ans: , MgmtId: 345050927939, via: 51(cloudxen01.dsm1.ippathways.net), Ver: v1, Flags: 110, [{"com.cloud.agent.api.CheckS2SVpnConnectionsAnswer":{"ipToConnected":{"65.100.18.183":true,"67.41.109.167":true,"67.41.109.165":true},"ipToDetail":{"65.100.18.183":"ISAKMP SA found;IPsec SA found;Site-to-site VPN have connected","67.41.109.167":"ISAKMP SA found;IPsec SA found;Site-to-site VPN have connected","67.41.109.165":"ISAKMP SA found;IPsec SA found;Site-to-site VPN have connected"},"details":"67.41.109.167:0:ISAKMP SA found;IPsec SA found;Site-to-site VPN have connected&65.100.18.183:0:ISAKMP SA found;IPsec SA found;Site-to-site VPN have connected&67.41.109.165:0:ISAKMP SA found;IPsec SA found;Site-to-site VPN have connected&","result":true,"wait":0}}] }
```
