### PR TITLE
Update dependency versions to latest where possible

### DIFF
--- a/cosmic-core/engine/api/pom.xml
+++ b/cosmic-core/engine/api/pom.xml
@@ -35,18 +35,8 @@
             <version>5.3.4.1-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-bundle-jaxrs</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-server</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.xml.bind</groupId>
-                    <artifactId>jaxb-impl</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/cosmic-core/server/src/test/java/com/cloud/network/NetworkModelTest.java
+++ b/cosmic-core/server/src/test/java/com/cloud/network/NetworkModelTest.java
@@ -21,11 +21,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
 
-import com.cloud.vm.NicSecondaryIp;
 import com.cloud.vm.dao.NicDao;
 import com.cloud.vm.dao.NicSecondaryIpDao;
 import junit.framework.Assert;
-import org.apache.bcel.generic.NEW;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/cosmic-core/utils/pom.xml
+++ b/cosmic-core/utils/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>aspectjweaver</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-css</artifactId>
+        </dependency>
+        <dependency>
             <groupId>cglib</groupId>
             <artifactId>cglib-nodep</artifactId>
         </dependency>
@@ -91,6 +95,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>commons-httpclient</groupId>
+            <artifactId>commons-httpclient</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>provided</scope>
@@ -102,28 +116,6 @@
                 <exclusion>
                     <groupId>xml-apis</groupId>
                     <artifactId>xml-apis</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.owasp.esapi</groupId>
-            <artifactId>esapi</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xml-apis</groupId>
-                    <artifactId>xml-apis</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xml-apis</groupId>
-                    <artifactId>xml-apis-ext</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xmlParserAPIs</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -142,6 +134,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,6 @@
         <cs.commons-lang3.version>3.4</cs.commons-lang3.version>
         <cs.commons-net.version>3.3</cs.commons-net.version>
         <cs.commons-validator.version>1.5.0</cs.commons-validator.version>
-        <cs.cxf-bundle-jaxrs.version>2.7.18</cs.cxf-bundle-jaxrs.version>
         <cs.dbunit.version>2.4.9</cs.dbunit.version>
         <cs.dependency-check-maven.version>1.4.5</cs.dependency-check-maven.version>
         <cs.ehcache-core.version>2.6.9</cs.ehcache-core.version>
@@ -89,6 +88,7 @@
         <cs.java-ipv6.version>0.15</cs.java-ipv6.version>
         <cs.javax.inject.version>1</cs.javax.inject.version>
         <cs.javax.persistence.version>2.1.0</cs.javax.persistence.version>
+        <cs.javax.ws.rs>2.0-m10</cs.javax.ws.rs>
         <cs.jna.version>4.2.2</cs.jna.version>
         <cs.jsch.version>0.1.54</cs.jsch.version>
         <cs.jstl.version>1.2</cs.jstl.version>
@@ -195,11 +195,6 @@
                 <groupId>org.dbunit</groupId>
                 <artifactId>dbunit</artifactId>
                 <version>${cs.dbunit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.cxf</groupId>
-                <artifactId>cxf-bundle-jaxrs</artifactId>
-                <version>${cs.cxf-bundle-jaxrs.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-httpclient</groupId>
@@ -354,6 +349,11 @@
                 <groupId>org.eclipse.persistence</groupId>
                 <artifactId>javax.persistence</artifactId>
                 <version>${cs.javax.persistence.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.ws.rs</groupId>
+                <artifactId>javax.ws.rs-api</artifactId>
+                <version>${cs.javax.ws.rs}</version>
             </dependency>
             <dependency>
                 <groupId>com.thoughtworks.xstream</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <cs.mail.version>1.4.7</cs.mail.version>
         <cs.mockito-all.version>1.10.19</cs.mockito-all.version>
         <cs.mycila.license.version>2.7</cs.mycila.license.version>
-        <cs.netty-all.version>4.0.25.Final</cs.netty-all.version>
+        <cs.netty-all.version>4.0.46.Final</cs.netty-all.version>
         <cs.org.jacoco.agent.rt.version>0.7.6.201602180812</cs.org.jacoco.agent.rt.version>
         <cs.org.jacoco.agent.version>0.7.6.201602180812</cs.org.jacoco.agent.version>
         <cs.powermock-api-mockito.version>1.6.4</cs.powermock-api-mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
 
         <cs.target.dir>target</cs.target.dir>
         <cs.dependency.check.report.dir>${cosmic.dir}/target/dependency-check</cs.dependency.check.report.dir>
+        <cs.dependency.check.format>XML</cs.dependency.check.format>
 
         <coverage.reports.dir>${cosmic.dir}/target/coverage-reports</coverage.reports.dir>
         <unit.tests.report>${coverage.reports.dir}/jacoco-ut.exec</unit.tests.report>
@@ -839,7 +840,8 @@
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
                         <configuration>
-                            <format>XML</format>
+                            <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                            <format>${cs.dependency.check.format}</format>
                             <outputDirectory>${cs.dependency.check.report.dir}</outputDirectory>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.4.1.RELEASE</version>
+        <version>1.4.6.RELEASE</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,6 @@
         <cs.maven-war-plugin.version>2.5</cs.maven-war-plugin.version>
         <cs.properties-maven-plugin.version>1.0-alpha-2</cs.properties-maven-plugin.version>
         <cs.sonar-maven-plugin.version>3.0.2</cs.sonar-maven-plugin.version>
-        <cs.tomcat7-maven-plugin.version>2.2</cs.tomcat7-maven-plugin.version>
     </properties>
 
     <licenses>
@@ -538,11 +537,6 @@
                     <groupId>ru.concerteza.buildnumber</groupId>
                     <artifactId>maven-jgit-buildnumber-plugin</artifactId>
                     <version>${cs.maven-jgit-buildnumber-plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.tomcat.maven</groupId>
-                    <artifactId>tomcat7-maven-plugin</artifactId>
-                    <version>${cs.tomcat7-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
         <cs.dependency-check-maven.version>1.4.5</cs.dependency-check-maven.version>
         <cs.ehcache-core.version>2.6.9</cs.ehcache-core.version>
         <cs.ejb-api.version>3.0</cs.ejb-api.version>
-        <cs.esapi.version>2.1.0.1</cs.esapi.version>
         <cs.gmaven-runtime-1.7.version>1.3</cs.gmaven-runtime-1.7.version>
         <cs.groovy-all.version>2.0.5</cs.groovy-all.version>
         <cs.guava-testlib.version>18.0</cs.guava-testlib.version>
@@ -339,11 +338,6 @@
                 <groupId>org.reflections</groupId>
                 <artifactId>reflections</artifactId>
                 <version>${cs.reflections.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.owasp.esapi</groupId>
-                <artifactId>esapi</artifactId>
-                <version>${cs.esapi.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
         <cs.commons-codec.version>1.10</cs.commons-codec.version>
         <cs.commons-configuration.version>1.10</cs.commons-configuration.version>
         <cs.commons-daemon.version>1.0.15</cs.commons-daemon.version>
-        <cs.commons-fileupload.version>1.3.2</cs.commons-fileupload.version>
         <cs.commons-httpclient.version>3.1</cs.commons-httpclient.version>
         <cs.commons-io.version>2.4</cs.commons-io.version>
         <cs.commons-lang3.version>3.4</cs.commons-lang3.version>
@@ -176,11 +175,6 @@
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils-core</artifactId>
                 <version>${cs.commons-beanutils-core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-fileupload</groupId>
-                <artifactId>commons-fileupload</artifactId>
-                <version>${cs.commons-fileupload.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <cs.target.dir>target</cs.target.dir>
+        <cosmic.dir>${project.basedir}</cosmic.dir>
         <cs.dependency.check.report.dir>${cosmic.dir}/target/dependency-check</cs.dependency.check.report.dir>
         <cs.dependency.check.format>XML</cs.dependency.check.format>
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <cs.javax.inject.version>1</cs.javax.inject.version>
         <cs.javax.persistence.version>2.1.0</cs.javax.persistence.version>
         <cs.jna.version>4.2.2</cs.jna.version>
-        <cs.jsch.version>0.1.51</cs.jsch.version>
+        <cs.jsch.version>0.1.54</cs.jsch.version>
         <cs.jstl.version>1.2</cs.jstl.version>
         <cs.libvirt.version>0.5.1</cs.libvirt.version>
         <cs.mail.version>1.4.7</cs.mail.version>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <cs.commons-validator.version>1.5.0</cs.commons-validator.version>
         <cs.cxf-bundle-jaxrs.version>2.7.18</cs.cxf-bundle-jaxrs.version>
         <cs.dbunit.version>2.4.9</cs.dbunit.version>
-        <cs.dependency-check-maven.version>1.4.3</cs.dependency-check-maven.version>
+        <cs.dependency-check-maven.version>1.4.5</cs.dependency-check-maven.version>
         <cs.ehcache-core.version>2.6.9</cs.ehcache-core.version>
         <cs.ejb-api.version>3.0</cs.ejb-api.version>
         <cs.esapi.version>2.1.0.1</cs.esapi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <cs.javax.inject.version>1</cs.javax.inject.version>
         <cs.javax.persistence.version>2.1.0</cs.javax.persistence.version>
         <cs.javax.ws.rs>2.0-m10</cs.javax.ws.rs>
-        <cs.jna.version>4.2.2</cs.jna.version>
+        <cs.jna.version>4.4.0</cs.jna.version>
         <cs.jsch.version>0.1.54</cs.jsch.version>
         <cs.jstl.version>1.2</cs.jstl.version>
         <cs.libvirt.version>0.5.1</cs.libvirt.version>


### PR DESCRIPTION
Includes/closes separate "test" PRs:
Closes #377 
Closes #378 
Closes #379 
Closes #380 
Closes #381 
Closes #382 
Closes #383

Closes PR for removal of Batik, but retains it as it seems to be required;
Not "explicitly" defined; runtime dependency (for Cosmic-Agent) 
Closes #384
