### PR TITLE
Cleanup transferMap to prevent disconnected agents

### DIFF
--- a/cosmic-core/engine/orchestration/src/main/java/com/cloud/agent/manager/ClusteredAgentManagerImpl.java
+++ b/cosmic-core/engine/orchestration/src/main/java/com/cloud/agent/manager/ClusteredAgentManagerImpl.java
@@ -151,6 +151,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
 
         // Schedule tasks for agent rebalancing
         if (isAgentRebalanceEnabled()) {
+            cleanupTransferMap(_nodeId);
             s_transferExecutor.scheduleAtFixedRate(getAgentRebalanceScanTask(), 60000, 60000, TimeUnit.MILLISECONDS);
             s_transferExecutor.scheduleAtFixedRate(getTransferScanTask(), 60000, ClusteredAgentRebalanceService.DEFAULT_TRANSFER_CHECK_INTERVAL, TimeUnit.MILLISECONDS);
         }


### PR DESCRIPTION
On simultanious/quick restarts of the management server, XenServer agents stay in Disconnected status due to the transferMap not being cleaned. Manually cleaning solves it, but this should prevent that situation.

Backport of ACS PR 2138