### PR TITLE
Replace hardcoded RETURN with actual action of the fw rule

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -86,7 +86,7 @@ class CsAcl(CsDataBag):
                                     " -s %s " % cidr +
                                     " -p %s " % rule['protocol'] +
                                     " -m %s " % rule['protocol'] +
-                                    " %s -j RETURN" % rnge])
+                                    " %s -j %s" % (rnge, self.rule['action'])])
 
             logging.debug("Current ACL IP direction is ==> %s", self.direction)
             if self.direction == 'egress':


### PR DESCRIPTION
Partial backport of ACS PR 2034

It is believed it was like this in ACS pre 4.6