### PR TITLE
When Gateway service is enabled we should use that ip for the router

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
@@ -286,9 +286,9 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
                     case DomainRouter:
                         if (network.getVpcId() != null) {
                             final Vpc vpc = _vpcDao.findById(network.getVpcId());
-                            if (_networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.SourceNat,
+                            if (_networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.Gateway,
                                     Provider.VPCVirtualRouter) && !vpc.isRedundant()) {
-                                // Non-redundant VPCs that support SourceNat acquire the gateway ip on their nic
+                                // Non-redundant VPCs that support Gateway acquire the gateway ip on their nic
                                 guestIp = network.getGateway();
                             } else {
                                 // In other cases, acquire an ip address from the DHCP range (take lowest possible)


### PR DESCRIPTION
VPC without SourceNat and with Gateway service doesn't take the gateway as its own ip address:

Before:

```
root@r-10-VM:~# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 0e:00:a9:fe:01:e6 brd ff:ff:ff:ff:ff:ff
    inet 169.254.1.230/16 brd 169.254.255.255 scope global eth0
       valid_lft forever preferred_lft forever
3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 02:00:4a:7f:00:02 brd ff:ff:ff:ff:ff:ff
    inet 10.2.1.2/24 brd 10.2.1.255 scope global eth1
       valid_lft forever preferred_lft forever

cat /etc/dnsmasq.d/cloud.conf
dhcp-hostsfile=/etc/dhcphosts.txt
dhcp-optsfile=/etc/dhcpopts.txt
log-dhcp
interface=eth1
dhcp-range=interface:eth1,set:interface-eth1-0,10.2.1.2,static
dhcp-option=tag:interface-eth1-0,15,cs2cloud
dhcp-option=tag:interface-eth1-0,6,10.2.1.1
dhcp-option=tag:interface-eth1-0,3,10.2.1.1
dhcp-option=tag:interface-eth1-0,1,255.255.255.0
```

After:
```
root@r-12-VM:~# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 0e:00:a9:fe:00:b5 brd ff:ff:ff:ff:ff:ff
    inet 169.254.0.181/16 brd 169.254.255.255 scope global eth0
       valid_lft forever preferred_lft forever
3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 02:00:43:c7:00:03 brd ff:ff:ff:ff:ff:ff
    inet 10.2.1.1/24 brd 10.2.1.255 scope global eth1
       valid_lft forever preferred_lft forever
root@r-12-VM:~# cat /etc/dnsmasq.d/cloud.conf
dhcp-hostsfile=/etc/dhcphosts.txt
dhcp-optsfile=/etc/dhcpopts.txt
log-dhcp
interface=eth1
dhcp-range=interface:eth1,set:interface-eth1-0,10.2.1.1,static
dhcp-option=tag:interface-eth1-0,15,cs2cloud
dhcp-option=tag:interface-eth1-0,6,10.2.1.1
dhcp-option=tag:interface-eth1-0,3,10.2.1.1
dhcp-option=tag:interface-eth1-0,1,255.255.255.0
```

