### PR TITLE
[WIP] Hide VM snapshot button on KVM

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/instances.js
+++ b/cosmic-client/src/main/webapp/scripts/instances.js
@@ -2811,7 +2811,7 @@
             allowedActions.push("stop");
             allowedActions.push("restart");
 
-            if ((jsonObj.hypervisor != 'KVM' || g_kvmsnapshotenabled == true)) {
+            if (jsonObj.hypervisor != 'KVM') {
                 allowedActions.push("snapshot");
             }
 
@@ -2843,7 +2843,7 @@
             allowedActions.push("destroy");
             allowedActions.push("reinstall");
 
-            if ((jsonObj.hypervisor != 'KVM' || g_kvmsnapshotenabled == true)) {
+            if (jsonObj.hypervisor != 'KVM') {
                 allowedActions.push("snapshot");
             }
 


### PR DESCRIPTION
Disable the snapshot button at instance level for now.