### PR TITLE
Write fw rules to location where iptables service can also restore them

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/CsNetfilter.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/CsNetfilter.py
@@ -163,7 +163,7 @@ class CsNetfilters(object):
         chains.table_printout()
 
         # COMMIT all rules.
-        p = Popen("iptables-restore < /tmp/rules.save", shell=True, stdout=PIPE, stderr=PIPE)
+        p = Popen("iptables-restore < /etc/sysconfig/iptables", shell=True, stdout=PIPE, stderr=PIPE)
         stdout, stderr = p.communicate()
         if not stderr:
             logging.info("iptables-restore result: success!")

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/databag/cs_iptables_save.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/databag/cs_iptables_save.py
@@ -170,7 +170,7 @@ class Tables(UserDict):
 
     def table_printout(self):
         """printout nonempty tabulars in fixed sequence"""
-        with open("/tmp/rules.save", 'w') as f:
+        with open("/etc/sysconfig/iptables", 'w') as f:
             for key in ["raw", "nat", "mangle", "filter"]:
                 len = self.data[key].length
                 if len > -1:


### PR DESCRIPTION
Changed the location of the iptables file so that it can also be loaded by the `iptables` service on boot, in case Cosmic doesn't control it.

(force) rebooted both routers from hypervisor/router itself (without Cosmic involved) one after another. Lost only a few pings due to keepalived failover. Recovery was fully automatic.

![image](https://user-images.githubusercontent.com/1630096/34059123-ef1e9338-e1dd-11e7-9a1b-35d3fd0f1f1c.png)
