### PR TITLE
Improve the permission denied message to be clear

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/api/ApiServlet.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/ApiServlet.java
@@ -239,7 +239,7 @@ public class ApiServlet extends HttpServlet {
                     }
                 }
 
-                final String errorMessage = "The given command either does not exist, is not available for user, or not available from ip address '" + remoteAddress + "'.";
+                final String errorMessage = "Permission denied due to: Expired session, unavailable API command or non-authorised from ip-address '" + remoteAddress + "'";
                 auditTrailSb.append(" " + HttpServletResponse.SC_UNAUTHORIZED + " " + errorMessage);
                 final String serializedResponse =
                         _apiServer.getSerializedApiError(HttpServletResponse.SC_UNAUTHORIZED, errorMessage, params, responseType);


### PR DESCRIPTION
Currently it's not clear this can also be due to an expired session.

Before:
![image](https://cloud.githubusercontent.com/assets/1630096/26098411/ee852c4c-3a27-11e7-85b4-3306c9aea14a.png)

After:
![image](https://cloud.githubusercontent.com/assets/1630096/26100030/ee652bcc-3a2c-11e7-89d9-6632f5527081.png)
