### PR TITLE
Add ability to remove cpu flags

### DIFF
--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVmDef.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVmDef.java
@@ -1234,7 +1234,11 @@ public class LibvirtVmDef {
 
             if (features != null) {
                 for (final String feature : features) {
-                    modeBuilder.append("<feature policy='require' name='" + feature + "'/>");
+                    if (feature.startsWith("-")) {
+                        modeBuilder.append("<feature policy='disable' name='" + feature.substring(1) + "'/>");
+                    } else {
+                        modeBuilder.append("<feature policy='require' name='" + feature + "'/>");
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR makes it possible to disable cpu flags in the agent.properties file.

Example:
`guest.cpu.features=-hypervisor`