### PR TITLE
Include hostname in title

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/cloudStack.js
+++ b/cosmic-client/src/main/webapp/scripts/cloudStack.js
@@ -420,6 +420,10 @@
 
         cloudStack.uiCustom.login(loginArgs);
 
-        document.title = _l('label.app.name');
+        var host = document.location.hostname.split('.');
+        if (host.length > 2) 
+            document.title = host[0].toUpperCase()+" "+_l('label.app.name');
+        else 
+            document.title = _l('label.app.name');
     });
 })(cloudStack, jQuery);


### PR DESCRIPTION
Prepend hostname in the title, If you have multiple tabs open it's easier to see which tab you need:

![image](https://user-images.githubusercontent.com/1177804/29463348-abab379a-8432-11e7-840b-829bac733cfa.png)

