### PR TITLE
SourceNat service implies the Gateway service for VPCs

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
@@ -286,9 +286,11 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
                     case DomainRouter:
                         if (network.getVpcId() != null) {
                             final Vpc vpc = _vpcDao.findById(network.getVpcId());
-                            if (_networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.Gateway,
-                                    Provider.VPCVirtualRouter) && !vpc.isRedundant()) {
+                            if ((_networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.Gateway, Provider.VPCVirtualRouter)
+                                    || _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.SourceNat, Provider.VPCVirtualRouter))
+                                    && !vpc.isRedundant()) {
                                 // Non-redundant VPCs that support Gateway acquire the gateway ip on their nic
+                                // When SourceNat service is enabled, this requires the gateway ip on the nic of the router as well
                                 guestIp = network.getGateway();
                             } else {
                                 // In other cases, acquire an ip address from the DHCP range (take lowest possible)


### PR DESCRIPTION
Issue:
After PR #414, a newly created network with VM has a non-working port-forward, because the tier ip address of the router didn't match the gateway that was handed out over DHCP to the VM.

The RCA for this is in the service map of the network_offering, and as a result in the map of the network too.

The default offerings all match, but we've seen older offerings in the wild that have SourceNat but no Gateway service and this breaks. This adds backwards compatibility.

Alternatively, I've looked into manually adding the missing Gateway offerings. Although it can be done, it might be easier to handle it as proposed here. Let's discuss.

```
# Add Gateway service when it is missing and we do have SourceNat in the offering
# Gateway is required when SourceNat is there
INSERT INTO `ntwk_offering_service_map_magweg` (`network_offering_id`, `service`, `provider`, `created`)
SELECT network_offering_id, 'Gateway', provider, NOW() from network_offerings, ntwk_offering_service_map where network_offerings.id=ntwk_offering_service_map.network_offering_id and service="SourceNat" and network_offering_id not in (select network_offering_id from ntwk_offering_service_map where service="Gateway" );

# Add Gateway service to networks that have SourceNat but no Gateway
INSERT INTO `ntwk_service_map_magweg` (`network_id`, `service`, `provider`, `created`)
SELECT networks.id, 'Gateway', provider, NOW() from networks, ntwk_service_map where networks.id = ntwk_service_map.network_id and networks.removed is null and service="SourceNat" and network_id not in (select network_id from ntwk_service_map where service="Gateway");

```