### PR TITLE
Added exit code output and cosmiccat

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/root/.bashrc
+++ b/cosmic-core/systemvm/patches/debian/config/root/.bashrc
@@ -18,6 +18,24 @@
 # alias mv='mv -i'
 
 
+cosmiccat() {
+  if [ $# -ne 1 ];
+  then
+    echo "usage: cosmiccat <file>|list"
+    echo "list will show all files in /etc/cloudstack"
+    echo "<file> is a file in /etc/cloudstack to show"
+    return 1
+  fi
+
+  if [ "$1" == "list" ]
+  then
+    ls -ltr /etc/cloudstack
+    return 0
+  fi
+
+  cat /etc/cloudstack/$1 | python -m json.tool
+}
+
 jsoncat() {
   if [ $# -ne 1 ];
   then
@@ -69,6 +87,7 @@ replay() {
   if [ -f ${f:0:(-3)} ]
   then
     update_config.py ${f:0:(-3)}
+    echo "Exit code $?"
     cd - > /dev/null
   else
     echo "Could not replay ${f}, it does not exist!"


### PR DESCRIPTION
- cosmicat will show the content of files in /etc/cloudstack

```
root@r-40977-VM:~# cosmiccat list
total 164
-rw-r--r-- 1 root root     29 Jun 16 04:07 buildtime
-rw-r--r-- 1 root root    414 Jun 22 21:58 cmdline.json
-rw-r--r-- 1 root root    581 Jun 22 21:58 privategateway.json
-rw-r--r-- 1 root root   1580 Jun 22 21:58 dhcpentry.json
-rw-r--r-- 1 root root   6247 Jun 22 21:58 vmdata.json
-rw-r--r-- 1 root root    115 Jun 22 21:58 virtualrouter.json
-rw-r--r-- 1 root root   3348 Jun 22 22:13 ips.json
-rw-r--r-- 1 root root   2310 Jun 22 22:13 guestnetwork.json
-rw-r--r-- 1 root root      0 Jun 24 09:06 do_not_update_scripts
-rw-r--r-- 1 root root 117333 Jul  3 13:48 networkacl.json
-rw-r--r-- 1 root root  10578 Jul  3 14:24 staticroutes.json
root@r-40977-VM:~# cosmiccat cmdline.json
{
    "config": {
        "disable_rp_filter": "true", 
        "dns1": "null", 
        "domain": "cloud.local", 
        "eth0ip": "169.254.2.206", 
        "eth0mask": "255.255.0.0", 
        "name": "r-40977-VM", 
        "redundant_router": "false", 
        "template": "domP", 
        "type": "vpcrouter", 
        "vmpassword": "*******", 
        "vpccidr": "10.10.68.0/22"
    }, 
    "id": "cmdline"
}
root@r-40977-VM:~# cosmiccat virtualrouter.json
{
    "id": "virtualrouter", 
    "syslog_server_list": "10.10.1.4,10.10.2.4", 
    "vpc_name": "TEST_VPC"
}
root@r-40977-VM:~# 
```