### PR TITLE
Display MAC address in UI

### DIFF
--- a/cosmic-client/src/main/webapp/l10n/en.js
+++ b/cosmic-client/src/main/webapp/l10n/en.js
@@ -902,6 +902,7 @@ var dictionary = {
     "label.login": "Login",
     "label.logout": "Logout",
     "label.lun": "LUN",
+    "label.macaddress": "MAC Address",
     "label.make.project.owner": "Make account project owner",
     "label.make.redundant": "Make redundant",
     "label.manage": "Manage",

--- a/cosmic-client/src/main/webapp/scripts/instances.js
+++ b/cosmic-client/src/main/webapp/scripts/instances.js
@@ -2618,6 +2618,9 @@
                             ipaddress: {
                                 label: 'label.ip.address'
                             },
+                            macaddress: {
+                              label: 'label.macaddress'
+                            },
                             secondaryips: {
                                 label: 'label.secondary.ips'
                             },


### PR DESCRIPTION
The MAC address is now visible for every tier, which makes it easy to find the right nic when on the VM.

![image](https://user-images.githubusercontent.com/1630096/26992438-fdd70f4a-4d5e-11e7-8a0c-02fc884337ae.png)

Also works for the public nic:
![image](https://user-images.githubusercontent.com/1630096/26992521-521eb5da-4d5f-11e7-88bc-34a223fa654f.png)
