### PR TITLE
Make sure the Remote Access VPN firewall is working

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -821,7 +821,7 @@ class CsRemoteAccessVpn(CsDataBag):
 
         self.fw.append(["", "","-A INPUT -i ppp+ -m udp -p udp --dport 53 -j ACCEPT"])
         self.fw.append(["", "","-A INPUT -i ppp+ -m tcp -p tcp --dport 53 -j ACCEPT"])
-        self.fw.append(["nat", "","-I PREROUTING -i ppp+ -m tcp --dport 53 -j DNAT --to-destination %s" % local_ip])
+        self.fw.append(["nat", "front","-A PREROUTING -i ppp+ -m tcp -p tcp --dport 53 -j DNAT --to-destination %s" % local_ip])
 
         if self.config.is_vpc():
             return


### PR DESCRIPTION
An invalid iptables config was generated:

```
root@r-46-VM:~# iptables-restore < /tmp/rules.save
iptables-restore: line 12 failed
```

The rule is now fixed, after which the rules apply fine.

Please review @sanderv32 @ebeekman