### PR TITLE
[WIP] StrongSwan: set auto to route instead of start

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -517,7 +517,7 @@ class CsSite2SiteVpn(CsDataBag):
             file.add(" esp=%s" % esppolicy, -1)
             file.add(" lifetime=%s" % self.convert_sec_to_h(obj['esp_lifetime']), -1)
             file.add(" keyingtries=%forever", -1)
-            file.add(" auto=start", -1)
+            file.add(" auto=route", -1)
             file.add(" closeaction=restart", -1)
             file.add(" inactivity=0", -1)
             if 'encap' not in obj:


### PR DESCRIPTION
Setting auto to route will reconnect the VPN if traffic flows from left to right. Otherwise connection won't be rebuild and a reload is required.