### PR TITLE
Change VPC offering should mention the missing services once

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -1035,7 +1035,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
     private void checkVpcOfferingServicesWithCurrentNetworkOfferings(final Long vpcOfferingId, final VpcVO currentVpc) {
         // List of VPC networks
-        final List<NetworkVO> networks = _ntwkDao.listVpcNetworks();
+        final List<NetworkVO> networks = _ntwkDao.listByVpc(currentVpc.getId());
 
         // Services that the new offering supports
         final List<String> newOfferingSupportedServicesStr =_vpcOffSvcMapDao.listServicesForVpcOffering(vpcOfferingId);

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -1046,7 +1046,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             final List<String> networkOfferingSupportedServicesStr = _ntwkOffServiceDao.listServicesForNetworkOffering(network.getNetworkOfferingId());
 
             for (final String serviceName : networkOfferingSupportedServicesStr) {
-                if (! newOfferingSupportedServicesStr.contains(serviceName)) {
+                if (! newOfferingSupportedServicesStr.contains(serviceName) && ! notSupportedServices.contains(serviceName)) {
                     notSupportedServices.add(serviceName);
                 }
             }


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/1630096/26242134/a888ce6c-3c87-11e7-8b52-a643e8e5c66b.png)

After:
![image](https://cloud.githubusercontent.com/assets/1630096/26242120/96944fc4-3c87-11e7-8a28-ee7b9a4fb2ff.png)

Two issues:
- it looked at all networks, not just the ones belonging to the VPC
- it mentioned the services that are missing multiple times (for every network)

Now only for the current VPC and once per service that is missing.

Thanks to @ddegoede for finding this issue!