### PR TITLE
Make Manufacturer string of KVM VM configurable via OS-Type

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/agent/api/to/VirtualMachineTO.java
+++ b/cosmic-core/api/src/main/java/com/cloud/agent/api/to/VirtualMachineTO.java
@@ -27,6 +27,7 @@ public class VirtualMachineTO {
     String hostName;
     String arch;
     String os;
+    String manufacturer;
     String platformEmulator;
     String bootArgs;
     String[] bootupScripts;
@@ -301,5 +302,13 @@ public class VirtualMachineTO {
 
     public void setConfigDriveIsoFile(final String configDriveIsoFile) {
         this.configDriveIsoFile = configDriveIsoFile;
+    }
+
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    public void setManufacturer(final String manufacturer) {
+        this.manufacturer = manufacturer;
     }
 }

--- a/cosmic-core/db-scripts/src/main/resources/db/schema-534to535.sql
+++ b/cosmic-core/db-scripts/src/main/resources/db/schema-534to535.sql
@@ -2,3 +2,6 @@
 -- Schema upgrade from 5.3.4 to 5.3.5;
 --
 
+-- Manufacturer field
+ALTER table guest_os ADD `manufacturer_string` varchar(64) DEFAULT "Mission Critical Cloud" COMMENT 'String to put in the Manufacturer field in the XML of a KVM VM';
+

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/storage/GuestOSVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/storage/GuestOSVO.java
@@ -35,6 +35,9 @@ public class GuestOSVO implements GuestOS {
     @Column(name = "is_user_defined")
     private boolean isUserDefined;
 
+    @Column(name = "manufacturer_string")
+    String manufacturer;
+
     @Override
     public long getId() {
         return id;
@@ -97,5 +100,13 @@ public class GuestOSVO implements GuestOS {
 
     public void setUuid(final String uuid) {
         this.uuid = uuid;
+    }
+
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    public void setManufacturer(final String manufacturer) {
+        this.manufacturer = manufacturer;
     }
 }

--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1600,6 +1600,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         guest.setGuestArch(vmTo.getArch());
         guest.setMachineType("pc");
         guest.setUuid(uuid);
+        guest.setManufacturer(vmTo.getManufacturer());
         guest.setBootOrder(GuestDef.BootOrder.CDROM);
         guest.setBootOrder(GuestDef.BootOrder.HARDISK);
 
@@ -1648,12 +1649,6 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         features.addFeatures("pae");
         features.addFeatures("apic");
         features.addFeatures("acpi");
-        // for rhel 6.5 and above, hyperv enlightment feature is added
-    /*
-     * if (vmTO.getOs().contains("Windows Server 2008") && hostOsVersion != null && ((hostOsVersion.first() == 6 &&
-     * hostOsVersion.second() >= 5) || (hostOsVersion.first() >= 7))) { LibvirtVMDef.HyperVEnlightenmentFeatureDef hyv =
-     * new LibvirtVMDef.HyperVEnlightenmentFeatureDef(); hyv.setRelaxed(true); features.addHyperVFeature(hyv); }
-     */
         vm.addComp(features);
 
         final TermPolicy term = new TermPolicy();

--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVmDef.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVmDef.java
@@ -101,6 +101,7 @@ public class LibvirtVmDef {
         private String cmdline;
         private String uuid;
         private String machine;
+        private String manufacturer;
 
         public GuestType getGuestType() {
             return type;
@@ -137,6 +138,10 @@ public class LibvirtVmDef {
             this.uuid = uuid;
         }
 
+        public void setManufacturer(final String manufacturer) {
+            this.manufacturer = manufacturer;
+        }
+
         @Override
         public String toString() {
             if (type == GuestType.KVM) {
@@ -144,7 +149,9 @@ public class LibvirtVmDef {
 
                 guestDef.append("<sysinfo type='smbios'>\n");
                 guestDef.append("<system>\n");
-                guestDef.append("<entry name='manufacturer'>Mission Critical Cloud</entry>\n");
+                if (manufacturer != null && ! manufacturer.isEmpty()) {
+                    guestDef.append("<entry name='manufacturer'>" + manufacturer + "</entry>\n");
+                }
                 guestDef.append("<entry name='product'>Cosmic " + type.toString() + " Hypervisor</entry>\n");
                 guestDef.append("<entry name='uuid'>" + uuid + "</entry>\n");
                 guestDef.append("</system>\n");

--- a/cosmic-core/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
+++ b/cosmic-core/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
@@ -77,6 +77,7 @@ public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
         // Determine the VM's OS description
         final GuestOSVO guestOS = _guestOsDao.findByIdIncludingRemoved(vm.getVirtualMachine().getGuestOSId());
         to.setOs(guestOS.getDisplayName());
+        to.setManufacturer(guestOS.getManufacturer());
         final HostVO host = _hostDao.findById(vm.getVirtualMachine().getHostId());
         GuestOSHypervisorVO guestOsMapping = null;
         if (host != null) {


### PR DESCRIPTION
In order to run a Cisco ASAv appliance, the Manufacturer needs to be set to 'Red Hat'. This PR allows to specify a Manufacturer string per OSType.

![image](https://cloud.githubusercontent.com/assets/1630096/26160678/3e5cf538-3b22-11e7-8ce2-6c8f37aa0a3f.png)

Resulting in:

```
    <system>
      <entry name='manufacturer'>Red Hat</entry>
      <entry name='product'>Cosmic KVM Hypervisor</entry>
      <entry name='uuid'>5959a498-f832-4158-8453-ccef8d29d361</entry>
    </system>
```

Then plug a NIC to the public network (ROOT-only):
![image](https://cloud.githubusercontent.com/assets/1630096/26160786/7dffce68-3b22-11e7-8a80-5e6c434b4da3.png)

Now ASAv works:
![image](https://cloud.githubusercontent.com/assets/1630096/26160637/2187287a-3b22-11e7-9d64-bf5cc049e2b0.png)
