### PR TITLE
Also sync private templates between secondary storages

### DIFF
--- a/cosmic-core/engine/storage/image/src/main/java/com/cloud/storage/image/TemplateServiceImpl.java
+++ b/cosmic-core/engine/storage/image/src/main/java/com/cloud/storage/image/TemplateServiceImpl.java
@@ -434,11 +434,6 @@ public class TemplateServiceImpl implements TemplateService {
                                 s_logger.info("Skip downloading template " + tmplt.getUniqueName() + " since no url is specified.");
                                 continue;
                             }
-                            // if this is private template, skip sync to a new image store
-                            if (!tmplt.isPublicTemplate() && !tmplt.isFeatured() && tmplt.getTemplateType() != TemplateType.SYSTEM) {
-                                s_logger.info("Skip sync downloading private template " + tmplt.getUniqueName() + " to a new image store");
-                                continue;
-                            }
 
                             // if this is a region store, and there is already an DOWNLOADED entry there without install_path information, which
                             // means that this is a duplicate entry from migration of previous NFS to staging.


### PR DESCRIPTION
When adding a new secondary storage, we want all templates to be synced to it so we can decommission the first one.