### PR TITLE
Allow domain admins to plug a public nic in a user vm

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -1635,7 +1635,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
                     throw new PermissionDeniedException("Unable to use network with id= " + ((NetworkVO) network).getUuid() +
                             ", permission denied");
                 }
-            } else {
+            } else if (! TrafficType.Public.equals(network.getTrafficType())) {
                 final List<NetworkVO> networkMap = _networksDao.listBy(owner.getId(), network.getId());
                 if (networkMap == null || networkMap.isEmpty()) {
                     throw new PermissionDeniedException("Unable to use network with id= " + ((NetworkVO) network).getUuid() +

--- a/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1851,9 +1851,11 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             throw new InvalidParameterValueException("unable to find a network with id " + networkId);
         }
 
+        // Root admin may plug anything, Domain admin is allowed to plug into the public network
         if (caller.getType() != Account.ACCOUNT_TYPE_ADMIN) {
             if (!(network.getGuestType() == Network.GuestType.Shared && network.getAclType() == ACLType.Domain)
-                    && !(network.getAclType() == ACLType.Account && network.getAccountId() == vmInstance.getAccountId())) {
+                    && !(network.getAclType() == ACLType.Account && network.getAccountId() == vmInstance.getAccountId())
+                    && !(caller.getType() == Account.ACCOUNT_TYPE_DOMAIN_ADMIN && TrafficType.Public.equals(network.getTrafficType()))) {
                 throw new InvalidParameterValueException("only shared network or isolated network with the same account_id can be added to vmId: " + vmId);
             }
         }


### PR DESCRIPTION
Domain Admins can now plug public nics to their VMs. No longer needs root to do that.

Before it failed a permission check:
```
(remi) 🐵 > add nictovirtualmachine networkid=b488b5b3-e35f-41e4-ba16-4043afeb90f4 virtualmachineid=a1aa9ca1-43c5-4093-b85e-6dbf6437221e
Error
Async job 08f4e75d-f061-444c-8999-39e997f3fc0a failed
Error 431, only shared network or isolated network with the same account_id can be added to vmId: 7
accountid = 86e1c46d-e01e-4542-b9f8-cf6b0e21b4f8
cmd = com.cloud.api.command.user.vm.AddNicToVMCmd
created = 2017-05-18T21:00:24+0200
jobid = 08f4e75d-f061-444c-8999-39e997f3fc0a
jobprocstatus = 0
jobresult:
errorcode = 431
errortext = only shared network or isolated network with the same account_id can be added to vmId: 7
jobresultcode = 530
jobresulttype = object
jobstatus = 2
userid = 4279661e-77b1-4cdf-90f0-35be657ade54
```

Now it is allowed and works:
```
(remi) 🐵 > add nictovirtualmachine networkid=b488b5b3-e35f-41e4-ba16-4043afeb90f4 virtualmachineid=a1aa9ca1-43c5-4093-b85e-6dbf6437221e

accountid = 86e1c46d-e01e-4542-b9f8-cf6b0e21b4f8
...
account = remi
...
broadcasturi = vlan://untagged
gateway = 192.168.23.1
ipaddress = 192.168.23.60
isdefault = False
isolationuri = vlan://untagged
...
```

![image](https://cloud.githubusercontent.com/assets/1630096/26219770/73e309c4-3c10-11e7-973e-cb0cc1f788b3.png)

This builds on top of #410 so secondary ip's also work.

The only nice-to-have is that a public nic can be added from the UI. We'll handle that later.
