### PR TITLE
Set cpu flags per guest os type

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/agent/api/to/VirtualMachineTO.java
+++ b/cosmic-core/api/src/main/java/com/cloud/agent/api/to/VirtualMachineTO.java
@@ -27,6 +27,7 @@ public class VirtualMachineTO {
     String hostName;
     String arch;
     String os;
+    String cpuflags;
     String manufacturer;
     String platformEmulator;
     String bootArgs;
@@ -319,5 +320,13 @@ public class VirtualMachineTO {
 
     public void setMetadata(final MetadataTO metadata) {
         this.metadata = metadata;
+    }
+
+    public String getCpuflags() {
+        return cpuflags;
+    }
+
+    public void setCpuflags(final String cpuflags) {
+        this.cpuflags = cpuflags;
     }
 }

--- a/cosmic-core/cosmic-flyway/src/main/resources/db/migration/V2_4__add_cpuflags_ostype.sql
+++ b/cosmic-core/cosmic-flyway/src/main/resources/db/migration/V2_4__add_cpuflags_ostype.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `guest_os` ADD `cpuflags` VARCHAR(64) NULL COMMENT 'Specific CPU flags for a KVM VM';

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/storage/GuestOSVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/storage/GuestOSVO.java
@@ -38,6 +38,9 @@ public class GuestOSVO implements GuestOS {
     @Column(name = "manufacturer_string")
     String manufacturer;
 
+    @Column(name = "cpuflags")
+    String cpuflags;
+
     @Override
     public long getId() {
         return id;
@@ -108,5 +111,13 @@ public class GuestOSVO implements GuestOS {
 
     public void setManufacturer(final String manufacturer) {
         this.manufacturer = manufacturer;
+    }
+
+    public String getCpuflags() {
+        return cpuflags;
+    }
+
+    public void setCpuflags(final String cpuflags) {
+        this.cpuflags = cpuflags;
     }
 }

--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1621,6 +1621,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         final CpuModeDef cmd = new CpuModeDef();
         cmd.setMode(getGuestCpuMode());
         cmd.setModel(getGuestCpuModel());
+        cmd.setCpuflags(vmTo.getCpuflags());
         if (vmTo.getType() == VirtualMachine.Type.User) {
             cmd.setFeatures(getCpuFeatures());
         }

--- a/cosmic-core/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
+++ b/cosmic-core/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
@@ -77,6 +77,7 @@ public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
         // Determine the VM's OS description
         final GuestOSVO guestOS = _guestOsDao.findByIdIncludingRemoved(vm.getVirtualMachine().getGuestOSId());
         to.setOs(guestOS.getDisplayName());
+        to.setCpuflags(guestOS.getCpuflags());
         to.setManufacturer(guestOS.getManufacturer());
         final HostVO host = _hostDao.findById(vm.getVirtualMachine().getHostId());
         GuestOSHypervisorVO guestOsMapping = null;


### PR DESCRIPTION
Make it possible to set CPU flags on guest OS. This PR will add an extra column in the `guest_os` table where cpu flags can be set separated by space. Also it's now possible to disable flags in the `agent.properties` by appending a dash in front of the flag.

Example of disabling flag `hypervisor` in `agent.properties` file:
```
guest.cpu.features=-hypervisor
```

Example of flag in `guest_os` table:
![image](https://user-images.githubusercontent.com/1177804/33830531-e709839a-de74-11e7-81f8-de5f2d2cac08.png)
