### PR TITLE
Support updating Explicit Dedication affinity on VMs in Running state

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/instances.js
+++ b/cosmic-client/src/main/webapp/scripts/instances.js
@@ -2833,6 +2833,8 @@
 
             allowedActions.push("resetPassword");
 
+            allowedActions.push("changeAffinity");
+
             allowedActions.push("viewConsole");
         } else if (jsonObj.state == 'Stopped') {
             allowedActions.push("edit");

--- a/cosmic-core/server/src/main/java/com/cloud/affinity/AffinityGroupServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/affinity/AffinityGroupServiceImpl.java
@@ -408,8 +408,9 @@ public class AffinityGroupServiceImpl extends ManagerBase implements AffinityGro
             if (ag == null) {
                 throw new InvalidParameterValueException("Unable to find affinity group by id " + affinityGroupId);
             } else {
-                // verify permissions
-                _accountMgr.checkAccess(caller, null, true, owner, ag);
+                // verify permissions (same as when deploying VM)
+                _accountMgr.checkAccess(caller, null, false, owner, ag);
+
                 // Root admin has access to both VM and AG by default, but make sure the
                 // owner of these entities is same
                 if (caller.getId() == Account.ACCOUNT_ID_SYSTEM || _accountMgr.isRootAdmin(caller.getId())) {


### PR DESCRIPTION
When a VM is running on a host that is dedicated to the same domain, it is now possible to live update the corresponding Explicit Dedication Affinity Group. This saves a stop/start action and thus reduces impact.

![image](https://user-images.githubusercontent.com/1630096/27013314-e3f5805a-4ee1-11e7-9bab-a7991f0f08e5.png)

If a VM is running on another host, it should first be (live) migrated to a dedicated host. This new error is shown:
![image](https://user-images.githubusercontent.com/1630096/27013269-1cf9e090-4ee1-11e7-82e3-9f7c76d4f68a.png)

The UI now also shows the affinity button when a VM is running:
![image](https://user-images.githubusercontent.com/1630096/27013272-533308e4-4ee1-11e7-9c75-8389c0f06fd4.png)

Only changes are made for Explicit Dedication. Affinity Groups of type anti-affinity can still only be applied when a VM is stopped.
![image](https://user-images.githubusercontent.com/1630096/27013285-84878136-4ee1-11e7-91b2-6d7d8c7261b5.png)

But it does allow to remove Affinity groups (taking effect the next time a VM starts):
![image](https://user-images.githubusercontent.com/1630096/27013325-0597ef4a-4ee2-11e7-83a7-66904a5f5d98.png)

This PR is built on top of #447 
