### PR TITLE
Change check if s2svpn is connected

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/checks2svpn.sh
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/checks2svpn.sh
@@ -20,7 +20,7 @@ fi
 if (( "${SYSTEMVM_VERSION}" > "170312" )); then
     ipsec status  vpn-$1 > /tmp/vpn-$1.status
 
-    cat /tmp/vpn-$1.status | grep "ESTABLISHED" > /dev/null
+    cat /tmp/vpn-$1.status | grep "INSTALLED" > /dev/null
     ipsecok=$?
     if [ $ipsecok -ne 0 ]
     then


### PR DESCRIPTION
In OpenSwan we could only see the 'ESTABLISHED' state while in
StrongSwan we can see if the tunnel is 'INSTALLED'.