### PR TITLE
Show login account and name with full name

### DIFF
--- a/cosmic-client/src/main/webapp/css/cloudstack3.css
+++ b/cosmic-client/src/main/webapp/css/cloudstack3.css
@@ -2494,7 +2494,7 @@ div.detail-group.actions td {
     padding: 1px 0 0;
     /*+placement:shift -174px -57px;*/
     position: relative;
-    left: -239px;
+    left: -440px;
     top: -57px;
 }
 
@@ -2560,7 +2560,7 @@ div.detail-group.actions td {
     margin: 0;
     position: absolute;
     top: -47px;
-    left: 1025px;
+    left: 820px;
     cursor: default !important;
     display: inline-block;
     float: left;
@@ -2573,9 +2573,9 @@ div.detail-group.actions td {
     padding: 9px 18px 7px 12px;
     border-right: none;
     /*[empty]border-top:;*/
-    min-width: 110px;
-    max-width: 220px;
-    text-align: center;
+    min-width: 320px;
+    max-width: 340px;
+    text-align: left;
     height: 12px;
     overflow: hidden;
     /*+text-shadow:0px -1px 1px #464646;*/

--- a/cosmic-client/src/main/webapp/scripts/cloudStack.js
+++ b/cosmic-client/src/main/webapp/scripts/cloudStack.js
@@ -101,6 +101,7 @@
                     g_role = unBoxCookieValue('role');
                     g_userid = unBoxCookieValue('userid');
                     g_domainid = unBoxCookieValue('domainid');
+                    g_domainname = unBoxCookieValue('domainname');
                     g_account = unBoxCookieValue('account');
                     g_username = unBoxCookieValue('username');
                     g_userfullname = unBoxCookieValue('userfullname');
@@ -112,6 +113,7 @@
                     g_userid = g_loginResponse.userid;
                     g_account = g_loginResponse.account;
                     g_domainid = g_loginResponse.domainid;
+                    g_domainname = g_loginResponse.domainname;
                     g_userfullname = g_loginResponse.firstname + ' ' + g_loginResponse.lastname;
                     g_timezone = g_loginResponse.timezone;
                 }
@@ -223,8 +225,9 @@
                         g_userid = loginresponse.userid;
                         g_account = loginresponse.account;
                         g_domainid = loginresponse.domainid;
+                        g_domainname = loginresponse.domainname;
                         g_timezone = loginresponse.timezone;
-                        g_userfullname = loginresponse.firstname + ' ' + loginresponse.lastname;
+                        g_userfullname = '(' + loginresponse.domainname + '/' + loginresponse.username + ') ' + loginresponse.firstname + ' ' + loginresponse.lastname;
 
                         $.cookie('username', g_username, {
                             expires: 1
@@ -275,7 +278,7 @@
                                 args.response.success({
                                     data: {
                                         user: $.extend(true, {}, loginresponse, {
-                                            name: loginresponse.firstname + ' ' + loginresponse.lastname,
+                                            name: '(' + loginresponse.domainname + '/' + loginresponse.username + ') ' + loginresponse.firstname + ' ' + loginresponse.lastname,
                                             role: loginresponse.type == 1 ? 'admin' : 'user',
                                             type: loginresponse.type
                                         })

--- a/cosmic-client/src/main/webapp/scripts/ui/core.js
+++ b/cosmic-client/src/main/webapp/scripts/ui/core.js
@@ -205,16 +205,16 @@
                 id: 'user'
             }).addClass('button')
                 .append(
-                    $('<div>').addClass('name').text(
-                        args.context && args.context.users ?
-                            cloudStack.concat(userLabel, 21) : 'Invalid User'
-                    )
-                )
-                .append(
                     $('<div>').addClass('icon options')
                         .append(
                             $('<div>').addClass('icon arrow')
                         )
+                )
+                .append(
+                    $('<div>').addClass('name').text(
+                        args.context && args.context.users ?
+                            cloudStack.concat(userLabel, 60) : 'Invalid User'
+                    )
                 );
             $userInfo.attr('title', userLabel);
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/LoginCmdResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/LoginCmdResponse.java
@@ -19,6 +19,10 @@ public class LoginCmdResponse extends AuthenticationCmdResponse {
     @Param(description = "Domain ID that the user belongs to")
     private String domainId;
 
+    @SerializedName(value = ApiConstants.DOMAIN_NAME)
+    @Param(description = "Domain name that the user belongs to")
+    private String domainName;
+
     @SerializedName(value = ApiConstants.TIMEOUT)
     @Param(description = "the time period before the session has expired")
     private Integer timeout;
@@ -137,5 +141,13 @@ public class LoginCmdResponse extends AuthenticationCmdResponse {
 
     public void setSessionKey(final String sessionKey) {
         this.sessionKey = sessionKey;
+    }
+
+    public String getDomainName() {
+        return domainName;
+    }
+
+    public void setDomainName(final String domainName) {
+        this.domainName = domainName;
     }
 }

--- a/cosmic-core/server/src/main/java/com/cloud/api/ApiServer.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/ApiServer.java
@@ -906,7 +906,9 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             if (domain.getUuid() != null) {
                 session.setAttribute("domain_UUID", domain.getUuid());
             }
-
+            if (domain.getName() != null) {
+                session.setAttribute(ApiConstants.DOMAIN_NAME, domain.getName());
+            }
             session.setAttribute("type", Short.valueOf(account.getType()).toString());
             session.setAttribute("registrationtoken", userAcct.getRegistrationToken());
             session.setAttribute("registered", Boolean.toString(userAcct.isRegistered()));
@@ -972,6 +974,9 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
                 }
                 if (ApiConstants.SESSIONKEY.equalsIgnoreCase(attrName)) {
                     response.setSessionKey(attrObj.toString());
+                }
+                if(ApiConstants.DOMAIN_NAME.equalsIgnoreCase(attrName)) {
+                    response.setDomainName(attrObj.toString());
                 }
             }
         }


### PR DESCRIPTION
This PR adds the domain name to the (login api) session, and shows the domain name and user name along with the full name (top right).
The size of the field has been expanded to allow the larger string.

An example user:
![image](https://user-images.githubusercontent.com/2699104/29160598-2deb75e8-7db3-11e7-87e2-bdf954a57b92.png)

Results in:
![image](https://user-images.githubusercontent.com/2699104/29160660-7a225710-7db3-11e7-9a19-d0933aef724a.png)

