### PR TITLE
Use FQDN for meta-data property local-hostname

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/network/NetworkModel.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/NetworkModel.java
@@ -260,5 +260,5 @@ public interface NetworkModel {
     boolean getNetworkEgressDefaultPolicy(Long networkId);
 
     List<String[]> generateVmData(String userData, String serviceOffering, String zoneName,
-                                  String vmName, long vmId, String publicKey, String password, Boolean isWindows);
+                                  String vmName, long vmId, String publicKey, String password, Boolean isWindows, Network network);
 }

--- a/cosmic-core/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/cosmic-core/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -653,7 +653,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
 
                     vmData = _networkModel.generateVmData(userVm.getUserData(), serviceOffering, zoneName, vm.getInstanceName(), vm.getId(),
                             (String) profile.getParameter(VirtualMachineProfile.Param.VmSshPubKey), (String) profile.getParameter(VirtualMachineProfile.Param.VmPassword),
-                            isWindows);
+                            isWindows, network);
                     final String vmName = vm.getInstanceName();
                     final String configDriveIsoRootFolder = "/tmp";
                     final String isoFile = configDriveIsoRootFolder + "/" + vmName + "/configDrive/" + vmName + ".iso";

--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -2215,15 +2215,22 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
 
     @Override
     public List<String[]> generateVmData(final String userData, final String serviceOffering, final String zoneName,
-                                         final String vmName, final long vmId, final String publicKey, final String password, final Boolean isWindows) {
+                                         final String vmName, final long vmId, final String publicKey, final String password, final Boolean isWindows,
+                                         final Network network) {
         final List<String[]> vmData = new ArrayList<>();
 
         if (userData != null) {
             vmData.add(new String[]{"userdata", "user-data", new String(Base64.decodeBase64(userData), StringUtils.getPreferredCharset())});
         }
+
+        String vmNameFQDN = vmName;
+        if (network != null) {
+            vmNameFQDN = vmName + "." + network.getNetworkDomain();
+        }
+
         vmData.add(new String[]{"metadata", "service-offering", StringUtils.unicodeEscape(serviceOffering)});
         vmData.add(new String[]{"metadata", "availability-zone", StringUtils.unicodeEscape(zoneName)});
-        vmData.add(new String[]{"metadata", "local-hostname", StringUtils.unicodeEscape(vmName)});
+        vmData.add(new String[]{"metadata", "local-hostname", StringUtils.unicodeEscape(vmNameFQDN)});
         vmData.add(new String[]{"metadata", "instance-id", vmName});
         vmData.add(new String[]{"metadata", "vm-id", String.valueOf(vmId)});
         vmData.add(new String[]{"metadata", "public-keys", publicKey});

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -723,9 +723,14 @@ public class CommandSetupHelper {
 
     private VmDataCommand generateVmDataCommand(final VirtualRouter router, final String vmPrivateIpAddress, final String userData, final String serviceOffering,
                                                 final String zoneName, final String guestIpAddress, final String vmName, final String vmInstanceName, final long vmId, final
-                                                String vmUuid, final String publicKey,
-                                                final long guestNetworkId) {
+                                                String vmUuid, final String publicKey, final long guestNetworkId) {
         final VmDataCommand cmd = new VmDataCommand(vmPrivateIpAddress, vmName, _networkModel.getExecuteInSeqNtwkElmtCmd());
+
+        final NetworkVO networkVO = _networkDao.findById(guestNetworkId);
+        String vmNameFQDN = vmName;
+        if (networkVO != null) {
+            vmNameFQDN = vmName + "." + networkVO.getNetworkDomain();
+        }
 
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_IP, _routerControlHelper.getRouterControlIp(router.getId()));
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_GUEST_IP, _routerControlHelper.getRouterIpInNetwork(guestNetworkId, router.getId()));
@@ -738,7 +743,7 @@ public class CommandSetupHelper {
         cmd.addVmData("metadata", "service-offering", StringUtils.unicodeEscape(serviceOffering));
         cmd.addVmData("metadata", "availability-zone", StringUtils.unicodeEscape(zoneName));
         cmd.addVmData("metadata", "local-ipv4", guestIpAddress);
-        cmd.addVmData("metadata", "local-hostname", StringUtils.unicodeEscape(vmName));
+        cmd.addVmData("metadata", "local-hostname", StringUtils.unicodeEscape(vmNameFQDN));
         if (dcVo.getNetworkType() == NetworkType.Basic) {
             cmd.addVmData("metadata", "public-ipv4", guestIpAddress);
             cmd.addVmData("metadata", "public-hostname", StringUtils.unicodeEscape(vmName));

--- a/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -4994,7 +4994,8 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 final boolean isWindows = _guestOSCategoryDao.findById(_guestOSDao.findById(vm.getGuestOSId()).getCategoryId()).getName().equalsIgnoreCase("Windows");
 
                 final List<String[]> vmData = _networkModel.generateVmData(vm.getUserData(), serviceOffering, zoneName, vm.getInstanceName(), vm.getId(),
-                        (String) profile.getParameter(VirtualMachineProfile.Param.VmSshPubKey), (String) profile.getParameter(VirtualMachineProfile.Param.VmPassword), isWindows);
+                        (String) profile.getParameter(VirtualMachineProfile.Param.VmSshPubKey), (String) profile.getParameter(VirtualMachineProfile.Param.VmPassword), isWindows,
+                        network);
                 final String vmName = vm.getInstanceName();
                 final String configDriveIsoRootFolder = "/tmp";
                 final String isoFile = configDriveIsoRootFolder + "/" + vmName + "/configDrive/" + vmName + ".iso";

--- a/cosmic-core/server/src/test/java/com/cloud/network/MockNetworkModelImpl.java
+++ b/cosmic-core/server/src/test/java/com/cloud/network/MockNetworkModelImpl.java
@@ -876,7 +876,7 @@ public class MockNetworkModelImpl extends ManagerBase implements NetworkModel {
 
     @Override
     public List<String[]> generateVmData(final String userData, final String serviceOffering, final String zoneName, final String vmName, final long vmId, final String
-            publicKey, final String password, final Boolean isWindows) {
+            publicKey, final String password, final Boolean isWindows, final Network network) {
         return null;
     }
 }

--- a/cosmic-core/server/src/test/java/com/cloud/vpc/MockNetworkModelImpl.java
+++ b/cosmic-core/server/src/test/java/com/cloud/vpc/MockNetworkModelImpl.java
@@ -890,7 +890,7 @@ public class MockNetworkModelImpl extends ManagerBase implements NetworkModel {
 
     @Override
     public List<String[]> generateVmData(final String userData, final String serviceOffering, final String zoneName, final String vmName, final long vmId, final String
-            publicKey, final String password, final Boolean isWindows) {
+            publicKey, final String password, final Boolean isWindows, final Network network) {
         return null;
     }
 }


### PR DESCRIPTION
Cloud-init now seems to depend on this, so let's add it.

Looks like this now:
```
root@r-18-VM:~# cat /var/www/html/metadata/10.3.2.252/local-hostname
VM-d177914c-2739-43fa-acb7-e74934330519.specified-domain.nl
```

It's also the same as AWS does it:

```
[ec2-user ~]$ curl http://169.254.169.254/latest/meta-data/local-hostname
ip-10-251-50-12.ec2.internal
```
