### PR TITLE
Power off VMs when force stop is provided

### DIFF
--- a/cosmic-core/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/cosmic-core/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -3165,7 +3165,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
 
         vmGuru.prepareStop(profile);
 
-        final StopCommand stop = new StopCommand(vm, getExecuteInSequence(vm.getHypervisorType()), false);
+        final StopCommand stop = new StopCommand(vm, getExecuteInSequence(vm.getHypervisorType()), false, cleanUpEvenIfUnableToStop);
 
         boolean stopped = false;
         Answer answer = null;

--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/api/StopCommand.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/api/StopCommand.java
@@ -9,6 +9,7 @@ public class StopCommand extends RebootCommand {
     private String urlPort = null;
     private String publicConsoleProxyIpAddress = null;
     private GPUDeviceTO gpuDevice;
+    boolean forceStop = false;
 
     protected StopCommand() {
     }
@@ -30,6 +31,11 @@ public class StopCommand extends RebootCommand {
     public StopCommand(final String vmName, final boolean executeInSequence, final boolean checkBeforeCleanup) {
         super(vmName, executeInSequence);
         this.checkBeforeCleanup = checkBeforeCleanup;
+    }
+
+    public StopCommand(VirtualMachine vm, boolean executeInSequence, boolean checkBeforeCleanup, boolean forceStop) {
+        super(vm.getInstanceName(), executeInSequence);
+        this.forceStop = forceStop;
     }
 
     @Override
@@ -63,5 +69,9 @@ public class StopCommand extends RebootCommand {
 
     public boolean checkBeforeCleanup() {
         return this.checkBeforeCleanup;
+    }
+
+    public boolean isForceStop() {
+        return forceStop;
     }
 }

--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2389,7 +2389,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 }
             }
             logger.debug(vmDef);
-            msg = stopVm(conn, vmName);
+            msg = stopVm(conn, vmName, false);
             msg = startVm(conn, vmName, vmDef);
             return null;
         } catch (final LibvirtException e) {
@@ -2411,12 +2411,12 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         return msg;
     }
 
-    public String stopVm(final Connect conn, final String vmName) {
+    public String stopVm(final Connect conn, final String vmName, final boolean forceStop) {
         DomainState state = null;
         Domain dm = null;
 
         logger.debug("Try to stop the vm at first");
-        String ret = stopVm(conn, vmName, false);
+        String ret = stopVmInternal(conn, vmName, forceStop);
         if (ret == Script.ERR_TIMEOUT) {
             ret = stopVm(conn, vmName, true);
         } else if (ret != null) {
@@ -2450,7 +2450,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
             if (state != DomainState.VIR_DOMAIN_SHUTOFF) {
                 logger.debug("Try to destroy the vm");
-                ret = stopVm(conn, vmName, true);
+                ret = stopVmInternal(conn, vmName, forceStop);
                 if (ret != null) {
                     return ret;
                 }
@@ -2494,7 +2494,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         return null;
     }
 
-    protected String stopVm(final Connect conn, final String vmName, final boolean force) {
+    protected String stopVmInternal(final Connect conn, final String vmName, final boolean force) {
         Domain dm = null;
         try {
             dm = conn.domainLookupByName(vmName);

--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtStopCommandWrapper.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtStopCommandWrapper.java
@@ -49,7 +49,7 @@ public final class LibvirtStopCommandWrapper extends CommandWrapper<StopCommand,
             final List<InterfaceDef> ifaces = libvirtComputingResource.getInterfaces(conn, vmName);
 
             libvirtComputingResource.destroyNetworkRulesForVm(conn, vmName);
-            final String result = libvirtComputingResource.stopVm(conn, vmName);
+            final String result = libvirtComputingResource.stopVm(conn, vmName, command.isForceStop());
             if (result == null) {
                 for (final DiskDef disk : disks) {
                     libvirtComputingResource.cleanupDisk(disk);

--- a/cosmic-core/plugins/hypervisor/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/cosmic-core/plugins/hypervisor/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -4885,10 +4885,15 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
 
     protected abstract String getPatchFilePath();
 
-    public void shutdownVM(final Connection conn, final VM vm, final String vmName) throws XmlRpcException {
+    public void shutdownVM(final Connection conn, final VM vm, final String vmName, final boolean forcedStop) throws XmlRpcException {
         Task task = null;
         try {
-            task = vm.cleanShutdownAsync(conn);
+            if (forcedStop) {
+                task = vm.hardShutdownAsync(conn);
+            } else {
+                task = vm.cleanShutdownAsync(conn);
+            }
+
             try {
                 // poll every 1 seconds , timeout after 10 minutes
                 waitForTask(conn, task, 1000, 10 * 60 * 1000);

--- a/cosmic-core/plugins/hypervisor/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixStopCommandWrapper.java
+++ b/cosmic-core/plugins/hypervisor/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixStopCommandWrapper.java
@@ -97,7 +97,7 @@ public final class CitrixStopCommandWrapper extends CommandWrapper<StopCommand, 
                                 s_logger.info("Removed  network rules for vm " + command.getVmName());
                             }
                         }
-                        citrixResourceBase.shutdownVM(conn, vm, vmName);
+                        citrixResourceBase.shutdownVM(conn, vm, vmName, command.isForceStop());
                     }
                 } catch (final Exception e) {
                     final String msg = "Catch exception " + e.getClass().getName() + " when stop VM:" + command.getVmName() + " due to " + e.toString();


### PR DESCRIPTION
Backport of ACS PR 2108

Stopping a VM on KVM now takes a few seconds:

```
2017-05-16 16:01:44.734 DEBUG (logid: 993f7ebf) 10129 --- [agentRequest-Handler-1] com.cloud.agent.service.Agent            : Request:Seq 2-7673570815085903919:  { Cmd , MgmtId: 90520732674659, via: 2, Ver: v1, Flags: 100011, [{"com.cloud.agent.api.StopCommand":{"checkBeforeCleanup":false,"isProxy":false,"forceStop":true,"vmName":"i-2-9-VM","executeInSequence":false,"wait":0}}] }
```