### PR TITLE
Prevents the StorageCollector thread from dying when failing to connect to end point

### DIFF
--- a/cosmic-core/engine/api/src/main/java/com/cloud/engine/subsystem/api/storage/EndPoint.java
+++ b/cosmic-core/engine/api/src/main/java/com/cloud/engine/subsystem/api/storage/EndPoint.java
@@ -2,6 +2,8 @@ package com.cloud.engine.subsystem.api.storage;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.Command;
+import com.cloud.exception.AgentUnavailableException;
+import com.cloud.exception.OperationTimedoutException;
 import com.cloud.framework.async.AsyncCompletionCallback;
 
 public interface EndPoint {
@@ -10,6 +12,8 @@ public interface EndPoint {
     String getHostAddr();
 
     String getPublicAddr();
+
+    Answer sendMessageOrBreak(Command cmd) throws AgentUnavailableException, OperationTimedoutException;
 
     Answer sendMessage(Command cmd);
 

--- a/cosmic-core/engine/storage/default/src/main/java/com/cloud/storage/LocalHostEndpoint.java
+++ b/cosmic-core/engine/storage/default/src/main/java/com/cloud/storage/LocalHostEndpoint.java
@@ -4,6 +4,8 @@ import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.Command;
 import com.cloud.configuration.Config;
 import com.cloud.engine.subsystem.api.storage.EndPoint;
+import com.cloud.exception.AgentUnavailableException;
+import com.cloud.exception.OperationTimedoutException;
 import com.cloud.framework.async.AsyncCompletionCallback;
 import com.cloud.framework.config.dao.ConfigurationDao;
 import com.cloud.managed.context.ManagedContextRunnable;
@@ -68,6 +70,11 @@ public class LocalHostEndpoint implements EndPoint {
         } else {
             return "127.0.0.0";
         }
+    }
+
+    @Override
+    public Answer sendMessageOrBreak(final Command cmd) throws AgentUnavailableException, OperationTimedoutException {
+        return sendMessage(cmd);
     }
 
     @Override

--- a/cosmic-core/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/cosmic-core/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -706,11 +706,16 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                     continue;
                 }
                 final long storeId = store.getId();
-                final Answer answer = ssAhost.sendMessage(command);
-                if (answer != null && answer.getResult()) {
-                    storageStats.put(storeId, (StorageStats) answer);
-                    s_logger.trace("HostId: " + storeId + " Used: " + ((StorageStats) answer).getByteUsed() + " Total Available: " +
-                            ((StorageStats) answer).getCapacityBytes());
+                final Answer answer;
+                try {
+                    answer = ssAhost.sendMessageOrBreak(command);
+                    if (answer != null && answer.getResult()) {
+                        storageStats.put(storeId, (StorageStats) answer);
+                        s_logger.trace("HostId: " + storeId + " Used: " + ((StorageStats) answer).getByteUsed() + " Total Available: " +
+                                ((StorageStats) answer).getCapacityBytes());
+                    }
+                } catch (final Exception e) {
+                    s_logger.warn("Unable to get stats for store: " + storeId, e);
                 }
             }
             _storageStats = storageStats;
@@ -737,9 +742,9 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                         }
                     }
                 } catch (final StorageUnavailableException e) {
-                    s_logger.info("Unable to reach " + pool, e);
+                    s_logger.info("Unable to reach pool: " + pool, e);
                 } catch (final Exception e) {
-                    s_logger.warn("Unable to get stats for " + pool, e);
+                    s_logger.warn("Unable to get stats for pool: " + pool, e);
                 }
             }
             _storagePoolStats = storagePoolStats;


### PR DESCRIPTION
The StorageCollector thread dies when it fails to communicate with the agent on the secondary storage VM. When sending a message to the agent, an `AgentUnavailableException` or `OperationTimedoutException` can be thrown and the thread doesn't catch them. This PR catches any exception thrown when attempting to send a message to the agent, reports the error and prevents the thread from dying.