### PR TITLE
Fix XenServer HVM VM with more than 3 disks bug

### DIFF
--- a/cosmic-core/plugins/hypervisor/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/cosmic-core/plugins/hypervisor/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1200,7 +1200,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             vbdr.unpluggable = volume.getType() == Volume.Type.ROOT ? false : true;
             vbdr.userdevice = "autodetect";
             final Long deviceId = volume.getDiskSeq();
-            if (deviceId != null && !isDeviceUsed(conn, vm, deviceId)) {
+            if (deviceId != null && !isDeviceUsed(conn, vm, deviceId) || deviceId > 3) {
                 vbdr.userdevice = deviceId.toString();
             }
         }


### PR DESCRIPTION
VM with more then 3 disks won't start and reports the exception:

Caused by: com.cloud.utils.exception.CloudRuntimeException: Failed to attach volume
DATA-1234 to VM blablabla; Failed to attach volume for uuid:
xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx due to The device name is invalid

With this backport:
![image](https://user-images.githubusercontent.com/1177804/29240528-a9425b0c-7f67-11e7-9d87-98bffca83276.png)
