### PR TITLE
Adding syslog servers to configure on the VPC

### DIFF
--- a/cosmic-client/src/main/webapp/l10n/en.js
+++ b/cosmic-client/src/main/webapp/l10n/en.js
@@ -1655,6 +1655,7 @@ var dictionary = {
     "label.vpc.distributedvpcrouter": "Distributed VPC Router",
     "label.vpc.id": "VPC ID",
     "label.vpc.sourcenatlist": "Source NAT list",
+    "label.vpc.syslogserverlist": "Syslog server list",
     "label.vpc.offering": "VPC Offering",
     "label.vpc.offering.details": "VPC offering details",
     "label.vpc.router.details": "VPC Router Details",

--- a/cosmic-client/src/main/webapp/scripts/docs.js
+++ b/cosmic-client/src/main/webapp/scripts/docs.js
@@ -970,6 +970,10 @@ cloudStack.docs = {
         desc: 'Comma separated list of CIDRs that will be source NATted into this VPC\'s Source NAT IP address.',
         externalLink: ''
     },
+    helpVPCSyslogServerList: {
+        desc: 'Comma separated list of IP addresses that will be configured as remote syslog servers to forward IP tables logging.',
+        externalLink: ''
+    },
     helpVPCDomain: {
         desc: 'If you want to assign a special domain name to this VPC\'s guest VM network, specify the DNS suffix',
         externalLink: ''

--- a/cosmic-client/src/main/webapp/scripts/network.js
+++ b/cosmic-client/src/main/webapp/scripts/network.js
@@ -627,6 +627,10 @@
                                         docID: 'helpVPCSourceNATList',
                                         label: 'label.vpc.sourcenatlist'
                                     },
+                                    syslogserverlist: {
+                                        docID: 'helpVPCSyslogServerList',
+                                        label: 'label.vpc.syslogserverlist'
+                                    },
                                     networkdomain: {
                                         docID: 'helpVPCDomain',
                                         label: 'label.DNS.domain.for.guest.networks'
@@ -675,6 +679,11 @@
                                 if (args.data.sourcenatlist != null && args.data.sourcenatlist.length > 0)
                                     $.extend(dataObj, {
                                         sourcenatlist: args.data.sourcenatlist
+                                    });
+
+                                if (args.data.syslogserverlist != null && args.data.syslogserverlist.length > 0)
+                                    $.extend(dataObj, {
+                                        syslogserverlist: args.data.syslogserverlist
                                     });
 
                                 if (args.data.networkdomain != null && args.data.networkdomain.length > 0)
@@ -755,6 +764,11 @@
                                                 sourcenatlist: args.data.sourcenatlist
                                             });
 
+                                        if (args.data.syslogserverlist != null && args.data.syslogserverlist.length > 0)
+                                            $.extend(dataObj, {
+                                                syslogserverlist: args.data.syslogserverlist
+                                            });
+
                                         cloudStack.dialog.confirm({
                                             message: 'message.confirm.change.vpcoffering',
                                             action: function () { //"Yes"    button is clicked
@@ -790,6 +804,11 @@
                                         if (args.data.sourcenatlist != null && args.data.sourcenatlist.length > 0)
                                             $.extend(dataObj, {
                                                 sourcenatlist: args.data.sourcenatlist
+                                            });
+
+                                        if (args.data.syslogserverlist != null && args.data.syslogserverlist.length > 0)
+                                            $.extend(dataObj, {
+                                                syslogserverlist: args.data.syslogserverlist
                                             });
 
                                         $.ajax({
@@ -987,6 +1006,10 @@
                                     },
                                     sourcenatlist: {
                                         label: 'label.vpc.sourcenatlist',
+                                        isEditable: true
+                                    },
+                                    syslogserverlist: {
+                                        label: 'label.vpc.syslogserverlist',
                                         isEditable: true
                                     },
                                     networkdomain: {

--- a/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
@@ -402,6 +402,7 @@ public class ApiConstants {
     public static final String ASSOCIATED_NETWORK_NAME = "associatednetworkname";
     public static final String SOURCE_NAT_SUPPORTED = "sourcenatsupported";
     public static final String SOURCE_NAT_LIST = "sourcenatlist";
+    public static final String SYSLOG_SERVER_LIST = "syslogserverlist";
     public static final String RESOURCE_STATE = "resourcestate";
     public static final String PROJECT_INVITE_REQUIRED = "projectinviterequired";
     public static final String REQUIRED = "required";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/UpdateVPCCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/UpdateVPCCmdByAdmin.java
@@ -18,7 +18,7 @@ public class UpdateVPCCmdByAdmin extends UpdateVPCCmd {
 
     @Override
     public void execute() {
-        final Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc(), getVpcOfferingId(), getSourceNatList());
+        final Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc(), getVpcOfferingId(), getSourceNatList(), getSyslogServerList());
         if (result != null) {
             final VpcResponse response = _responseGenerator.createVpcResponse(ResponseView.Full, result);
             response.setResponseName(getCommandName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/CreateVPCCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/CreateVPCCmd.java
@@ -84,6 +84,10 @@ public class CreateVPCCmd extends BaseAsyncCreateCmd {
             description = "Source NAT CIDR list for used to allow other CIDRs to be source NATted by the VPC over the public interface")
     private String sourceNatList;
 
+    @Parameter(name = ApiConstants.SYSLOG_SERVER_LIST, type = CommandType.STRING,
+            description = "Comma separated list of IP addresses to configure as syslog servers on the VPC to forward IP tables logging")
+    private String syslogServerList;
+
     // ///////////////////////////////////////////////////
     // ///////////////// Accessors ///////////////////////
     // ///////////////////////////////////////////////////
@@ -98,7 +102,7 @@ public class CreateVPCCmd extends BaseAsyncCreateCmd {
 
     @Override
     public void create() throws ResourceAllocationException {
-        final Vpc vpc = _vpcService.createVpc(getZoneId(), getVpcOffering(), getEntityOwnerId(), getVpcName(), getDisplayText(), getCidr(), getNetworkDomain(), getDisplayVpc(), getSourceNatList());
+        final Vpc vpc = _vpcService.createVpc(getZoneId(), getVpcOffering(), getEntityOwnerId(), getVpcName(), getDisplayText(), getCidr(), getNetworkDomain(), getDisplayVpc(), getSourceNatList(), getSyslogServerList());
         if (vpc != null) {
             setEntityId(vpc.getId());
             setEntityUuid(vpc.getUuid());
@@ -140,6 +144,13 @@ public class CreateVPCCmd extends BaseAsyncCreateCmd {
             return sourceNatList;
         }
         return sourceNatList.replaceAll("\\s", "");
+    }
+
+    public String getSyslogServerList() {
+        if (StringUtils.isEmpty(syslogServerList)) {
+            return syslogServerList;
+        }
+        return syslogServerList.replaceAll("\\s", "");
     }
 
     @Override

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/UpdateVPCCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/UpdateVPCCmd.java
@@ -52,13 +52,17 @@ public class UpdateVPCCmd extends BaseAsyncCustomIdCmd {
             description = "Source NAT CIDR list for used to allow other CIDRs to be source NATted by the VPC over the public interface")
     private String sourceNatList;
 
+    @Parameter(name = ApiConstants.SYSLOG_SERVER_LIST, type = CommandType.STRING,
+            description = "Comma separated list of IP addresses to configure as syslog servers on the VPC to forward IP tables logging")
+    private String syslogServerList;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
 
     @Override
     public void execute() {
-        final Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc(), getVpcOfferingId(), getSourceNatList());
+        final Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc(), getVpcOfferingId(), getSourceNatList(), getSyslogServerList());
         if (result != null) {
             final VpcResponse response = _responseGenerator.createVpcResponse(ResponseView.Restricted, result);
             response.setResponseName(getCommandName());
@@ -131,6 +135,13 @@ public class UpdateVPCCmd extends BaseAsyncCustomIdCmd {
             return sourceNatList;
         }
         return sourceNatList.replaceAll("\\s", "");
+    }
+
+    public String getSyslogServerList() {
+        if (StringUtils.isEmpty(syslogServerList)) {
+            return syslogServerList;
+        }
+        return syslogServerList.replaceAll("\\s", "");
     }
 
     @Override

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/VpcResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/VpcResponse.java
@@ -118,6 +118,10 @@ public class VpcResponse extends BaseResponse implements ControlledEntityRespons
     @Param(description = "Source Nat CIDR list for used to allow other CIDRs to be source NATted by the VPC over the public interface", since = "5.3")
     private String sourceNatList;
 
+    @SerializedName(ApiConstants.SYSLOG_SERVER_LIST)
+    @Param(description = "Comma separated list of IP addresses to configure as syslog servers on the VPC to forward IP tables logging", since = "5.3")
+    private String syslogServerList;
+
     public void setId(final String id) {
         this.id = id;
     }
@@ -229,5 +233,9 @@ public class VpcResponse extends BaseResponse implements ControlledEntityRespons
 
     public void setSourceNatList(final String sourceNatList) {
         this.sourceNatList = sourceNatList;
+    }
+
+    public void setSyslogServerList(final String syslogServerList) {
+        this.syslogServerList = syslogServerList;
     }
 }

--- a/cosmic-core/api/src/main/java/com/cloud/network/vpc/Vpc.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/vpc/Vpc.java
@@ -47,6 +47,11 @@ public interface Vpc extends ControlledEntity, Identity, InternalIdentity {
     String getSourceNatList();
 
     /**
+     * @return VPC syslog server list
+     */
+    String getSyslogServerList();
+
+    /**
      * @return true if restart is required for the VPC; false otherwise
      */
     boolean isRestartRequired();

--- a/cosmic-core/api/src/main/java/com/cloud/network/vpc/VpcService.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/vpc/VpcService.java
@@ -30,7 +30,7 @@ public interface VpcService {
      * @return
      * @throws ResourceAllocationException TODO
      */
-    public Vpc createVpc(long zoneId, long vpcOffId, long vpcOwnerId, String vpcName, String displayText, String cidr, String networkDomain, Boolean displayVpc, String sourceNatList)
+    public Vpc createVpc(long zoneId, long vpcOffId, long vpcOwnerId, String vpcName, String displayText, String cidr, String networkDomain, Boolean displayVpc, String sourceNatList, String syslogServerList)
             throws ResourceAllocationException;
 
     /**
@@ -54,7 +54,7 @@ public interface VpcService {
      * @param displayVpc  TODO
      * @return
      */
-    public Vpc updateVpc(long vpcId, String vpcName, String displayText, String customId, Boolean displayVpc, Long vpcOfferingId, String sourceNatList);
+    public Vpc updateVpc(long vpcId, String vpcName, String displayText, String customId, Boolean displayVpc, Long vpcOfferingId, String sourceNatList, String syslogServerList);
 
     /**
      * Lists VPC(s) based on the parameters passed to the method call

--- a/cosmic-core/db-scripts/src/main/resources/db/schema-535to536.sql
+++ b/cosmic-core/db-scripts/src/main/resources/db/schema-535to536.sql
@@ -4,3 +4,6 @@
 
 -- Add source nat list
 ALTER TABLE `cloud`.`vpc` ADD COLUMN `source_nat_list` varchar(255) DEFAULT NULL COMMENT 'List of CIDRS to source NAT on VPC' AFTER `redundant`;
+
+-- Add syslog server list
+ALTER TABLE `cloud`.`vpc` ADD COLUMN `syslog_server_list` varchar(255) DEFAULT NULL COMMENT 'List of IP addresses to configure as syslog servers on VPC' AFTER `source_nat_list`;

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/network/vpc/VpcVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/network/vpc/VpcVO.java
@@ -55,6 +55,8 @@ public class VpcVO implements Vpc {
     private String cidr = null;
     @Column(name = "source_nat_list")
     String sourceNatList;
+    @Column(name = "syslog_server_list")
+    String syslogServerList;
 
     public VpcVO() {
         uuid = UUID.randomUUID().toString();
@@ -62,7 +64,7 @@ public class VpcVO implements Vpc {
 
     public VpcVO(final long zoneId, final String name, final String displayText, final long accountId, final long domainId,
                  final long vpcOffId, final String cidr, final String networkDomain, final boolean useDistributedRouter,
-                 final boolean regionLevelVpc, final boolean isRedundant, final String sourceNatList) {
+                 final boolean regionLevelVpc, final boolean isRedundant, final String sourceNatList, final String syslogServerList) {
         this.zoneId = zoneId;
         this.name = name;
         this.displayText = displayText;
@@ -77,6 +79,7 @@ public class VpcVO implements Vpc {
         this.regionLevelVpc = regionLevelVpc;
         redundant = isRedundant;
         this.sourceNatList = sourceNatList;
+        this.syslogServerList = syslogServerList;
     }
 
     @Override
@@ -212,5 +215,13 @@ public class VpcVO implements Vpc {
 
     public String getSourceNatList() {
         return sourceNatList;
+    }
+
+    public void setSyslogServerList(final String syslogServerList) {
+        this.syslogServerList = syslogServerList;
+    }
+
+    public String getSyslogServerList() {
+        return syslogServerList;
     }
 }

--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/api/SetupVRCommand.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/api/SetupVRCommand.java
@@ -5,17 +5,23 @@ import com.cloud.network.vpc.Vpc;
 
 public class SetupVRCommand extends NetworkElementCommand {
     String sourceNatList;
+    String syslogServerList;
     String vpcName;
 
     protected SetupVRCommand() {}
 
     public SetupVRCommand(final Vpc vpc) {
         this.sourceNatList = vpc.getSourceNatList();
+        this.syslogServerList = vpc.getSyslogServerList();
         this.vpcName = vpc.getName();
     }
 
     public String getSourceNatList() {
         return sourceNatList;
+    }
+
+    public String getSyslogServerList() {
+        return syslogServerList;
     }
 
     public String getVpcName() {

--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/SetVRConfigItem.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/SetVRConfigItem.java
@@ -15,7 +15,7 @@ public class SetVRConfigItem extends AbstractConfigItemFacade {
     public List<ConfigItem> generateConfig(final NetworkElementCommand cmd) {
         final SetupVRCommand command = (SetupVRCommand) cmd;
 
-        return generateConfigItems(new VRConfig(command.getVpcName(), command.getSourceNatList()));
+        return generateConfigItems(new VRConfig(command.getVpcName(), command.getSourceNatList(), command.getSyslogServerList()));
     }
 
     @Override

--- a/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/model/VRConfig.java
+++ b/cosmic-core/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/model/VRConfig.java
@@ -2,6 +2,7 @@ package com.cloud.agent.resource.virtualnetwork.model;
 
 public class VRConfig extends ConfigBase {
     private String sourceNatList;
+    private String syslogServerList;
     private String vpcName;
 
     public VRConfig() {
@@ -9,9 +10,10 @@ public class VRConfig extends ConfigBase {
         super(ConfigBase.VR);
     }
 
-    public VRConfig(final String vpcName, final String sourceNatList) {
+    public VRConfig(final String vpcName, final String sourceNatList, final String syslogServerList) {
         super(ConfigBase.VR);
         this.sourceNatList = sourceNatList;
+        this.syslogServerList = syslogServerList;
         this.vpcName = vpcName;
     }
 
@@ -21,5 +23,13 @@ public class VRConfig extends ConfigBase {
 
     public void setSourceNatList(final String sourceNatList) {
         this.sourceNatList = sourceNatList;
+    }
+
+    public String getSyslogServerList() {
+        return syslogServerList;
+    }
+
+    public void setSyslogServerList(final String syslogServerList) {
+        this.syslogServerList = syslogServerList;
     }
 }

--- a/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2559,6 +2559,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         response.setRedundantRouter(vpc.isRedundant());
         response.setRegionLevelVpc(vpc.isRegionLevelVpc());
         response.setSourceNatList(vpc.getSourceNatList());
+        response.setSyslogServerList(vpc.getSyslogServerList());
 
         final Map<Service, Set<Provider>> serviceProviderMap = ApiDBUtils.listVpcOffServices(vpc.getVpcOfferingId());
         final List<ServiceResponse> serviceResponses = getServiceResponses(serviceProviderMap);

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -760,7 +760,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     @ActionEvent(eventType = EventTypes.EVENT_VPC_CREATE, eventDescription = "creating vpc", create = true)
     public Vpc createVpc(final long zoneId, final long vpcOffId, final long vpcOwnerId, final String vpcName,
                          final String displayText, final String cidr, String networkDomain,
-                         final Boolean displayVpc, final String sourceNatList) throws ResourceAllocationException {
+                         final Boolean displayVpc, final String sourceNatList, final String syslogServerList) throws ResourceAllocationException {
         final Account caller = CallContext.current().getCallingAccount();
         final Account owner = _accountMgr.getAccount(vpcOwnerId);
 
@@ -817,7 +817,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         final boolean useDistributedRouter = vpcOff.supportsDistributedRouter();
         final VpcVO vpc = new VpcVO(zoneId, vpcName, displayText, owner.getId(), owner.getDomainId(), vpcOffId, cidr,
                 networkDomain, useDistributedRouter, isRegionLevelVpcOff,
-                vpcOff.getRedundantRouter(), sourceNatList);
+                vpcOff.getRedundantRouter(), sourceNatList, syslogServerList);
 
         return createVpc(displayVpc, vpc);
     }
@@ -931,7 +931,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_VPC_UPDATE, eventDescription = "updating vpc")
-    public Vpc updateVpc(final long vpcId, final String vpcName, final String displayText, final String customId, final Boolean displayVpc, final Long vpcOfferingId, final String sourceNatList) {
+    public Vpc updateVpc(final long vpcId, final String vpcName, final String displayText, final String customId, final Boolean displayVpc, final Long vpcOfferingId, final String sourceNatList, final String syslogServerList) {
         CallContext.current().setEventDetails(" Id: " + vpcId);
         final Account caller = CallContext.current().getCallingAccount();
 
@@ -961,6 +961,8 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         if (displayVpc != null) {
             vpc.setDisplay(displayVpc);
         }
+
+        vpc.setSyslogServerList(syslogServerList);
 
         if (vpcOfferingId != null) {
             final VpcOfferingVO newVpcOffering = _vpcOffDao.findById(vpcOfferingId);

--- a/cosmic-core/server/src/test/java/com/cloud/vpc/dao/MockVpcDaoImpl.java
+++ b/cosmic-core/server/src/test/java/com/cloud/vpc/dao/MockVpcDaoImpl.java
@@ -80,9 +80,9 @@ public class MockVpcDaoImpl extends GenericDaoBase<VpcVO, Long> implements VpcDa
     public VpcVO findById(final Long id) {
         VpcVO vo = null;
         if (id.longValue() == 1) {
-            vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, false, false, "");
+            vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, false, false, "", "");
         } else if (id.longValue() == 2) {
-            vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, false, false, "");
+            vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, false, false, "", "");
             vo.setState(State.Inactive);
         }
 

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsVrConfig.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsVrConfig.py
@@ -6,11 +6,17 @@ import sys
 import logging
 
 from CsDatabag import CsDataBag
+import CsHelper
+from cs.CsFile import CsFile
 
+
+RSYSLOG_IPTABLES_CONF = "/etc/rsyslog.d/00-iptables.conf"
 
 class CsVrConfig(CsDataBag):
     def process(self):
         logging.debug("Processing CsVrConfig file ==> %s" % self.dbag)
+
+        syslogserverlist = ""
 
         for item in self.dbag:
             if item == "id":
@@ -19,18 +25,44 @@ class CsVrConfig(CsDataBag):
             if item == "source_nat_list":
                 self._configure_firewall(self.dbag[item])
 
-            result = self.__update(self.dbag[item])
-            logging.debug("Processing item from data bag: %s, returncode: %s" % (self.dbag[item], result))
-            if result is not None and result is False:
-                logging.debug("Executing CsVrConfig command returned False, exiting.")
-                sys.exit(1)
+            if item == "syslog_server_list":
+                syslogserverlist = self.dbag[item]
 
-    def __update(self, dbag):
-        # For now no specific private gateway config yet
-        return True
+        self._configure_syslog(syslogserverlist)
 
     def _configure_firewall(self, sourcenatlist):
         firewall = self.config.get_fw()
 
+        logging.debug("Processing source NAT list: %s" % sourcenatlist)
         for cidr in sourcenatlist.split(','):
             firewall.append(["filter", "", "-A SOURCE_NAT_LIST -o eth1 -s %s -j ACCEPT" % cidr])
+
+    def _configure_syslog(self, syslogserverlist):
+        self.syslogconf = CsFile(RSYSLOG_IPTABLES_CONF)
+        self.syslogconf.repopulate()
+
+        logging.debug("Processing syslog server list: %s" % syslogserverlist)
+        ips = filter(bool, syslogserverlist.split(','))
+        if not ips:
+            # no IP in the syslog server list; reset the config to default:
+            self.syslogconf.append("# no remote syslog servers so stop further processing")
+            self.syslogconf.append("# this file is managed by CsVrConfig.py")
+            self.syslogconf.append(":msg, regex, \"^\[ *[0-9]*\.[0-9]*\] iptables denied: \" ~")
+        else:
+            # add IPs from the syslog server list to the config:
+            self.syslogconf.append("# forwarding IP tables syslog to %s and stop further processing" % syslogserverlist)
+            self.syslogconf.append("# this file is managed by CsVrConfig.py")
+            first = True
+            for ip in ips:
+                if first:
+                    self.syslogconf.append(":msg, regex, \"^\[ *[0-9]*\.[0-9]*\] iptables denied: \" @@%s:514" % ip)
+                    first = False
+                else:
+                    self.syslogconf.append("& @@%s:514" % ip)
+
+            self.syslogconf.append("& ~")
+
+        changed = self.syslogconf.is_changed()
+        self.syslogconf.commit()
+        if changed:
+            CsHelper.execute2("service rsyslog restart")

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs_virtualrouter.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs_virtualrouter.py
@@ -20,7 +20,19 @@ def merge(dbag, data):
                 try:
                     net = IPNetwork(cidr)
                 except:
-                    print('[ERROR] So it seems we have an faulty CIDR in the source NAT list: ' + cidr)
+                    print('[ERROR] So it seems we have a faulty CIDR in the source NAT list: ' + cidr)
+                    exit(1)
+
+            dbag[key] = data[key]
+
+        if key == "syslog_server_list":
+            # let's verify that the list contains valid CIDRs
+            ips = data[key].split(',')
+            for ip in ips:
+                try:
+                    address = IPAddress(ip)
+                except:
+                    print('[ERROR] So it seems we have a faulty IP address in the syslog server list: ' + ip)
                     exit(1)
 
             dbag[key] = data[key]


### PR DESCRIPTION
With this PR we will be able to configure one or more IP addresses of remote syslog servers to forward IP tables logging towards. Syslog messages will be forwarded on TCP port 514 to all IP addresses in the list.

Add them when you create a VPC:
![image](https://cloud.githubusercontent.com/assets/2650429/26411334/f0dac356-40a5-11e7-9733-d6220358022b.png)

And can be added or changed in the VPC details screen: 
![image](https://cloud.githubusercontent.com/assets/2650429/26411490/4e532762-40a6-11e7-9dac-345329c621ce.png)

This is how it looks like on the VPC router VM:
![image](https://cloud.githubusercontent.com/assets/2650429/26411641/a4f64798-40a6-11e7-9218-2874ebddf46f.png)
