### PR TITLE
Fixed finding the default static route

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsStaticRoutes.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsStaticRoutes.py
@@ -43,6 +43,8 @@ class CsStaticRoutes(CsDataBag):
             data = line.split()
             if data:
                 key = data.pop(0)
+                if key == 'default':
+                    key = '0.0.0.0/0'
                 self.routes[key] = data
         logging.debug("Found these existing routes: %s" % self.routes)
         return self.routes


### PR DESCRIPTION
On a VPC without a public interface the default route can be set as a static route.

But since the output of `ip route show` shows the default route as `default` this fixes the problem of finding the default route that is in the data bag as `0.0.0.0/0`.