### PR TITLE
Improve vm migrating with dedicated hosts

### DIFF
--- a/cosmic-client/src/main/webapp/l10n/en.js
+++ b/cosmic-client/src/main/webapp/l10n/en.js
@@ -928,6 +928,7 @@ var dictionary = {
     "label.md5.checksum": "MD5 checksum",
     "label.memory": "Memory",
     "label.memory.allocated": "Memory Allocated",
+    "label.memory.available": "Memory Available",
     "label.memory.limits": "Memory limits (MiB)",
     "label.memory.mb": "Memory (in MB)",
     "label.memory.total": "Memory Total",

--- a/cosmic-client/src/main/webapp/scripts/instances.js
+++ b/cosmic-client/src/main/webapp/scripts/instances.js
@@ -1497,6 +1497,9 @@
                                             availableHostName: {
                                                 label: 'label.name'
                                             },
+                                            dedicated: {
+                                                label: 'label.dedicated'
+                                            },
                                             availableHostSuitability: {
                                                 label: 'label.suitability',
                                                 indicator: {
@@ -1540,12 +1543,15 @@
                                                             if (this.requiresStorageMotion == true) {
                                                                 suitability += ("-Storage migration required");
                                                             }
+                                                            var dedicated = (this.dedicated ? "Yes, to " + this.domainname : _l('label.no'));
+
                                                             items.push({
                                                                 id: this.id,
                                                                 availableHostName: this.name,
                                                                 availableHostSuitability: suitability,
                                                                 cpuallocated: this.cpuallocated,
-                                                                memoryavailable: (parseFloat(this.memorytotal - this.memoryallocated)/(1024.0*1024.0*1024.0)).toFixed(2) + ' GB'
+                                                                memoryavailable: (parseFloat(this.memorytotal - this.memoryallocated)/(1024.0*1024.0*1024.0)).toFixed(2) + ' GB',
+                                                                dedicated: dedicated
                                                             });
                                                         });
                                                         args.response.success({

--- a/cosmic-client/src/main/webapp/scripts/instances.js
+++ b/cosmic-client/src/main/webapp/scripts/instances.js
@@ -1506,11 +1506,11 @@
                                                     'Not Suitable-Storage migration required': 'notsuitable notsuitable-storage-migration-required'
                                                 }
                                             },
-                                            cpuused: {
-                                                label: 'label.cpu.utilized'
+                                            cpuallocated: {
+                                                label: 'label.cpu.allocated'
                                             },
-                                            memoryused: {
-                                                label: 'label.memory.used'
+                                            memoryavailable: {
+                                                label: 'label.memory.available'
                                             }
                                         },
                                         dataProvider: function(args) {
@@ -1529,6 +1529,11 @@
                                                 success: function(json) {
                                                     if (json.findhostsformigrationresponse.host != undefined) {
                                                         vmMigrationHostObjs = json.findhostsformigrationresponse.host;
+                                                        if (vmMigrationHostObjs != null && vmMigrationHostObjs.length > 0) {
+                                                            vmMigrationHostObjs.sort(function (a, b) {
+                                                                return a.name.localeCompare(b.name);
+                                                            });
+                                                        }
                                                         var items = [];
                                                         $(vmMigrationHostObjs).each(function() {
                                                             var suitability = (this.suitableformigration ? "Suitable" : "Not Suitable");
@@ -1539,8 +1544,8 @@
                                                                 id: this.id,
                                                                 availableHostName: this.name,
                                                                 availableHostSuitability: suitability,
-                                                                cpuused: this.cpuused,
-                                                                memoryused: (parseFloat(this.memoryused)/(1024.0*1024.0*1024.0)).toFixed(2) + ' GB'
+                                                                cpuallocated: this.cpuallocated,
+                                                                memoryavailable: (parseFloat(this.memorytotal - this.memoryallocated)/(1024.0*1024.0*1024.0)).toFixed(2) + ' GB'
                                                             });
                                                         });
                                                         args.response.success({

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/HostForMigrationResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/HostForMigrationResponse.java
@@ -191,6 +191,34 @@ public class HostForMigrationResponse extends BaseResponse {
     @Param(description = "true if the host is Ha host (dedicated to vms started by HA process; false otherwise")
     private Boolean haHost;
 
+    @SerializedName(ApiConstants.DEDICATED)
+    @Param(description = "Is the host dedicated?")
+    private Boolean dedicated = Boolean.FALSE;
+
+    @SerializedName(ApiConstants.DOMAIN_ID)
+    @Param(description = "Domain ID to which the host is dedicated")
+    private String domainId;
+
+    @SerializedName(ApiConstants.DOMAIN_NAME)
+    @Param(description = "Domain name to which the host is dedicated")
+    private String domainName;
+
+    @SerializedName(ApiConstants.ACCOUNT_ID)
+    @Param(description = "Account ID to which the host is dedicated")
+    private String accountId;
+
+    @SerializedName(ApiConstants.ACCOUNT_NAME)
+    @Param(description = "Account name to which the host is dedicated")
+    private String accountName;
+
+    @SerializedName(ApiConstants.AFFINITY_GROUP_ID)
+    @Param(description = "Affinity group ID to which the host is dedicated")
+    private String affinityGroupId;
+
+    @SerializedName(ApiConstants.AFFINITY_GROUP_NAME)
+    @Param(description = "Affinity group name to which the host is dedicated")
+    private String affinityGroupName;
+
     @Override
     public String getObjectId() {
         return getId();
@@ -390,5 +418,33 @@ public class HostForMigrationResponse extends BaseResponse {
 
     public void setHaHost(final Boolean haHost) {
         this.haHost = haHost;
+    }
+
+    public void setDedicated(final Boolean dedicated) {
+        this.dedicated = dedicated;
+    }
+
+    public void setDomainId(final String domainId) {
+        this.domainId = domainId;
+    }
+
+    public void setDomainName(final String domainName) {
+        this.domainName = domainName;
+    }
+
+    public void setAccountId(final String accountId) {
+        this.accountId = accountId;
+    }
+
+    public void setAccountName(final String accountName) {
+        this.accountName = accountName;
+    }
+
+    public void setAffinityGroupId(final String affinityGroupId) {
+        this.affinityGroupId = affinityGroupId;
+    }
+
+    public void setAffinityGroupName(final String affinityGroupName) {
+        this.affinityGroupName = affinityGroupName;
     }
 }

--- a/cosmic-core/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
@@ -291,6 +291,29 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
         hostResponse.setVersion(host.getVersion());
         hostResponse.setCreated(host.getCreated());
 
+        final DedicatedResourceVO dedicatedResourceVO = dedicatedResourceDao.findByHostId(host.getId());
+        if (dedicatedResourceVO != null) {
+            hostResponse.setDedicated(true);
+
+            final DomainVO domainVO = domainDao.findById(dedicatedResourceVO.getDomainId());
+            if (domainVO != null) {
+                hostResponse.setDomainId(domainVO.getUuid());
+                hostResponse.setDomainName(domainVO.getName());
+            }
+
+            final AccountVO accountVO = accountDao.findById(dedicatedResourceVO.getAccountId());
+            if (accountVO != null) {
+                hostResponse.setAccountId(accountVO.getUuid());
+                hostResponse.setAccountName(accountVO.getAccountName());
+            }
+
+            final AffinityGroupVO affinityGroupVO = affinityGroupDao.findById(dedicatedResourceVO.getAffinityGroupId());
+            if (affinityGroupVO != null) {
+                hostResponse.setAffinityGroupId(affinityGroupVO.getUuid());
+                hostResponse.setAffinityGroupName(affinityGroupVO.getName());
+            }
+        }
+
         if (details.contains(HostDetails.all) || details.contains(HostDetails.capacity) || details.contains(HostDetails.stats) || details.contains(HostDetails.events)) {
 
             hostResponse.setOsCategoryId(host.getOsCategoryUuid());


### PR DESCRIPTION
- report a dedicated host as "Unsuitable" when the domain of the VM does not match the domain of the host
- sort the list of available hosts on name in the UI
- display the available cpu/memory in UI, not the amount that the host actually uses

Screenshot (kvm3 is dedicated to another domain):
![image](https://user-images.githubusercontent.com/1630096/27005966-cd7369d6-4e29-11e7-8761-2277d3061950.png)

VM with dedicated affinity group, running on a dedicated hypervisor in a cluster where no other hosts are dedicated to this domain:
![image](https://user-images.githubusercontent.com/1630096/27005996-886811b0-4e2a-11e7-89c3-2631e1403b21.png)

Same, but with two dedicated hosts:
![image](https://user-images.githubusercontent.com/1630096/27006027-fcfeb3d0-4e2a-11e7-8671-765de839e3a8.png)
