### PR TITLE
VM on multiple tiers of a VPC

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -4370,14 +4370,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 securityGroupEnabled = true;
             }
 
-            // vm can't be a part of more than 1 VPC network
-            if (network.getVpcId() != null) {
-                if (vpcNetwork) {
-                    throw new InvalidParameterValueException("Vm can't be a part of more than 1 VPC network");
-                }
-                vpcNetwork = true;
-            }
-
             networkNicMap.put(network.getUuid(), profile);
         }
 


### PR DESCRIPTION
Removed restriction that prevented VMs from belonging to multiple tiers of a VPC. 