### PR TITLE
Honor hosts put in the avoidset when checking for suitable hosts

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/deploy/DeploymentPlanner.java
+++ b/cosmic-core/api/src/main/java/com/cloud/deploy/DeploymentPlanner.java
@@ -149,50 +149,28 @@ public interface DeploymentPlanner extends Adapter {
             hostIds.addAll(hostList);
         }
 
-        public boolean shouldAvoid(final Host host) {
-            return shouldAvoid(host.getDataCenterId(), host.getPodId(), host.getClusterId(), host.getId());
-        }
-
-        public boolean shouldAvoid(final Cluster cluster) {
-            if (dcIds.contains(cluster.getDataCenterId())) {
-                return true;
-            }
-
-            if (! podIds.isEmpty() && podIds.contains(cluster.getPodId())) {
-                return true;
-            }
-
-            if (! clusterIds.isEmpty() && clusterIds.contains(cluster.getId())) {
-                return true;
-            }
-            return false;
+        public boolean shouldAvoid(final DataCenter dc) {
+            return shouldAvoid(dc.getId(), null, null, null, null);
         }
 
         public boolean shouldAvoid(final Pod pod) {
-            if (dcIds.contains(pod.getDataCenterId())) {
-                return true;
-            }
+            return shouldAvoid(pod.getDataCenterId(), pod.getId(), null, null, null);
+        }
 
-            if (! podIds.isEmpty() && podIds.contains(pod.getId())) {
-                return true;
-            }
+        public boolean shouldAvoid(final Cluster cluster) {
+            return shouldAvoid(cluster.getDataCenterId(), cluster.getPodId(), cluster.getId(), null, null);
+        }
 
-            return false;
+        public boolean shouldAvoid(final Host host) {
+            return shouldAvoid(host.getDataCenterId(), host.getPodId(), host.getClusterId(), null, host.getId());
         }
 
         public boolean shouldAvoid(final StoragePool pool) {
-            return shouldAvoid(pool.getDataCenterId(), pool.getPodId(), pool.getClusterId(), pool.getId());
+            return shouldAvoid(pool.getDataCenterId(), pool.getPodId(), pool.getClusterId(), pool.getId(), null);
         }
 
-        public boolean shouldAvoid(final DataCenter dc) {
-            if (dcIds.contains(dc.getId())) {
-                return true;
-            }
-            return false;
-        }
-
-        private boolean shouldAvoid(final long dataCenterId, final Long podId, final Long clusterId, final long poolId) {
-            if (dcIds.contains(dataCenterId)) {
+        private boolean shouldAvoid(final Long dataCenterId, final Long podId, final Long clusterId, final Long poolId, final Long hostId) {
+            if (dataCenterId != null && ! dcIds.isEmpty() && dcIds.contains(dataCenterId)) {
                 return true;
             }
 
@@ -204,7 +182,11 @@ public interface DeploymentPlanner extends Adapter {
                 return true;
             }
 
-            if (! poolIds.isEmpty() && poolIds.contains(poolId)) {
+            if (poolId != null && ! poolIds.isEmpty() && poolIds.contains(poolId)) {
+                return true;
+            }
+
+            if (hostId != null && ! hostIds.isEmpty() && hostIds.contains(hostId)) {
                 return true;
             }
 


### PR DESCRIPTION
While checking the `avoidset`, with method `shouldAvoid`, the last parameter supplied was `host.getId()`. However, the method expected another ID `final long poolId` so it wouldn't honor the excluded host:

![image](https://cloud.githubusercontent.com/assets/1630096/26836068/27ee7b74-4ada-11e7-89b0-329d618e8574.png)

In this PR the check is fixed and now all VMs deployed with the affinity group end up on the dedicated hypervisor, until capacity runs out.

![image](https://cloud.githubusercontent.com/assets/1630096/26836160/641c5f08-4ada-11e7-95b2-80caa90744bd.png)
