### PR TITLE
Allow a paused router to be stopped

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/system.js
+++ b/cosmic-client/src/main/webapp/scripts/system.js
@@ -13296,6 +13296,8 @@
             allowedActions.push("scaleUp");
 
             allowedActions.push("remove");
+        } else if (jsonObj.state == 'Paused') {
+            allowedActions.push("stop");
         }
         return allowedActions;
     }


### PR DESCRIPTION
If a router is in the paused state, you can now stop it from the GUI.