### PR TITLE
Resource dedicated to a domain should be owned by this domain

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/affinity/AffinityGroupServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/affinity/AffinityGroupServiceImpl.java
@@ -205,6 +205,13 @@ public class AffinityGroupServiceImpl extends ManagerBase implements AffinityGro
                         new AffinityGroupVO(affinityGroupName, affinityGroupType, description, owner.getDomainId(), owner.getId(), aclType);
                 _affinityGroupDao.persist(group);
 
+                if (aclType == ACLType.Domain) {
+                    boolean subDomainAccess;
+                    subDomainAccess = processor.subDomainAccess();
+                    AffinityGroupDomainMapVO domainMap = new AffinityGroupDomainMapVO(group.getId(), owner.getDomainId(), subDomainAccess);
+                    _affinityGroupDomainMapDao.persist(domainMap);
+                }
+
                 return group;
             }
         });


### PR DESCRIPTION
When dedicating a resource (cluster or host) to a domain, the affinity group which is created is visible to everyone rather than only to domain that the cluster is dedicated to.

Backport of ACS PR 2124