### PR TITLE
Make sure RPC services are disabled and stopped at boot time

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/generic_startup_hook.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/generic_startup_hook.py
@@ -67,6 +67,9 @@ class App:
     def start_app(self):
         Utils(self.cmdline).bootstrap()
 
+        logging.info("Disabling RPC services")
+        disable_rpc()
+
         if self.cmdline["type"] == "secstorage":
             logging.info("Starting app %s" % self.cmdline["type"])
 
@@ -85,6 +88,10 @@ class App:
         else:
             logging.error("Unknown type %s" % self.cmdline["type"])
             sys.exit(1)
+
+
+def disable_rpc():
+    os.system("for s in \"rpcbind.socket rpc-gssd rpcidmapd rpc-rquotad rpc-statd rpc-statd-notify\"; do systemctl stop $s; systemctl disable $s; done")
 
 
 def full_start(application):


### PR DESCRIPTION
They are also disabled in the template, should they be enabled again this will stop/disable them.

```
/var/log/messages:Dec  8 09:19:09 localhost python3.6: 2017-12-08 09:19:09,232  generic_startup_hook.py start_app:70 Disabling RPC services
```