### PR TITLE
Introduce Paused state for VirtualMachines

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/instances.js
+++ b/cosmic-client/src/main/webapp/scripts/instances.js
@@ -2837,6 +2837,9 @@
             allowedActions.push("changeAffinity");
 
             allowedActions.push("viewConsole");
+        } else if (jsonObj.state == 'Paused') {
+            allowedActions.push("stop");
+
         } else if (jsonObj.state == 'Stopped') {
             allowedActions.push("edit");
 

--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -196,7 +196,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     static {
         s_powerStatesTable = new HashMap<>();
         s_powerStatesTable.put(DomainState.VIR_DOMAIN_SHUTOFF, PowerState.PowerOff);
-        s_powerStatesTable.put(DomainState.VIR_DOMAIN_PAUSED, PowerState.PowerOn);
+        s_powerStatesTable.put(DomainState.VIR_DOMAIN_PAUSED, PowerState.PowerPaused);
         s_powerStatesTable.put(DomainState.VIR_DOMAIN_RUNNING, PowerState.PowerOn);
         s_powerStatesTable.put(DomainState.VIR_DOMAIN_BLOCKED, PowerState.PowerOn);
         s_powerStatesTable.put(DomainState.VIR_DOMAIN_NOSTATE, PowerState.PowerUnknown);
@@ -2248,14 +2248,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
                 logger.trace("VM " + dm.getName() + ": powerstate = " + ps + "; vm state=" + state.toString());
                 final String vmName = dm.getName();
-
-                // TODO : for XS/KVM (host-based resource), we require to remove
-                // VM completely from host, for some reason, KVM seems to still keep
-                // Stopped VM around, to work-around that, reporting only powered-on VM
-                //
-                if (state == PowerState.PowerOn) {
-                    vmStates.put(vmName, new HostVmStateReportEntry(state, conn.getHostName()));
-                }
+                vmStates.put(vmName, new HostVmStateReportEntry(state, conn.getHostName()));
             } catch (final LibvirtException e) {
                 logger.warn("Unable to get vms", e);
             } finally {
@@ -2278,14 +2271,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 final PowerState state = convertToPowerState(ps);
                 final String vmName = dm.getName();
                 logger.trace("VM " + vmName + ": powerstate = " + ps + "; vm state=" + state.toString());
-
-                // TODO : for XS/KVM (host-based resource), we require to remove
-                // VM completely from host, for some reason, KVM seems to still keep
-                // Stopped VM around, to work-around that, reporting only powered-on VM
-                //
-                if (state == PowerState.PowerOn) {
-                    vmStates.put(vmName, new HostVmStateReportEntry(state, conn.getHostName()));
-                }
+                vmStates.put(vmName, new HostVmStateReportEntry(state, conn.getHostName()));
             } catch (final LibvirtException e) {
                 logger.warn("Unable to get vms", e);
             } finally {

--- a/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -2801,7 +2801,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         try {
             final VirtualMachineEntity vmEntity = _orchSrvc.getVirtualMachine(vm.getUuid());
 
-            if (forced) {
+            if (forced || vm.getState() == State.Paused) {
                 status = vmEntity.stopForced(Long.toString(userId));
             } else {
                 status = vmEntity.stop(Long.toString(userId));


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1630096/29124521-70a20630-7d19-11e7-872c-99cd15f7396a.png)

![image](https://user-images.githubusercontent.com/1630096/29127131-7be6ca60-7d20-11e7-8b1c-732f7c40f542.png)

When a VM is in `paused` state, it can be stopped, then started. Another improvement would be to introduce a `resumeVM` command to try getting it back without downtime.

This at least makes it visible and allows users to action on it.