### PR TITLE
Hide SecretKey from being listed

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/accounts.js
+++ b/cosmic-client/src/main/webapp/scripts/accounts.js
@@ -1225,6 +1225,12 @@
                                         url: createURL('registerUserKeys'),
                                         data: data,
                                         success: function (json) {
+                                            var secretKey = json.registeruserkeysresponse.userkeys.secretkey
+                                            cloudStack.dialog.notice({
+                                                message: 'Secret key (non-retrievable after this): </br></br>' + _s(secretKey),
+                                                width: 800
+                                            });
+
                                             args.response.success({
                                                 data: json.registeruserkeysresponse.userkeys
                                             });

--- a/cosmic-client/src/main/webapp/scripts/ui/dialog.js
+++ b/cosmic-client/src/main/webapp/scripts/ui/dialog.js
@@ -988,6 +988,7 @@
                     dialogClass: 'notice',
                     closeOnEscape: false,
                     zIndex: 5000,
+                    width: args.width,
                     buttons: [{
                         text: _l('label.close'),
                         'class': 'close',

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/GetUserCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/GetUserCmd.java
@@ -6,6 +6,7 @@ import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
 import com.cloud.api.response.UserResponse;
 import com.cloud.user.UserAccount;
+import com.cloud.utils.StringUtils;
 import com.cloud.utils.exception.InvalidParameterValueException;
 
 import org.slf4j.Logger;
@@ -34,7 +35,9 @@ public class GetUserCmd extends BaseCmd {
         final UserAccount result = _accountService.getUserByApiKey(getApiKey());
         if (result != null) {
             final UserResponse response = _responseGenerator.createUserResponse(result);
-            response.setResponseName(getCommandName());
+            if (StringUtils.isNotBlank(response.getSecretKey())) {
+                response.setSecretKey("SecretKey only visible when generating a new key");
+            }
             response.setResponseName(getCommandName());
             this.setResponseObject(response);
         } else {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/ListUsersCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/ListUsersCmd.java
@@ -6,6 +6,9 @@ import com.cloud.api.BaseListAccountResourcesCmd;
 import com.cloud.api.Parameter;
 import com.cloud.api.response.ListResponse;
 import com.cloud.api.response.UserResponse;
+import com.cloud.utils.StringUtils;
+
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,6 +66,15 @@ public class ListUsersCmd extends BaseListAccountResourcesCmd {
     public void execute() {
         final ListResponse<UserResponse> response = _queryService.searchForUsers(this);
         response.setResponseName(getCommandName());
+        List<UserResponse> responseList = response.getResponses();
+
+        if (responseList != null && responseList.size() > 0) {
+            for (UserResponse userResponse : responseList) {
+                if (StringUtils.isNotBlank(userResponse.getSecretKey())) {
+                    userResponse.setSecretKey("SecretKey only visible when generating a new key");
+                }
+            }
+        }
         this.setResponseObject(response);
     }
 

--- a/cosmic-core/api/src/test/java/com/cloud/api/command/admin/user/GetUserCmdTest.java
+++ b/cosmic-core/api/src/test/java/com/cloud/api/command/admin/user/GetUserCmdTest.java
@@ -1,0 +1,71 @@
+package com.cloud.api.command.admin.user;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.when;
+
+import com.cloud.api.ResponseGenerator;
+import com.cloud.api.response.UserResponse;
+import com.cloud.context.CallContext;
+import com.cloud.user.AccountService;
+import com.cloud.user.UserAccount;
+import com.cloud.utils.exception.InvalidParameterValueException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class GetUserCmdTest {
+    public static final Logger s_logger = LoggerFactory.getLogger(GetUserCmdTest.class.getName());
+
+    @Mock
+    private AccountService accountService;
+
+    @Mock
+    private ResponseGenerator responseGenerator;
+
+    @Mock
+    private UserAccount userAccount;
+
+    @InjectMocks
+    private final GetUserCmd getUserCmd = new GetUserCmd();
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        CallContext.unregister();
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void testExecuteWithUnknownApikey() {
+        userAccount = null;
+
+        when(accountService.getUserByApiKey(null)).thenReturn(userAccount);
+
+        getUserCmd.execute();
+    }
+
+    @Test
+    public void testExecuteWithDefault() {
+        final String secretKey = "Very secret key";
+        UserResponse response = new UserResponse();
+        response.setSecretKey(secretKey);
+
+        when(accountService.getUserByApiKey(null)).thenReturn(userAccount);
+        when(responseGenerator.createUserResponse(userAccount)).thenReturn(response);
+
+        getUserCmd.execute();
+
+        response = (UserResponse) getUserCmd.getResponseObject();
+        assertFalse("SecretKey was revealed in ResponseObject, wasn't masked", secretKey.equals(response.getSecretKey()));
+    }
+}

--- a/cosmic-core/api/src/test/java/com/cloud/api/command/admin/user/ListUsersCmdTest.java
+++ b/cosmic-core/api/src/test/java/com/cloud/api/command/admin/user/ListUsersCmdTest.java
@@ -1,0 +1,73 @@
+package com.cloud.api.command.admin.user;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.when;
+
+import com.cloud.api.response.ListResponse;
+import com.cloud.api.response.UserResponse;
+import com.cloud.context.CallContext;
+import com.cloud.query.QueryService;
+import com.cloud.utils.StringUtils;
+
+import java.util.Arrays;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ListUsersCmdTest {
+    public static final Logger s_logger = LoggerFactory.getLogger(ListUsersCmdTest.class.getName());
+
+    @Mock
+    private QueryService queryService;
+
+    @InjectMocks
+    private final ListUsersCmd listUsersCmd = new ListUsersCmd();
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        CallContext.unregister();
+    }
+
+    @Test
+    public void testExecuteWithDefault() {
+        final String secretKey = "Very secret key";
+        ListResponse<UserResponse> responseList = new ListResponse<>();
+        UserResponse response = new UserResponse();
+
+        response.setSecretKey(secretKey);
+        responseList.setResponses(Arrays.asList(response));
+        when(queryService.searchForUsers(listUsersCmd)).thenReturn(responseList);
+
+        listUsersCmd.execute();
+        responseList = (ListResponse)listUsersCmd.getResponseObject();
+        response = responseList.getResponses().get(0);
+
+        assertFalse("SecretKey was revealed in ResponseObject, wasn't masked", secretKey.equals(response.getSecretKey()));
+    }
+
+    @Test
+    public void testExecuteWithEmptySecretKey() {
+        ListResponse<UserResponse> responseList = new ListResponse<>();
+        UserResponse response = new UserResponse();
+
+        responseList.setResponses(Arrays.asList(response));
+        when(queryService.searchForUsers(listUsersCmd)).thenReturn(responseList);
+
+        listUsersCmd.execute();
+        responseList = (ListResponse)listUsersCmd.getResponseObject();
+        response = responseList.getResponses().get(0);
+
+        assertFalse("Empty SecretKey should be left empty", StringUtils.isNotBlank(response.getSecretKey()));
+    }
+}

--- a/cosmic-marvin/marvin/cloudstackTestClient.py
+++ b/cosmic-marvin/marvin/cloudstackTestClient.py
@@ -141,20 +141,17 @@ class CSTestClient(object):
                     self.__logger.error("API Client Creation Failed")
                     return FAILED
                 user_id = list_user_res[0].id
-                api_key = list_user_res[0].apikey
-                security_key = list_user_res[0].secretkey
-                if api_key is None:
-                    ret = self.__getKeys(user_id)
-                    if ret != FAILED:
-                        mgmt_details.apiKey = ret[0]
-                        mgmt_details.securityKey = ret[1]
-                    else:
-                        self.__logger.error("API Client Creation Failed while Registering User")
-                        return FAILED
+                ret = self.__getKeys(user_id)
+                if ret != FAILED:
+                    api_key = ret[0]
+                    security_key = ret[1]
                 else:
-                    mgmt_details.port = 8080
-                    mgmt_details.apiKey = api_key
-                    mgmt_details.securityKey = security_key
+                    self.__logger.error("API Client Creation Failed while Registering User")
+                    return FAILED
+
+                mgmt_details.port = 8080
+                mgmt_details.apiKey = api_key
+                mgmt_details.securityKey = security_key
                 '''
                 Now Create the Connection objects and Api Client using
                 new details


### PR DESCRIPTION
Adjust ListUsers and GetUser to mask the users _SecretKey_

RegisterUserKeys returns the generated API key and _SecretKey_.
The web interface provides a pop-up which show the _SecretKey_ (once). 

Sequence of generating/retrieving the key;

Cloudmonkey:
![image](https://user-images.githubusercontent.com/2699104/28917303-7d327782-7845-11e7-894d-51ea360cd5d5.png)
![image](https://user-images.githubusercontent.com/2699104/28919560-4cfc582c-784e-11e7-92ad-4dbd9c9098f4.png)
![image](https://user-images.githubusercontent.com/2699104/28917531-44d7cf6c-7846-11e7-882d-da301ed06bb2.png)

Web interface:
![image](https://user-images.githubusercontent.com/2699104/28919481-ff3f4edc-784d-11e7-86b0-5915feeb2faa.png)

