### PR TITLE
Add ability to restrict deployments of certain Hypervisor Types

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/BaseCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/BaseCmd.java
@@ -13,6 +13,7 @@ import com.cloud.exception.InsufficientCapacityException;
 import com.cloud.exception.NetworkRuleConflictException;
 import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.ResourceUnavailableException;
+import com.cloud.framework.config.dao.ConfigurationDao;
 import com.cloud.network.NetworkModel;
 import com.cloud.network.NetworkService;
 import com.cloud.network.NetworkUsageService;
@@ -160,6 +161,8 @@ public abstract class BaseCmd {
     public UUIDManager _uuidMgr;
     @Inject
     public ZoneRepository zoneRepository;
+    @Inject
+    public ConfigurationDao _configDao;
 
     private Object _responseObject;
     private Map<String, String> fullUrlParams;

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/config/ListCapabilitiesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/config/ListCapabilitiesCmd.java
@@ -34,6 +34,8 @@ public class ListCapabilitiesCmd extends BaseCmd {
         response.setKVMSnapshotEnabled((Boolean) capabilities.get("KVMSnapshotEnabled"));
         response.setAllowUserViewDestroyedVM((Boolean) capabilities.get("allowUserViewDestroyedVM"));
         response.setAllowUserExpungeRecoverVM((Boolean) capabilities.get("allowUserExpungeRecoverVM"));
+        response.setXenServerDeploymentsEnabled((Boolean) capabilities.get("xenserverDeploymentsEnabled"));
+        response.setKvmDeploymentsEnabled((Boolean) capabilities.get("KVMDeploymentsEnabled"));
         if (capabilities.containsKey("apiLimitInterval")) {
             response.setApiLimitInterval((Integer) capabilities.get("apiLimitInterval"));
         }

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/CapabilitiesResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/CapabilitiesResponse.java
@@ -67,6 +67,22 @@ public class CapabilitiesResponse extends BaseResponse {
     @Param(description = "true if the user can recover and expunge virtualmachines, false otherwise", since = "4.6.0")
     private boolean allowUserExpungeRecoverVM;
 
+    @SerializedName("xenserverdeploymentsenabled")
+    @Param(description = "true if the user can deploy VMs on XenServer, false otherwise")
+    private boolean xenServerDeploymentsEnabled;
+
+    @SerializedName("kvmdeploymentsenabled")
+    @Param(description = "true if the user can deploy VMs on KVM, false otherwise")
+    private boolean kvmDeploymentsEnabled;
+
+    public void setXenServerDeploymentsEnabled(final boolean xenServerDeploymentsEnabled) {
+        this.xenServerDeploymentsEnabled = xenServerDeploymentsEnabled;
+    }
+
+    public void setKvmDeploymentsEnabled(final boolean kvmDeploymentsEnabled) {
+        this.kvmDeploymentsEnabled = kvmDeploymentsEnabled;
+    }
+
     public void setSecurityGroupsEnabled(final boolean securityGroupsEnabled) {
         this.securityGroupsEnabled = securityGroupsEnabled;
     }

--- a/cosmic-core/server/src/main/java/com/cloud/server/ManagementServer.java
+++ b/cosmic-core/server/src/main/java/com/cloud/server/ManagementServer.java
@@ -50,4 +50,8 @@ public interface ManagementServer extends ManagementService, PluggableService {
     Pair<String, Integer> getVncPort(VirtualMachine vm);
 
     public long getMemoryOrCpuCapacityByHost(Long hostId, short capacityType);
+
+    public boolean getXenserverDeploymentsEnabled();
+
+    public boolean getKvmDeploymentsEnabled();
 }

--- a/cosmic-core/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -657,6 +657,11 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     static final ConfigKey<Integer> vmPasswordLength = new ConfigKey<>("Advanced", Integer.class, "vm.password.length", "10",
             "Specifies the length of a randomly generated password", false);
+    static final ConfigKey<Boolean> xenserverDeploymentsEnabled = new ConfigKey<>("Advanced", Boolean.class, "xenserver.deployments.enabled", "true",
+            "Are deployments to XenServer enabled or not", false);
+    static final ConfigKey<Boolean> kvmDeploymentsEnabled = new ConfigKey<>("Advanced", Boolean.class, "kvm.deployments.enabled", "true",
+            "Are deployments to KVM are enabled or not", false);
+
     private final ScheduledExecutorService _eventExecutor = Executors.newScheduledThreadPool(1, new NamedThreadFactory("EventChecker"));
     private final ScheduledExecutorService _alertExecutor = Executors.newScheduledThreadPool(1, new NamedThreadFactory("AlertChecker"));
     private final List<HypervisorType> supportedHypervisors = new ArrayList<>();
@@ -807,6 +812,16 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     public void setHostAllocators(final List<HostAllocator> hostAllocators) {
         this.hostAllocators = hostAllocators;
+    }
+
+    @Override
+    public boolean getXenserverDeploymentsEnabled() {
+        return xenserverDeploymentsEnabled.value();
+    }
+
+    @Override
+    public boolean getKvmDeploymentsEnabled() {
+        return kvmDeploymentsEnabled.value();
     }
 
     @Override
@@ -2391,6 +2406,9 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         final boolean allowUserViewDestroyedVM = QueryService.AllowUserViewDestroyedVM.valueIn(caller.getId()) | _accountService.isAdmin(caller.getId());
         final boolean allowUserExpungeRecoverVM = UserVmManager.AllowUserExpungeRecoverVm.valueIn(caller.getId()) | _accountService.isAdmin(caller.getId());
 
+        final boolean XenServerDeploymentsEnabled = xenserverDeploymentsEnabled.value();
+        final boolean KvmDeploymentsEnabled = kvmDeploymentsEnabled.value();
+
         // check if region-wide secondary storage is used
         boolean regionSecondaryEnabled = false;
         final List<ImageStoreVO> imgStores = _imgStoreDao.findRegionImageStores();
@@ -2410,6 +2428,8 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         capabilities.put("KVMSnapshotEnabled", KVMSnapshotEnabled);
         capabilities.put("allowUserViewDestroyedVM", allowUserViewDestroyedVM);
         capabilities.put("allowUserExpungeRecoverVM", allowUserExpungeRecoverVM);
+        capabilities.put("xenserverDeploymentsEnabled", XenServerDeploymentsEnabled);
+        capabilities.put("KVMDeploymentsEnabled", KvmDeploymentsEnabled);
         if (apiLimitEnabled) {
             capabilities.put("apiLimitInterval", apiLimitInterval);
             capabilities.put("apiLimitMax", apiLimitMax);
@@ -3892,7 +3912,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[]{vmPasswordLength};
+        return new ConfigKey<?>[]{vmPasswordLength, xenserverDeploymentsEnabled, kvmDeploymentsEnabled};
     }
 
     @Inject


### PR DESCRIPTION
This PR implements two new global settings:

- xenserver.deployments.enabled
- kvm.deployments.enabled

The default for both is `true`. It allows to disable a certain hypervisor, that for example is being phased out.

These settings can also be queried using the `listCapabilities` API call:

```
(local) 🐵 > list capabilities
capability:
allowusercreateprojects = True
allowuserexpungerecovervm = True
cloudstackversion = 5.3.9-SNAPSHOT
...
kvmdeploymentsenabled = True
....
xenserverdeploymentsenabled = True
```
Before you deploy, you can already check whether a deployment will work, or not.

When it's disabled an error is thrown:
![image](https://user-images.githubusercontent.com/1630096/29416627-049c4eba-8367-11e7-996a-e7f1f78e4034.png)
