### PR TITLE
UI: Separated Network tabs for VPC tiers and other networks

### DIFF
--- a/cosmic-client/src/main/webapp/css/cloudstack3.css
+++ b/cosmic-client/src/main/webapp/css/cloudstack3.css
@@ -3540,7 +3540,7 @@ div.toolbar div.section-switcher div.section-select {
 }
 
 div.toolbar div.section-switcher div.section-select select {
-    width: 225px;
+    width: 245px;
     height: 21px;
     margin-right: 13px;
     font-size: 12px;

--- a/cosmic-client/src/main/webapp/l10n/en.js
+++ b/cosmic-client/src/main/webapp/l10n/en.js
@@ -733,7 +733,7 @@ var dictionary = {
     "label.guest.netmask": "Guest Netmask",
     "label.guest.network.details": "Guest network details",
     "label.guest.networks": "Guest networks",
-    "label.networks.long": "Networks (Guest, Tiers, Private)",
+    "label.networks.long": "Isolated Networks (Guest and Private)",
     "label.guest.start.ip": "Guest start IP",
     "label.guest.traffic": "Guest Traffic",
     "label.guest.traffic.vswitch.name": "Guest Traffic vSwitch Name",

--- a/cosmic-client/src/main/webapp/scripts/network.js
+++ b/cosmic-client/src/main/webapp/scripts/network.js
@@ -390,7 +390,6 @@
                         $.ajax({
                             url: createURL('listRemoteAccessVpns'),
                             data: {
-                                account: g_account,
                                 domainid: g_domainid,
                                 listAll: true
                             },

--- a/cosmic-client/src/main/webapp/scripts/network.js
+++ b/cosmic-client/src/main/webapp/scripts/network.js
@@ -1657,9 +1657,8 @@
                     },
 
                     dataProvider: function (args) {
-                        var data = {};
+                        var data = { 'forvpc': 'false' };
                         listViewDataProvider(args, data);
-
                         $.ajax({
                             url: createURL('listNetworks'),
                             data: data,


### PR DESCRIPTION
We now have separate tabs for VPC tiers and other Networks. Also aligned the list views.

Networks:
![image](https://user-images.githubusercontent.com/1630096/27635718-7ee85604-5c08-11e7-976a-078064e704ac.png)

VPC Tiers:
![image](https://user-images.githubusercontent.com/1630096/27640590-02896e6a-5c1a-11e7-919b-ac4c475215f6.png)

