### PR TITLE
Restrict SSH (port 3922) to allow only from the hypervisor

### DIFF
--- a/cosmic-core/systemvm/patches/debian/config/etc/iptables/iptables-consoleproxy
+++ b/cosmic-core/systemvm/patches/debian/config/etc/iptables/iptables-consoleproxy
@@ -13,7 +13,7 @@ COMMIT
 -A INPUT -i eth2 -m state --state RELATED,ESTABLISHED -j ACCEPT
 -A INPUT -p icmp --icmp-type 13 -j DROP
 -A INPUT -p icmp -j ACCEPT
--A INPUT -i eth1 -p tcp -m state --state NEW -m tcp --dport 3922 -j ACCEPT
+-A INPUT -i eth1 -p tcp -m state --state NEW -m tcp -s 169.254.0.1/32 --dport 3922 -j ACCEPT
 -A INPUT -i eth0 -p tcp -m state --state NEW -m tcp --dport 8001 -j ACCEPT
 -A INPUT -i eth1 -p tcp -m state --state NEW -m tcp --dport 8001 -j ACCEPT
 -A INPUT -i eth2 -p tcp -m state --state NEW -m tcp --dport 443 -j ACCEPT

--- a/cosmic-core/systemvm/patches/debian/config/etc/iptables/iptables-dhcpsrvr
+++ b/cosmic-core/systemvm/patches/debian/config/etc/iptables/iptables-dhcpsrvr
@@ -19,7 +19,7 @@ COMMIT
 -A INPUT -i eth0 -p udp -m udp --dport 67 -j ACCEPT
 -A INPUT -i eth0 -p udp -m udp --dport 53 -j ACCEPT
 -A INPUT -i eth0 -p tcp -m tcp --dport 53 -j ACCEPT
--A INPUT -i eth1 -p tcp -m tcp -m state --state NEW,ESTABLISHED --dport 3922 -j ACCEPT
+-A INPUT -i eth1 -p tcp -m tcp -m state --state NEW,ESTABLISHED -s 169.254.0.1/32 --dport 3922 -j ACCEPT
 -A INPUT -i eth0 -p tcp -m tcp -m state --state NEW --dport 80 -j ACCEPT
 -A FORWARD -i eth0 -o eth1 -m state --state RELATED,ESTABLISHED -j ACCEPT
 -A FORWARD -i eth2 -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT

--- a/cosmic-core/systemvm/patches/debian/config/etc/iptables/iptables-router
+++ b/cosmic-core/systemvm/patches/debian/config/etc/iptables/iptables-router
@@ -19,7 +19,7 @@ COMMIT
 -A INPUT -i eth0 -p udp -m udp --dport 67 -j ACCEPT
 -A INPUT -i eth0 -p udp -m udp --dport 53 -j ACCEPT
 -A INPUT -i eth0 -p tcp -m tcp --dport 53 -j ACCEPT
--A INPUT -i eth1 -p tcp -m tcp -m state --state NEW,ESTABLISHED --dport 3922 -j ACCEPT
+-A INPUT -i eth1 -p tcp -m tcp -m state --state NEW,ESTABLISHED -s 169.254.0.1/32 --dport 3922 -j ACCEPT
 -A INPUT -i eth0 -p tcp -m tcp -m state --state NEW --dport 80 -j ACCEPT
 -A FORWARD -i eth0 -o eth1 -m state --state RELATED,ESTABLISHED -j ACCEPT
 -A FORWARD -i eth2 -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT

--- a/cosmic-core/systemvm/patches/debian/config/etc/iptables/iptables-secstorage
+++ b/cosmic-core/systemvm/patches/debian/config/etc/iptables/iptables-secstorage
@@ -15,5 +15,5 @@ COMMIT
 -A INPUT -i lo  -j ACCEPT
 -A INPUT -p icmp --icmp-type 13 -j DROP
 -A INPUT -p icmp -j ACCEPT
--A INPUT -i eth0 -p tcp -m state --state NEW --dport 3922 -j ACCEPT
+-A INPUT -i eth0 -p tcp -m state --state NEW -s 169.254.0.1/32 --dport 3922 -j ACCEPT
 COMMIT

--- a/cosmic-core/systemvm/patches/debian/config/etc/iptables/iptables-vpcrouter
+++ b/cosmic-core/systemvm/patches/debian/config/etc/iptables/iptables-vpcrouter
@@ -11,7 +11,7 @@ COMMIT
 -A INPUT -d 225.0.0.50/32 -j ACCEPT
 -A INPUT -p icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
--A INPUT -i eth0 -p tcp -m tcp -m state --state NEW,ESTABLISHED --dport 3922 -j ACCEPT
+-A INPUT -i eth0 -p tcp -m tcp -m state --state NEW,ESTABLISHED -s 169.254.0.1/32 --dport 3922 -j ACCEPT
 -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
 COMMIT

--- a/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/cosmic-core/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -381,7 +381,7 @@ class CsIP:
         if self.config.is_vpc():
             return
 
-        self.fw.append(["filter", "", "-A INPUT -i eth1 -p tcp -m tcp --dport 3922 -m state --state NEW,ESTABLISHED -j ACCEPT"])
+        self.fw.append(["filter", "", "-A INPUT -i eth1 -p tcp -s 169.254.0.1/32 -m tcp --dport 3922 -m state --state NEW,ESTABLISHED -j ACCEPT"])
 
         self.fw.append(["filter", "", "-P INPUT DROP"])
         self.fw.append(["filter", "", "-P FORWARD DROP"])
@@ -525,7 +525,7 @@ class CsIP:
         self.fw.append(["filter", "", "-A INPUT -i %s -m state --state RELATED,ESTABLISHED -j ACCEPT" % self.dev])
         self.fw.append(["filter", "", "-A INPUT -i lo -j ACCEPT"])
         self.fw.append(["filter", "", "-A INPUT -p icmp -j ACCEPT"])
-        self.fw.append(["filter", "", "-A INPUT -i eth0 -p tcp -m tcp --dport 3922 -m state --state NEW,ESTABLISHED -j ACCEPT"])
+        self.fw.append(["filter", "", "-A INPUT -i eth0 -p tcp -m tcp -s 169.254.0.1/32 --dport 3922 -m state --state NEW,ESTABLISHED -j ACCEPT"])
         self.fw.append(["filter", "", "-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT"])
 
         self.fw.append(["filter", "", "-P INPUT DROP"])


### PR DESCRIPTION
Before:

```
root@s-2-VM:~# ssh root@169.254.0.208 -p 3922
The authenticity of host '[169.254.0.208]:3922 ([169.254.0.208]:3922)' can't be established.
ECDSA key fingerprint is a3:b1:73:d9:57:e8:5d:50:10:ee:dc:e5:03:bb:5e:f5.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added '[169.254.0.208]:3922' (ECDSA) to the list of known hosts.
Permission denied (publickey).
```

Now it won't even respond.
