### PR TITLE
Dedicated host info now shown when listing hosts

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/system.js
+++ b/cosmic-client/src/main/webapp/scripts/system.js
@@ -10296,12 +10296,18 @@
                                             label: 'label.id'
                                         }
                                     }, {
-
-                                        isdedicated: {
-                                            label: 'label.dedicated'
+                                        dedicated: {
+                                            label: 'label.dedicated',
+                                            converter: cloudStack.converters.toBooleanText
                                         },
                                         domainname: {
                                             label: 'label.domain'
+                                        },
+                                        accountname: {
+                                            label: 'label.account'
+                                        },
+                                        affinitygroupname: {
+                                            label: 'label.affinity.group'
                                         }
                                     }],
 
@@ -10311,38 +10317,9 @@
                                         dataType: "json",
                                         async: true,
                                         success: function (json) {
-                                            var item = json.listhostsresponse.host[0];
-                                            $.ajax({
-                                                url: createURL("listDedicatedHosts&hostid=" + args.context.hosts[0].id),
-                                                dataType: "json",
-                                                async: false,
-                                                success: function (json) {
-                                                    if (json.listdedicatedhostsresponse.dedicatedhost != undefined) {
-                                                        var hostItem = json.listdedicatedhostsresponse.dedicatedhost[0];
-                                                        if (hostItem.domainid != null) {
-                                                            $.extend(item, {
-                                                                isdedicated: _l('label.yes'),
-                                                                domainid: hostItem.domainid
-                                                            });
-                                                        }
-                                                        if (hostItem.domainname != null) {
-                                                            $.extend(item, {
-                                                                isdedicated: _l('label.yes'),
-                                                                domainname: hostItem.domainname
-                                                            });
-                                                        }
-                                                    } else
-                                                        $.extend(item, {
-                                                            isdedicated: _l('label.no')
-                                                        })
-                                                },
-                                                error: function (json) {
-                                                    args.response.error(parseXMLHttpResponse(XMLHttpResponse));
-                                                }
-                                            });
                                             args.response.success({
                                                 actionFilter: hostActionfilter,
-                                                data: item
+                                                data: json.listhostsresponse.host[0]
                                             });
                                         }
                                     });

--- a/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
@@ -5,6 +5,7 @@ public class ApiConstants {
     public static final String ACCOUNTS = "accounts";
     public static final String ACCOUNT_TYPE = "accounttype";
     public static final String ACCOUNT_ID = "accountid";
+    public static final String ACCOUNT_NAME = "accountname";
     public static final String ALGORITHM = "algorithm";
     public static final String ALLOCATED_ONLY = "allocatedonly";
     public static final String API_KEY = "apikey";
@@ -57,6 +58,7 @@ public class ApiConstants {
     public static final String DESCRIPTION = "description";
     public static final String DESTINATION_ZONE_ID = "destzoneid";
     public static final String DETAILS = "details";
+    public static final String DEDICATED = "dedicated";
     public static final String DEVICE_ID = "deviceid";
     public static final String DISK_OFFERING_ID = "diskofferingid";
     public static final String DISK_SIZE = "disksize";
@@ -74,6 +76,7 @@ public class ApiConstants {
     public static final String IP6_DNS2 = "ip6dns2";
     public static final String DOMAIN = "domain";
     public static final String DOMAIN_ID = "domainid";
+    public static final String DOMAIN_NAME = "domainname";
     public static final String DOMAIN__ID = "domainId";
     public static final String DURATION = "duration";
     public static final String EMAIL = "email";
@@ -541,6 +544,7 @@ public class ApiConstants {
     public static final String AFFINITY_GROUP_NAMES = "affinitygroupnames";
     public static final String ASA_INSIDE_PORT_PROFILE = "insideportprofile";
     public static final String AFFINITY_GROUP_ID = "affinitygroupid";
+    public static final String AFFINITY_GROUP_NAME = "affinitygroupname";
     public static final String DEPLOYMENT_PLANNER = "deploymentplanner";
     public static final String ACL_ID = "aclid";
     public static final String NUMBER = "number";

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/HostResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/HostResponse.java
@@ -202,6 +202,34 @@ public class HostResponse extends BaseResponse {
     @Param(description = "Host details in key/value pairs.", since = "4.5")
     private Map details;
 
+    @SerializedName(ApiConstants.DEDICATED)
+    @Param(description = "Is the host dedicated?")
+    private Boolean dedicated = Boolean.FALSE;
+
+    @SerializedName(ApiConstants.DOMAIN_ID)
+    @Param(description = "Domain ID to which the host is dedicated")
+    private String domainId;
+
+    @SerializedName(ApiConstants.DOMAIN_NAME)
+    @Param(description = "Domain name to which the host is dedicated")
+    private String domainName;
+
+    @SerializedName(ApiConstants.ACCOUNT_ID)
+    @Param(description = "Account ID to which the host is dedicated")
+    private String accountId;
+
+    @SerializedName(ApiConstants.ACCOUNT_NAME)
+    @Param(description = "Account name to which the host is dedicated")
+    private String accountName;
+
+    @SerializedName(ApiConstants.AFFINITY_GROUP_ID)
+    @Param(description = "Affinity group ID to which the host is dedicated")
+    private String affinityGroupId;
+
+    @SerializedName(ApiConstants.AFFINITY_GROUP_NAME)
+    @Param(description = "Affinity group name to which the host is dedicated")
+    private String affinityGroupName;
+
     // Default visibility to support accessing the details from unit tests
     Map getDetails() {
         return details;
@@ -427,5 +455,33 @@ public class HostResponse extends BaseResponse {
 
     public void setHaHost(final Boolean haHost) {
         this.haHost = haHost;
+    }
+
+    public void setDedicated(final boolean dedicated) {
+        this.dedicated = dedicated;
+    }
+
+    public void setDomainId(final String domainId) {
+        this.domainId = domainId;
+    }
+
+    public void setDomainName(final String domainName) {
+        this.domainName = domainName;
+    }
+
+    public void setAccountId(final String accountId) {
+        this.accountId = accountId;
+    }
+
+    public void setAccountName(final String accountName) {
+        this.accountName = accountName;
+    }
+
+    public void setAffinityGroupId(final String affinityGroupId) {
+        this.affinityGroupId = affinityGroupId;
+    }
+
+    public void setAffinityGroupName(final String affinityGroupName) {
+        this.affinityGroupName = affinityGroupName;
     }
 }


### PR DESCRIPTION
The dedicated host info was available only in a separate API call `listDedicatedHost`. Now this is added to the generic `listHosts` api call