### PR TITLE
Handle AffinityGroup permissions for root admin better

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/affinity/AffinityGroupServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/affinity/AffinityGroupServiceImpl.java
@@ -78,6 +78,8 @@ public class AffinityGroupServiceImpl extends ManagerBase implements AffinityGro
     private UserVmDao _userVmDao;
     @Inject
     DedicatedResourceDao _dedicatedDao;
+    @Inject
+    AffinityGroupService _affinityGroupService;
 
     public List<AffinityGroupProcessor> getAffinityGroupProcessors() {
         return _affinityProcessors;
@@ -436,8 +438,8 @@ public class AffinityGroupServiceImpl extends ManagerBase implements AffinityGro
                 // Root admin has access to both VM and AG by default, but make sure the
                 // owner of these entities is same
                 if (caller.getId() == Account.ACCOUNT_ID_SYSTEM || _accountMgr.isRootAdmin(caller.getId())) {
-                    if (AffinityGroupVO.getAccountId() != owner.getAccountId()) {
-                        throw new PermissionDeniedException("Affinity Group " + AffinityGroupVO + " does not belong to the VM's account");
+                    if (!_affinityGroupService.isAffinityGroupAvailableInDomain(AffinityGroupVO.getId(), owner.getDomainId())) {
+                        throw new PermissionDeniedException("Affinity Group " + AffinityGroupVO + " does not belong to the VM's domain");
                     }
                 }
             }

--- a/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -4461,8 +4461,8 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                         // but
                         // make sure the owner of these entities is same
                         if (caller.getId() == Account.ACCOUNT_ID_SYSTEM || _accountMgr.isRootAdmin(caller.getId())) {
-                            if (ag.getAccountId() != owner.getAccountId()) {
-                                throw new PermissionDeniedException("Affinity Group " + ag + " does not belong to the VM's account");
+                            if (ag.getDomainId() != owner.getDomainId()) {
+                                throw new PermissionDeniedException("Affinity Group " + ag + " does not belong to the VM's domain");
                             }
                         }
                     }


### PR DESCRIPTION
This way, root admin can also add/remove the affinity group for a user vm.