### PR TITLE
Add Source NAT list on VPC

### DIFF
--- a/cosmic-client/src/main/webapp/l10n/en.js
+++ b/cosmic-client/src/main/webapp/l10n/en.js
@@ -1654,6 +1654,7 @@ var dictionary = {
     "label.vpc": "VPC",
     "label.vpc.distributedvpcrouter": "Distributed VPC Router",
     "label.vpc.id": "VPC ID",
+    "label.vpc.sourcenatlist": "Source NAT list",
     "label.vpc.offering": "VPC Offering",
     "label.vpc.offering.details": "VPC offering details",
     "label.vpc.router.details": "VPC Router Details",

--- a/cosmic-client/src/main/webapp/scripts/docs.js
+++ b/cosmic-client/src/main/webapp/scripts/docs.js
@@ -966,6 +966,10 @@ cloudStack.docs = {
         desc: 'CIDR range for all the tiers within a VPC. Each tier\'s CIDR must be within the Super CIDR.',
         externalLink: ''
     },
+    helpVPCSourceNATList: {
+        desc: 'Comma separated list of CIDRs that will be source NATted into this VPC\'s Source NAT IP address.',
+        externalLink: ''
+    },
     helpVPCDomain: {
         desc: 'If you want to assign a special domain name to this VPC\'s guest VM network, specify the DNS suffix',
         externalLink: ''

--- a/cosmic-client/src/main/webapp/scripts/network.js
+++ b/cosmic-client/src/main/webapp/scripts/network.js
@@ -623,6 +623,10 @@
                                             ipv4cidr: true
                                         }
                                     },
+                                    sourcenatlist: {
+                                        docID: 'helpVPCSourceNATList',
+                                        label: 'label.vpc.sourcenatlist'
+                                    },
                                     networkdomain: {
                                         docID: 'helpVPCDomain',
                                         label: 'label.DNS.domain.for.guest.networks'
@@ -667,6 +671,11 @@
                                     cidr: args.data.cidr,
                                     vpcofferingid: args.data.vpcoffering
                                 };
+
+                                if (args.data.sourcenatlist != null && args.data.sourcenatlist.length > 0)
+                                    $.extend(dataObj, {
+                                        sourcenatlist: args.data.sourcenatlist
+                                    });
 
                                 if (args.data.networkdomain != null && args.data.networkdomain.length > 0)
                                     $.extend(dataObj, {
@@ -732,18 +741,26 @@
                                 label: 'label.edit',
                                 action: function (args) {
                                     // should we update the vpc offering
+
                                     if (args.data.vpcofferingid != null && args.data.vpcofferingid != args.context.vpc[0].vpcofferingid) {
+                                        var dataObj = {
+                                            id: args.context.vpc[0].id,
+                                            name: args.data.name,
+                                            displaytext: args.data.displaytext,
+                                            vpcofferingid: args.data.vpcofferingid
+                                        };
+
+                                        if (args.data.sourcenatlist != null && args.data.sourcenatlist.length > 0)
+                                            $.extend(dataObj, {
+                                                sourcenatlist: args.data.sourcenatlist
+                                            });
+
                                         cloudStack.dialog.confirm({
                                             message: 'message.confirm.change.vpcoffering',
                                             action: function () { //"Yes"    button is clicked
                                                 $.ajax({
                                                     url: createURL('updateVPC'),
-                                                    data: {
-                                                        id: args.context.vpc[0].id,
-                                                        name: args.data.name,
-                                                        displaytext: args.data.displaytext,
-                                                        vpcofferingid: args.data.vpcofferingid
-                                                    },
+                                                    data: dataObj,
                                                     success: function (json) {
                                                         var jid = json.updatevpcresponse.jobid;
                                                         args.response.success({
@@ -764,13 +781,20 @@
                                             }
                                         });
                                     } else {
+                                        var dataObj = {
+                                            id: args.context.vpc[0].id,
+                                            name: args.data.name,
+                                            displaytext: args.data.displaytext
+                                        };
+
+                                        if (args.data.sourcenatlist != null && args.data.sourcenatlist.length > 0)
+                                            $.extend(dataObj, {
+                                                sourcenatlist: args.data.sourcenatlist
+                                            });
+
                                         $.ajax({
                                             url: createURL('updateVPC'),
-                                            data: {
-                                                id: args.context.vpc[0].id,
-                                                name: args.data.name,
-                                                displaytext: args.data.displaytext
-                                            },
+                                            data: dataObj,
                                             success: function (json) {
                                                 var jid = json.updatevpcresponse.jobid;
                                                 args.response.success({
@@ -960,6 +984,10 @@
                                     },
                                     cidr: {
                                         label: 'label.cidr'
+                                    },
+                                    sourcenatlist: {
+                                        label: 'label.vpc.sourcenatlist',
+                                        isEditable: true
                                     },
                                     networkdomain: {
                                         label: 'label.network.domain'

--- a/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
@@ -401,6 +401,7 @@ public class ApiConstants {
     public static final String ASSOCIATED_NETWORK_ID = "associatednetworkid";
     public static final String ASSOCIATED_NETWORK_NAME = "associatednetworkname";
     public static final String SOURCE_NAT_SUPPORTED = "sourcenatsupported";
+    public static final String SOURCE_NAT_LIST = "sourcenatlist";
     public static final String RESOURCE_STATE = "resourcestate";
     public static final String PROJECT_INVITE_REQUIRED = "projectinviterequired";
     public static final String REQUIRED = "required";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/UpdateVPCCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/UpdateVPCCmdByAdmin.java
@@ -18,7 +18,7 @@ public class UpdateVPCCmdByAdmin extends UpdateVPCCmd {
 
     @Override
     public void execute() {
-        final Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc(), getVpcOfferingId());
+        final Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc(), getVpcOfferingId(), getSourceNatList());
         if (result != null) {
             final VpcResponse response = _responseGenerator.createVpcResponse(ResponseView.Full, result);
             response.setResponseName(getCommandName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/CreateVPCCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/CreateVPCCmd.java
@@ -21,6 +21,7 @@ import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.network.vpc.Vpc;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,6 +80,10 @@ public class CreateVPCCmd extends BaseAsyncCreateCmd {
             ".4", authorized = {RoleType.Admin})
     private Boolean display;
 
+    @Parameter(name = ApiConstants.SOURCE_NAT_LIST, type = CommandType.STRING,
+            description = "Source NAT CIDR list for used to allow other CIDRs to be source NATted by the VPC over the public interface")
+    private String sourceNatList;
+
     // ///////////////////////////////////////////////////
     // ///////////////// Accessors ///////////////////////
     // ///////////////////////////////////////////////////
@@ -93,7 +98,7 @@ public class CreateVPCCmd extends BaseAsyncCreateCmd {
 
     @Override
     public void create() throws ResourceAllocationException {
-        final Vpc vpc = _vpcService.createVpc(getZoneId(), getVpcOffering(), getEntityOwnerId(), getVpcName(), getDisplayText(), getCidr(), getNetworkDomain(), getDisplayVpc());
+        final Vpc vpc = _vpcService.createVpc(getZoneId(), getVpcOffering(), getEntityOwnerId(), getVpcName(), getDisplayText(), getCidr(), getNetworkDomain(), getDisplayVpc(), getSourceNatList());
         if (vpc != null) {
             setEntityId(vpc.getId());
             setEntityUuid(vpc.getUuid());
@@ -128,6 +133,13 @@ public class CreateVPCCmd extends BaseAsyncCreateCmd {
 
     public Boolean getDisplayVpc() {
         return display;
+    }
+
+    public String getSourceNatList() {
+        if (StringUtils.isEmpty(sourceNatList)) {
+            return sourceNatList;
+        }
+        return sourceNatList.replaceAll("\\s", "");
     }
 
     @Override

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/UpdateVPCCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/UpdateVPCCmd.java
@@ -17,6 +17,7 @@ import com.cloud.event.EventTypes;
 import com.cloud.network.vpc.Vpc;
 import com.cloud.user.Account;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,13 +48,17 @@ public class UpdateVPCCmd extends BaseAsyncCustomIdCmd {
             "in a restart+cleanup of the VPC")
     private Long vpcOfferingId;
 
+    @Parameter(name = ApiConstants.SOURCE_NAT_LIST, type = CommandType.STRING,
+            description = "Source NAT CIDR list for used to allow other CIDRs to be source NATted by the VPC over the public interface")
+    private String sourceNatList;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
 
     @Override
     public void execute() {
-        final Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc(), getVpcOfferingId());
+        final Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc(), getVpcOfferingId(), getSourceNatList());
         if (result != null) {
             final VpcResponse response = _responseGenerator.createVpcResponse(ResponseView.Restricted, result);
             response.setResponseName(getCommandName());
@@ -119,6 +124,13 @@ public class UpdateVPCCmd extends BaseAsyncCustomIdCmd {
     @Override
     public Long getSyncObjId() {
         return getId();
+    }
+
+    public String getSourceNatList() {
+        if (StringUtils.isEmpty(sourceNatList)) {
+            return sourceNatList;
+        }
+        return sourceNatList.replaceAll("\\s", "");
     }
 
     @Override

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/VpcResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/VpcResponse.java
@@ -114,6 +114,10 @@ public class VpcResponse extends BaseResponse implements ControlledEntityRespons
     @Param(description = "if this VPC has redundant router", since = "4.6")
     private boolean redundantRouter;
 
+    @SerializedName(ApiConstants.SOURCE_NAT_LIST)
+    @Param(description = "Source Nat CIDR list for used to allow other CIDRs to be source NATted by the VPC over the public interface", since = "5.3")
+    private String sourceNatList;
+
     public void setId(final String id) {
         this.id = id;
     }
@@ -221,5 +225,9 @@ public class VpcResponse extends BaseResponse implements ControlledEntityRespons
 
     public void setVpcOfferingDisplayText(final String vpcOfferingDisplayText) {
         this.vpcOfferingDisplayText = vpcOfferingDisplayText;
+    }
+
+    public void setSourceNatList(final String sourceNatList) {
+        this.sourceNatList = sourceNatList;
     }
 }

--- a/cosmic-core/api/src/main/java/com/cloud/network/vpc/Vpc.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/vpc/Vpc.java
@@ -42,6 +42,11 @@ public interface Vpc extends ControlledEntity, Identity, InternalIdentity {
     String getNetworkDomain();
 
     /**
+     * @return VPC source NAT list
+     */
+    String getSourceNatList();
+
+    /**
      * @return true if restart is required for the VPC; false otherwise
      */
     boolean isRestartRequired();

--- a/cosmic-core/api/src/main/java/com/cloud/network/vpc/VpcService.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/vpc/VpcService.java
@@ -30,7 +30,7 @@ public interface VpcService {
      * @return
      * @throws ResourceAllocationException TODO
      */
-    public Vpc createVpc(long zoneId, long vpcOffId, long vpcOwnerId, String vpcName, String displayText, String cidr, String networkDomain, Boolean displayVpc)
+    public Vpc createVpc(long zoneId, long vpcOffId, long vpcOwnerId, String vpcName, String displayText, String cidr, String networkDomain, Boolean displayVpc, String sourceNatList)
             throws ResourceAllocationException;
 
     /**
@@ -54,7 +54,7 @@ public interface VpcService {
      * @param displayVpc  TODO
      * @return
      */
-    public Vpc updateVpc(long vpcId, String vpcName, String displayText, String customId, Boolean displayVpc, Long vpcOfferingId);
+    public Vpc updateVpc(long vpcId, String vpcName, String displayText, String customId, Boolean displayVpc, Long vpcOfferingId, String sourceNatList);
 
     /**
      * Lists VPC(s) based on the parameters passed to the method call

--- a/cosmic-core/db-scripts/src/main/resources/db/schema-535to536.sql
+++ b/cosmic-core/db-scripts/src/main/resources/db/schema-535to536.sql
@@ -2,3 +2,5 @@
 -- Schema upgrade from 5.3.5 to 5.3.6;
 --
 
+-- Add source nat list
+ALTER TABLE `cloud`.`vpc` ADD COLUMN `source_nat_list` varchar(255) DEFAULT NULL COMMENT 'List of CIDRS to source NAT on VPC' AFTER `redundant`;

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/network/vpc/VpcVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/network/vpc/VpcVO.java
@@ -53,6 +53,8 @@ public class VpcVO implements Vpc {
     private String name;
     @Column(name = "cidr")
     private String cidr = null;
+    @Column(name = "source_nat_list")
+    String sourceNatList;
 
     public VpcVO() {
         uuid = UUID.randomUUID().toString();
@@ -60,7 +62,7 @@ public class VpcVO implements Vpc {
 
     public VpcVO(final long zoneId, final String name, final String displayText, final long accountId, final long domainId,
                  final long vpcOffId, final String cidr, final String networkDomain, final boolean useDistributedRouter,
-                 final boolean regionLevelVpc, final boolean isRedundant) {
+                 final boolean regionLevelVpc, final boolean isRedundant, final String sourceNatList) {
         this.zoneId = zoneId;
         this.name = name;
         this.displayText = displayText;
@@ -74,6 +76,7 @@ public class VpcVO implements Vpc {
         usesDistributedRouter = useDistributedRouter;
         this.regionLevelVpc = regionLevelVpc;
         redundant = isRedundant;
+        this.sourceNatList = sourceNatList;
     }
 
     @Override
@@ -201,5 +204,13 @@ public class VpcVO implements Vpc {
     @Override
     public Class<?> getEntityType() {
         return Vpc.class;
+    }
+
+    public void setSourceNatList(final String sourceNatList) {
+        this.sourceNatList = sourceNatList;
+    }
+
+    public String getSourceNatList() {
+        return sourceNatList;
     }
 }

--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/api/SetupVRCommand.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/api/SetupVRCommand.java
@@ -1,0 +1,29 @@
+package com.cloud.agent.api;
+
+import com.cloud.agent.api.routing.NetworkElementCommand;
+import com.cloud.network.vpc.Vpc;
+
+public class SetupVRCommand extends NetworkElementCommand {
+    String sourceNatList;
+    String vpcName;
+
+    protected SetupVRCommand() {}
+
+    public SetupVRCommand(final Vpc vpc) {
+        this.sourceNatList = vpc.getSourceNatList();
+        this.vpcName = vpc.getName();
+    }
+
+    public String getSourceNatList() {
+        return sourceNatList;
+    }
+
+    public String getVpcName() {
+        return vpcName;
+    }
+
+    @Override
+    public boolean executeInSequence() {
+        return true;
+    }
+}

--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/VRScripts.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/VRScripts.java
@@ -21,6 +21,7 @@ public class VRScripts {
     public static final String DHCP_CONFIG = "dhcp.json";
     public static final String IP_ALIAS_CONFIG = "ip_aliases.json";
     public static final String LOAD_BALANCER_CONFIG = "load_balancer.json";
+    public static final String VR_CONFIG = "vr.json";
 
     public final static String CONFIG_CACHE_LOCATION = "/var/cache/cloud/";
     public final static int DEFAULT_EXECUTEINVR_TIMEOUT = 120; //Seconds

--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/AbstractConfigItemFacade.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/AbstractConfigItemFacade.java
@@ -2,6 +2,7 @@ package com.cloud.agent.resource.virtualnetwork.facade;
 
 import com.cloud.agent.api.BumpUpPriorityCommand;
 import com.cloud.agent.api.SetupGuestNetworkCommand;
+import com.cloud.agent.api.SetupVRCommand;
 import com.cloud.agent.api.routing.CreateIpAliasCommand;
 import com.cloud.agent.api.routing.DeleteIpAliasCommand;
 import com.cloud.agent.api.routing.DhcpEntryCommand;
@@ -81,6 +82,7 @@ public abstract class AbstractConfigItemFacade {
         flyweight.put(SetSourceNatCommand.class, new SetSourceNatConfigItem());
         flyweight.put(IpAssocCommand.class, new IpAssociationConfigItem());
         flyweight.put(IpAssocVpcCommand.class, new IpAssociationConfigItem());
+        flyweight.put(SetupVRCommand.class, new SetVRConfigItem());
     }
 
     protected String destinationFile;

--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/SetVRConfigItem.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/SetVRConfigItem.java
@@ -1,0 +1,27 @@
+package com.cloud.agent.resource.virtualnetwork.facade;
+
+import com.cloud.agent.api.routing.NetworkElementCommand;
+import com.cloud.agent.api.SetupVRCommand;
+import com.cloud.agent.resource.virtualnetwork.ConfigItem;
+import com.cloud.agent.resource.virtualnetwork.VRScripts;
+import com.cloud.agent.resource.virtualnetwork.model.ConfigBase;
+import com.cloud.agent.resource.virtualnetwork.model.VRConfig;
+
+import java.util.List;
+
+public class SetVRConfigItem extends AbstractConfigItemFacade {
+
+    @Override
+    public List<ConfigItem> generateConfig(final NetworkElementCommand cmd) {
+        final SetupVRCommand command = (SetupVRCommand) cmd;
+
+        return generateConfigItems(new VRConfig(command.getVpcName(), command.getSourceNatList()));
+    }
+
+    @Override
+    protected List<ConfigItem> generateConfigItems(final ConfigBase configuration) {
+        destinationFile = VRScripts.VR_CONFIG;
+
+        return super.generateConfigItems(configuration);
+    }
+}

--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/model/ConfigBase.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/model/ConfigBase.java
@@ -21,6 +21,7 @@ public abstract class ConfigBase {
     public static final String MONITORSERVICE = "monitorservice";
     public static final String DHCP_CONFIG = "dhcpconfig";
     public static final String LOAD_BALANCER = "loadbalancer";
+    public static final String VR = "virtualrouter";
 
     private String type = UNKNOWN;
 

--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/model/VRConfig.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/model/VRConfig.java
@@ -1,0 +1,25 @@
+package com.cloud.agent.resource.virtualnetwork.model;
+
+public class VRConfig extends ConfigBase {
+    private String sourceNatList;
+    private String vpcName;
+
+    public VRConfig() {
+        // Empty constructor for (de)serialization
+        super(ConfigBase.VR);
+    }
+
+    public VRConfig(final String vpcName, final String sourceNatList) {
+        super(ConfigBase.VR);
+        this.sourceNatList = sourceNatList;
+        this.vpcName = vpcName;
+    }
+
+    public String getSourceNatList() {
+        return sourceNatList;
+    }
+
+    public void setSourceNatList(final String sourceNatList) {
+        this.sourceNatList = sourceNatList;
+    }
+}

--- a/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2558,6 +2558,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         response.setUsesDistributedRouter(vpc.usesDistributedRouter());
         response.setRedundantRouter(vpc.isRedundant());
         response.setRegionLevelVpc(vpc.isRegionLevelVpc());
+        response.setSourceNatList(vpc.getSourceNatList());
 
         final Map<Service, Set<Provider>> serviceProviderMap = ApiDBUtils.listVpcOffServices(vpc.getVpcOfferingId());
         final List<ServiceResponse> serviceResponses = getServiceResponses(serviceProviderMap);

--- a/cosmic-core/server/src/main/java/com/cloud/network/element/VpcVirtualRouterElement.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/element/VpcVirtualRouterElement.java
@@ -133,8 +133,7 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
         params.put(VirtualMachineProfile.Param.ReProgramGuestNetworks, true);
 
         final RouterDeploymentDefinition routerDeploymentDefinition = routerDeploymentDefinitionBuilder.create().setVpc(vpc).setDeployDestination(dest)
-                                                                                                       .setAccountOwner(_accountMgr.getAccount(vpc.getAccountId())).setParams
-                        (params).build();
+                .setAccountOwner(_accountMgr.getAccount(vpc.getAccountId())).setParams(params).build();
 
         routerDeploymentDefinition.deployVirtualRouter();
 

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -1,6 +1,7 @@
 package com.cloud.network.router;
 
 import com.cloud.agent.api.SetupGuestNetworkCommand;
+import com.cloud.agent.api.SetupVRCommand;
 import com.cloud.agent.api.routing.CreateIpAliasCommand;
 import com.cloud.agent.api.routing.DeleteIpAliasCommand;
 import com.cloud.agent.api.routing.DhcpEntryCommand;
@@ -631,6 +632,15 @@ public class CommandSetupHelper {
         cmds.addCommand(cmd);
     }
 
+    public void createVRConfigCommands(final Vpc vpc, final DomainRouterVO router, final Commands cmds) {
+        final SetupVRCommand cmd = new SetupVRCommand(vpc);
+        cmd.setAccessDetail(NetworkElementCommand.ROUTER_IP, _routerControlHelper.getRouterControlIp(router.getId()));
+        cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, router.getInstanceName());
+        final DataCenterVO dcVo = _dcDao.findById(router.getDataCenterId());
+        cmd.setAccessDetail(NetworkElementCommand.ZONE_NETWORK_TYPE, dcVo.getNetworkType().toString());
+        cmds.addCommand(cmd);
+    }
+
     public void createApplyVpnCommands(final boolean isCreate, final RemoteAccessVpn vpn, final VirtualRouter router, final Commands cmds) {
         final List<VpnUserVO> vpnUsers = _vpnUsersDao.listByAccount(vpn.getAccountId());
 
@@ -921,15 +931,6 @@ public class CommandSetupHelper {
             cmd.setAccessDetail(NetworkElementCommand.ZONE_NETWORK_TYPE, dcVo.getNetworkType().toString());
             cmds.addCommand("SetSourceNatCommand", cmd);
         }
-    }
-
-    public void createStaticRouteCommands(final List<StaticRouteProfile> staticRoutes, final DomainRouterVO router, final Commands cmds) {
-        final SetStaticRouteCommand cmd = new SetStaticRouteCommand(staticRoutes);
-        cmd.setAccessDetail(NetworkElementCommand.ROUTER_IP, _routerControlHelper.getRouterControlIp(router.getId()));
-        cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, router.getInstanceName());
-        final DataCenterVO dcVo = _dcDao.findById(router.getDataCenterId());
-        cmd.setAccessDetail(NetworkElementCommand.ZONE_NETWORK_TYPE, dcVo.getNetworkType().toString());
-        cmds.addCommand(cmd);
     }
 
     public void createSite2SiteVpnCfgCommands(final Site2SiteVpnConnection conn, final boolean isCreate, final VirtualRouter router, final Commands cmds) {

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManager.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManager.java
@@ -6,6 +6,7 @@ import com.cloud.framework.config.ConfigKey;
 import com.cloud.network.Network;
 import com.cloud.network.RemoteAccessVpn;
 import com.cloud.network.VirtualNetworkApplianceService;
+import com.cloud.network.vpc.Vpc;
 import com.cloud.user.Account;
 import com.cloud.user.User;
 import com.cloud.utils.component.Manager;
@@ -59,4 +60,6 @@ public interface VirtualNetworkApplianceManager extends Manager, VirtualNetworkA
     boolean prepareAggregatedExecution(Network network, List<DomainRouterVO> routers) throws ResourceUnavailableException;
 
     boolean completeAggregatedExecution(Network network, List<DomainRouterVO> routers) throws ResourceUnavailableException;
+
+    boolean updateVR(final Vpc vpc, final DomainRouterVO router);
 }

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -900,6 +900,8 @@ public class VirtualNetworkApplianceManagerImpl extends ManagerBase implements V
         return startRouter(id, true);
     }
 
+    public boolean updateVR(final Vpc vpc, final DomainRouterVO router) { return false; }
+
     @Override
     public VirtualRouter destroyRouter(final long routerId, final Account caller, final Long callerUserId) throws ResourceUnavailableException, ConcurrentOperationException {
         return _nwHelper.destroyRouter(routerId, caller, callerUserId);

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -760,7 +760,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     @ActionEvent(eventType = EventTypes.EVENT_VPC_CREATE, eventDescription = "creating vpc", create = true)
     public Vpc createVpc(final long zoneId, final long vpcOffId, final long vpcOwnerId, final String vpcName,
                          final String displayText, final String cidr, String networkDomain,
-                         final Boolean displayVpc) throws ResourceAllocationException {
+                         final Boolean displayVpc, final String sourceNatList) throws ResourceAllocationException {
         final Account caller = CallContext.current().getCallingAccount();
         final Account owner = _accountMgr.getAccount(vpcOwnerId);
 
@@ -817,7 +817,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         final boolean useDistributedRouter = vpcOff.supportsDistributedRouter();
         final VpcVO vpc = new VpcVO(zoneId, vpcName, displayText, owner.getId(), owner.getDomainId(), vpcOffId, cidr,
                 networkDomain, useDistributedRouter, isRegionLevelVpcOff,
-                vpcOff.getRedundantRouter());
+                vpcOff.getRedundantRouter(), sourceNatList);
 
         return createVpc(displayVpc, vpc);
     }
@@ -931,7 +931,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_VPC_UPDATE, eventDescription = "updating vpc")
-    public Vpc updateVpc(final long vpcId, final String vpcName, final String displayText, final String customId, final Boolean displayVpc, final Long vpcOfferingId) {
+    public Vpc updateVpc(final long vpcId, final String vpcName, final String displayText, final String customId, final Boolean displayVpc, final Long vpcOfferingId, final String sourceNatList) {
         CallContext.current().setEventDetails(" Id: " + vpcId);
         final Account caller = CallContext.current().getCallingAccount();
 
@@ -960,6 +960,10 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
         if (displayVpc != null) {
             vpc.setDisplay(displayVpc);
+        }
+
+        if (sourceNatList != null) {
+            vpc.setSourceNatList(sourceNatList);
         }
 
         if (vpcOfferingId != null) {

--- a/cosmic-core/server/src/test/java/com/cloud/vpc/MockVpcVirtualNetworkApplianceManager.java
+++ b/cosmic-core/server/src/test/java/com/cloud/vpc/MockVpcVirtualNetworkApplianceManager.java
@@ -13,6 +13,7 @@ import com.cloud.network.VpcVirtualNetworkApplianceService;
 import com.cloud.network.router.VirtualRouter;
 import com.cloud.network.router.VpcVirtualNetworkApplianceManager;
 import com.cloud.network.vpc.PrivateGateway;
+import com.cloud.network.vpc.Vpc;
 import com.cloud.user.Account;
 import com.cloud.user.User;
 import com.cloud.utils.component.ManagerBase;
@@ -247,6 +248,12 @@ public class MockVpcVirtualNetworkApplianceManager extends ManagerBase implement
     @Override
     public boolean stopRemoteAccessVpn(final RemoteAccessVpn vpn, final VirtualRouter router) throws ResourceUnavailableException {
         // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean updateVR(final Vpc vpc, final DomainRouterVO router) {
+    // TODO Auto-generated method stub
         return false;
     }
 }

--- a/cosmic-core/server/src/test/java/com/cloud/vpc/dao/MockVpcDaoImpl.java
+++ b/cosmic-core/server/src/test/java/com/cloud/vpc/dao/MockVpcDaoImpl.java
@@ -80,9 +80,9 @@ public class MockVpcDaoImpl extends GenericDaoBase<VpcVO, Long> implements VpcDa
     public VpcVO findById(final Long id) {
         VpcVO vo = null;
         if (id.longValue() == 1) {
-            vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, false, false);
+            vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, false, false, "");
         } else if (id.longValue() == 2) {
-            vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, false, false);
+            vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, false, false, "");
             vo.setState(State.Inactive);
         }
 

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -17,6 +17,7 @@ from cs.CsRedundant import *
 from cs.CsStaticRoutes import CsStaticRoutes
 from cs.CsPrivateGateway import CsPrivateGateway
 from cs.CsHelper import get_systemvm_version
+from cs.CsVrConfig import CsVrConfig
 
 OCCURRENCES = 1
 
@@ -1203,7 +1204,8 @@ def main(argv):
                                ("load_balancer.json", { "process_iptables": True, "executor": IpTablesExecutor(config) }),
                                ("monitor_service.json", { "process_iptables": False, "executor": CsMonitor("monitorservice", config) }),
                                ("static_routes.json", { "process_iptables": False, "executor": CsStaticRoutes("staticroutes", config) }),
-                               ("private_gateway.json", { "process_iptables": True, "executor": CsPrivateGateway("privategateway", config) })
+                               ("private_gateway.json", { "process_iptables": True, "executor": CsPrivateGateway("privategateway", config) }),
+                               ("vr.json", { "process_iptables": True, "executor": CsVrConfig("virtualrouter", config) })
                                ])
 
     if process_file.count("cmd_line.json") == OCCURRENCES:

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -1139,6 +1139,9 @@ class IpTablesExecutor:
         fwd = CsForwardingRules("forwardingrules", self.config)
         fwd.process()
 
+        acls = CsVrConfig('virtualrouter', self.config)
+        acls.process()
+
         # Strongswan is included in the systemvm template 17.3.13 and newer
         if get_systemvm_version() > 170312:
             logging.debug("Found StrongSwan compatible systemvm template so let's configure VPN with it")
@@ -1205,7 +1208,7 @@ def main(argv):
                                ("monitor_service.json", { "process_iptables": False, "executor": CsMonitor("monitorservice", config) }),
                                ("static_routes.json", { "process_iptables": False, "executor": CsStaticRoutes("staticroutes", config) }),
                                ("private_gateway.json", { "process_iptables": True, "executor": CsPrivateGateway("privategateway", config) }),
-                               ("vr.json", { "process_iptables": True, "executor": CsVrConfig("virtualrouter", config) })
+                               ("vr.json", { "process_iptables": True, "executor": IpTablesExecutor(config) })
                                ])
 
     if process_file.count("cmd_line.json") == OCCURRENCES:

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -140,6 +140,7 @@ class CsAddress(CsDataBag):
         if self.config.is_vpc():
             vpccidr = cmdline.get_vpccidr()
             self.fw.append(["filter", "", "-A FORWARD -s %s ! -d %s -j ACCEPT" % (vpccidr, vpccidr)])
+            self.fw.append(["filter", "", "-A FORWARD -j SOURCE_NAT_LIST"])
             # adding logging here for all ingress traffic at once
             self.fw.append(["filter", "", "-A FORWARD -m limit --limit 2/second -j LOG  --log-prefix \"iptables denied: [ingress]\" --log-level 4"])
 
@@ -532,6 +533,9 @@ class CsIP:
             # jump to egress chain
             self.fw.append(["mangle", "front", "-A PREROUTING -m state --state NEW -i %s -j ACL_OUTBOUND_%s" %
                             (self.dev, self.dev)])
+
+            # create source nat list chain
+            self.fw.append(["filter", "", "-N SOURCE_NAT_LIST"])
 
         if self.get_type() in ["privategateway"]:
             # create egress chain

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs_virtualrouter.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs_virtualrouter.py
@@ -1,0 +1,30 @@
+from netaddr import *
+
+
+def merge(dbag, data):
+    print(dbag)
+
+    for key in dbag.keys():
+        del dbag[key]
+
+    print(dbag)
+
+    for key in data:
+        if key == "type":
+            dbag['id'] = data[key]
+
+        if key == "vpc_name":
+            dbag[key] = data[key]
+
+        if key == "source_nat_list":
+            cidrs = data[key].split(',')
+            for cidr in cidrs:
+                try:
+                    net = IPNetwork(cidr)
+                except:
+                    print('[ERROR] So it seems we have an faulty CIDR in the source NAT list: ' + cidr)
+                    exit(1)
+
+            dbag[key] = data[key]
+
+    return dbag

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs_virtualrouter.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs_virtualrouter.py
@@ -2,12 +2,9 @@ from netaddr import *
 
 
 def merge(dbag, data):
-    print(dbag)
-
+    # always empty the databag as we will receive all new data
     for key in dbag.keys():
         del dbag[key]
-
-    print(dbag)
 
     for key in data:
         if key == "type":
@@ -17,6 +14,7 @@ def merge(dbag, data):
             dbag[key] = data[key]
 
         if key == "source_nat_list":
+            # let's verify that the list contains valid CIDRs
             cidrs = data[key].split(',')
             for cidr in cidrs:
                 try:

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/merge.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/merge.py
@@ -25,6 +25,7 @@ import cs_staticroutes
 import cs_vmdata
 import cs_vpnusers
 import cs_privategateway
+import cs_virtualrouter
 import cs.CsHelper as csHelper
 
 
@@ -125,6 +126,8 @@ class updateDataBag:
             return
         elif self.qFile.type == 'privategateway':
             dbag = self.process_privategateway(self.db.getDataBag())
+        elif self.qFile.type == 'virtualrouter':
+            dbag = self.process_virtualrouter(self.db.getDataBag())
         else:
             logging.error("Error I do not know what to do with file of type %s", self.qFile.type)
             return
@@ -293,6 +296,9 @@ class updateDataBag:
         # to be used by both staticnat and portforwarding
         return cs_forwardingrules.merge(dbag, self.qFile.data)
 
+    def process_virtualrouter(self, dbag):
+        return cs_virtualrouter.merge(dbag, self.qFile.data)
+
     def process_ip(self, dbag):
         for ip in self.qFile.data["ip_address"]:
             # Find the right device we should use to configure the ip address
@@ -313,7 +319,7 @@ class updateDataBag:
                                       % (device_name, ip['device_mac_address'], ip['vif_mac_address'])
                         ip['vif_mac_address_as_sent_by_mgt_server'] = ip['vif_mac_address']
                     else:
-                        log_message = "The mac address as sent by the management server %s matches the one we found (%s) on device %s so that's good"\
+                        log_message = "The mac address as sent by the management server %s matches the one we found (%s) on device %s so that's good" \
                                       % (ip['vif_mac_address'], ip['device_mac_address'], device_name)
                         logging.info(log_message)
 


### PR DESCRIPTION
This PR adds a source NAT list on a VPC. Next to the VPC CIDR also all CIDRs in the source NAT list will be added to the source NAT in iptables. This allows traffic over the private gateway from other VPCs to be source NATted using the source NAT IP address to this VPC.

When adding a new VPC the source NAT list can entered here:
![image](https://cloud.githubusercontent.com/assets/2650429/26222293/bb7e6626-3c19-11e7-8085-d5a775b12486.png)

The source NAT list is in the form of a comma separated list of CIDRs e.g: 
- 10.0.0.0/8 
- 192.168.22.0/24,192.168.45.39/32

The list can also be edited after creation:
![image](https://cloud.githubusercontent.com/assets/2650429/26222518/91b76666-3c1a-11e7-9b24-90d2b3fb80f7.png)

Adding a source NAT list will result in a vr.json to be sent to the router, from that vr.json a data bag called virtualrouter.json will be created:
![image](https://cloud.githubusercontent.com/assets/2650429/26222760/7ac67068-3c1b-11e7-843c-e3002fd97672.png)

And IP tables will contain entries in the SOURCE_NAT_LIST chain:
![image](https://cloud.githubusercontent.com/assets/2650429/26222880/e903c418-3c1b-11e7-8830-dc0b1f0da5c0.png)

