### PR TITLE
FIX: GSON deserialization, replace slash with unicode slash in ExceptionResponse

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/response/ExceptionResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/ExceptionResponse.java
@@ -40,11 +40,11 @@ public class ExceptionResponse extends BaseResponse {
     }
 
     public String getErrorText() {
-        return errorText;
+        return errorText.replaceAll("\\\\u002F", "/");
     }
 
     public void setErrorText(final String errorText) {
-        this.errorText = errorText;
+        this.errorText = errorText.replaceAll("/", "\\\\u002F");
     }
 
     public void addProxyObject(final ExceptionProxyObject id) {


### PR DESCRIPTION
Sometimes in the `ExceptionResponse` in the `errortext` a path is returned with slashes, but the slash is also used as delimiter between the class response and the JSON which results in a `ClassNotFoundException` in `fromSerializedString`. By replacing the slash in `setErrorText` with the unicode version this resolves this problem. 

Before:
![image](https://user-images.githubusercontent.com/1177804/34100318-57ee4812-e3e2-11e7-9f96-a08159c9fec1.png)

After:
![image](https://user-images.githubusercontent.com/1177804/34100289-49901dd6-e3e2-11e7-9d1c-3eef3feed440.png)
