### PR TITLE
Moved user option arrow to the right

### DIFF
--- a/cosmic-client/src/main/webapp/css/cloudstack3.css
+++ b/cosmic-client/src/main/webapp/css/cloudstack3.css
@@ -4330,6 +4330,7 @@ textarea {
     background: #FFFFFF;
     z-index: 10000;
     width: 150px;
+    left: -150px;
     position: absolute;
     padding: 10px;
     top: 20px;

--- a/cosmic-client/src/main/webapp/scripts/ui/core.js
+++ b/cosmic-client/src/main/webapp/scripts/ui/core.js
@@ -205,16 +205,17 @@
                 id: 'user'
             }).addClass('button')
                 .append(
-                    $('<div>').addClass('icon options')
-                        .append(
-                            $('<div>').addClass('icon arrow')
-                        )
-                )
-                .append(
                     $('<div>').addClass('name').text(
                         args.context && args.context.users ?
                             cloudStack.concat(userLabel, 60) : 'Invalid User'
                     )
+                )
+                .append(
+                    $('<div>').addClass('icon options')
+                        .append($('<div>').attr({
+                                id: 'userarrow'
+                            }).addClass('icon arrow')
+                        )
                 );
             $userInfo.attr('title', userLabel);
 
@@ -286,8 +287,7 @@
         // User options
         var $options = $('<div>').attr({
             id: 'user-options'
-        })
-            .appendTo($('#user'));
+        }).appendTo($('#userarrow'));
 
         $(['label.logout', 'label.issue', 'label.changelog', 'label.about.app']).each(function () {
             var $link = $('<a>')


### PR DESCRIPTION
Moved user option arrow from the left to the right side of the user name.

Before:
![image](https://user-images.githubusercontent.com/1177804/29470931-7f40e3fa-844e-11e7-9690-bf18528ccc21.png)

After:
![image](https://user-images.githubusercontent.com/1177804/29471050-dd49374a-844e-11e7-944d-3280e7f998a5.png)
