### PR TITLE
Fix label translations in VPNCGW

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/network.js
+++ b/cosmic-client/src/main/webapp/scripts/network.js
@@ -5949,7 +5949,7 @@
                                             var items = [];
                                             items.push({
                                                 id: '',
-                                                description: 'label.none'
+                                                description: _l('label.none')
                                             });
                                             items.push({
                                                 id: 'modp1024',
@@ -6049,7 +6049,7 @@
                                             var items = [];
                                             items.push({
                                                 id: '',
-                                                description: 'label.none'
+                                                description: _l('label.none')
                                             });
                                             items.push({
                                                 id: 'modp1024',
@@ -6350,7 +6350,7 @@
                                             var items = [];
                                             items.push({
                                                 id: '',
-                                                description: 'label.none'
+                                                description: _l('label.none')
                                             });
                                             items.push({
                                                 id: 'modp1024',
@@ -6418,7 +6418,7 @@
                                             var items = [];
                                             items.push({
                                                 id: '',
-                                                description: 'label.none'
+                                                description: _l('label.none')
                                             });
                                             items.push({
                                                 id: 'modp1024',


### PR DESCRIPTION
Description of none was shown as label.none which is not correct.

**Before:**
![cosmic-label none](https://cloud.githubusercontent.com/assets/1177804/26592751/02d107b2-4562-11e7-93b1-8cfe05a11267.png)

**After:**
![cosmic-label_none](https://cloud.githubusercontent.com/assets/1177804/26592770/0d3e5b50-4562-11e7-8ed9-09c523007d79.png)
