### PR TITLE
Show remove template button also when not ready or when empty status

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/templates.js
+++ b/cosmic-client/src/main/webapp/scripts/templates.js
@@ -2599,9 +2599,8 @@
         }
 
         // "Delete Template"
-        //if (((isUser() && jsonObj.ispublic == true && !(jsonObj.domainid == g_domainid && jsonObj.account == g_account)))
         if (((isAdmin() == false && !(jsonObj.domainid == g_domainid && jsonObj.account == g_account) && !(jsonObj.domainid == g_domainid && cloudStack.context.projects && jsonObj.projectid == cloudStack.context.projects[0].id))) //if neither root-admin, nor the same account, nor the same project
-            || (jsonObj.isready == false && jsonObj.status != null && jsonObj.status.indexOf("Downloaded") != -1) || (jsonObj.account == "system")) {
+            || (jsonObj.account == "system")) {
             //do nothing
         } else {
             allowedActions.push("remove");
@@ -2623,22 +2622,6 @@
 
             allowedActions.push("copyISO");
         }
-
-        // "Create VM"
-        // Commenting this out for Beta2 as it does not support the new network.
-        /*
-         //if (((isUser() && jsonObj.ispublic == true && !(jsonObj.domainid == g_domainid && jsonObj.account == g_account) && !(jsonObj.domainid == g_domainid && cloudStack.context.projects && jsonObj.projectid == cloudStack.context.projects[0].id))  //if neither root-admin, nor the same account, nor the same project
-         if (((isAdmin() == false && !(jsonObj.domainid == g_domainid && jsonObj.account == g_account))  //if neither root-admin, nor item owner
-         || jsonObj.isready == false)
-         || (jsonObj.bootable == false)
-         || (jsonObj.domainid ==    1 && jsonObj.account ==    "system")
-         ) {
-         //do nothing
-         }
-         else {
-         allowedActions.push("createVm");
-         }
-         */
 
         // "Download ISO"
         //if (((isUser() && jsonObj.ispublic == true && !(jsonObj.domainid == g_domainid && jsonObj.account == g_account)))


### PR DESCRIPTION
If impossible, the API will fail anyway. Now we see that "cloudmonkey" works quite often whereas the UI shows no button.

Button:
![image](https://user-images.githubusercontent.com/1630096/26992134-86191120-4d5d-11e7-8421-cb075aeb9dbf.png)

But no guarantees the delete will work, in cases where CloudMonkey would fail it still fails. It's just a button after all:

![image](https://user-images.githubusercontent.com/1630096/26992158-a1ffb484-4d5d-11e7-99cb-11511be1d515.png)
