### PR TITLE
Prevent NPE when hypervisor_version is null

### DIFF
--- a/cosmic-core/engine/schema/src/main/java/com/cloud/hypervisor/dao/HypervisorCapabilitiesDaoImpl.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/hypervisor/dao/HypervisorCapabilitiesDaoImpl.java
@@ -42,7 +42,11 @@ public class HypervisorCapabilitiesDaoImpl extends GenericDaoBase<HypervisorCapa
     public HypervisorCapabilitiesVO findByHypervisorTypeAndVersion(final HypervisorType hypervisorType, final String hypervisorVersion) {
         final SearchCriteria<HypervisorCapabilitiesVO> sc = HypervisorTypeAndVersionSearch.create();
         sc.setParameters("hypervisorType", hypervisorType);
-        sc.setParameters("hypervisorVersion", hypervisorVersion);
+
+        if (hypervisorVersion != null) {
+            sc.setParameters("hypervisorVersion", hypervisorVersion);
+        }
+
         return findOneBy(sc);
     }
 

--- a/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -3245,8 +3245,13 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
 
         // Check if the source and destination hosts are of the same type and support storage motion.
-        if (!(srcHost.getHypervisorType().equals(destinationHost.getHypervisorType()) && srcHost.getHypervisorVersion().equals(destinationHost.getHypervisorVersion()))) {
-            throw new CloudRuntimeException("The source and destination hosts are not of the same type and version. " + "Source hypervisor type and version: "
+        if (!srcHost.getHypervisorType().equals(destinationHost.getHypervisorType())) {
+            throw new CloudRuntimeException("The source and destination hosts are not of the same type " + "Source hypervisor type and version: "
+                    + srcHost.getHypervisorType().toString() + " " + srcHost.getHypervisorVersion() + ", Destination hypervisor type and version: "
+                    + destinationHost.getHypervisorType().toString() + " " + destinationHost.getHypervisorVersion());
+        }
+        if (srcHost.getHypervisorVersion() != null && !srcHost.getHypervisorVersion().equals(destinationHost.getHypervisorVersion())) {
+            throw new CloudRuntimeException("The source and destination hosts are not of the same version. " + "Source hypervisor type and version: "
                     + srcHost.getHypervisorType().toString() + " " + srcHost.getHypervisorVersion() + ", Destination hypervisor type and version: "
                     + destinationHost.getHypervisorType().toString() + " " + destinationHost.getHypervisorVersion());
         }


### PR DESCRIPTION
Fixing this is needed in order to make live migration of VMs work between clusters on KVM.

Instead of NPE, it still has issues, but at least the obvious stuff is fixed now so we can continue to work on making the feature work.