### PR TITLE
[WIP] Fix for filling up the buffer for p.wait()

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/CsHelper.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/CsHelper.py
@@ -217,6 +217,7 @@ def execute2(command, log=True):
     """ Execute command """
     logging.debug("Executing: %s" % command)
     p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    buffer = p.stdout.read()
     p.wait()
     if log:
         out, err = p.communicate()


### PR DESCRIPTION
By using p.wait(), when the output of a command has a large amount of stdout or stderr, this will hang forever and cause upstream issues (reset of a VPN connection will stop working). By adding a buffer, the process will put the output into the variable and p.wait() will only check if the command finished successfully. Later, p.communicate() is used to actually gather logs. Tested on live routerVM and confirmed it fixed the issue from the GUI.

This only occurs when there are a large number of VPNs being used.