### PR TITLE
Refresh network overview on VPN customer gateway updates

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/UpdateVpnCustomerGatewayCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/UpdateVpnCustomerGatewayCmd.java
@@ -35,7 +35,7 @@ public class UpdateVpnCustomerGatewayCmd extends BaseAsyncCmd {
             description = "id of customer gateway")
     private Long id;
 
-    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = false, description = "name of this customer gateway")
+    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, description = "name of this customer gateway")
     private String name;
 
     @Parameter(name = ApiConstants.GATEWAY, type = CommandType.STRING, required = true, description = "public ip address id of the customer gateway")
@@ -67,10 +67,10 @@ public class UpdateVpnCustomerGatewayCmd extends BaseAsyncCmd {
             description = "Lifetime of phase 2 VPN connection to the customer gateway, in seconds")
     private Long espLifetime;
 
-    @Parameter(name = ApiConstants.DPD, type = CommandType.BOOLEAN, required = false, description = "If DPD is enabled for VPN connection")
+    @Parameter(name = ApiConstants.DPD, type = CommandType.BOOLEAN, description = "If DPD is enabled for VPN connection")
     private Boolean dpd;
 
-    @Parameter(name = ApiConstants.FORCE_ENCAP, type = CommandType.BOOLEAN, required = false, description = "Force encapsulation for Nat Traversal")
+    @Parameter(name = ApiConstants.FORCE_ENCAP, type = CommandType.BOOLEAN, description = "Force encapsulation for Nat Traversal")
     private Boolean encap;
 
     @Parameter(name = ApiConstants.ACCOUNT, type = CommandType.STRING, description = "the account associated with the gateway. Must be used with the domainId parameter.")

--- a/cosmic-core/api/src/main/java/com/cloud/network/element/Site2SiteVpnServiceProvider.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/element/Site2SiteVpnServiceProvider.java
@@ -7,5 +7,7 @@ import com.cloud.utils.component.Adapter;
 public interface Site2SiteVpnServiceProvider extends Adapter {
     boolean startSite2SiteVpn(Site2SiteVpnConnection conn) throws ResourceUnavailableException;
 
+    boolean refreshSite2SiteVpn(Site2SiteVpnConnection conn) throws ResourceUnavailableException;
+
     boolean stopSite2SiteVpn(Site2SiteVpnConnection conn) throws ResourceUnavailableException;
 }

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManager.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManager.java
@@ -35,6 +35,14 @@ public interface VpcVirtualNetworkApplianceManager extends VirtualNetworkApplian
      * @return
      * @throws ResourceUnavailableException
      */
+    boolean refreshSite2SiteVpn(Site2SiteVpnConnection conn, VirtualRouter router) throws ResourceUnavailableException;
+
+    /**
+     * @param conn
+     * @param routers
+     * @return
+     * @throws ResourceUnavailableException
+     */
     boolean stopSite2SiteVpn(Site2SiteVpnConnection conn, VirtualRouter router) throws ResourceUnavailableException;
 
     /**

--- a/cosmic-core/server/src/test/java/com/cloud/vpc/MockSite2SiteVpnServiceProvider.java
+++ b/cosmic-core/server/src/test/java/com/cloud/vpc/MockSite2SiteVpnServiceProvider.java
@@ -59,6 +59,15 @@ public class MockSite2SiteVpnServiceProvider extends ManagerBase implements Site
     }
 
     /* (non-Javadoc)
+     * @see com.cloud.network.element.Site2SiteVpnServiceProvider#refreshSite2SiteVpn(com.cloud.network.Site2SiteVpnConnection)
+     */
+    @Override
+    public boolean refreshSite2SiteVpn(final Site2SiteVpnConnection conn) throws ResourceUnavailableException {
+        // TODO Auto-generated method stub
+        return true;
+    }
+
+    /* (non-Javadoc)
      * @see com.cloud.network.element.Site2SiteVpnServiceProvider#stopSite2SiteVpn(com.cloud.network.Site2SiteVpnConnection)
      */
     @Override

--- a/cosmic-core/server/src/test/java/com/cloud/vpc/MockVpcVirtualNetworkApplianceManager.java
+++ b/cosmic-core/server/src/test/java/com/cloud/vpc/MockVpcVirtualNetworkApplianceManager.java
@@ -220,6 +220,15 @@ public class MockVpcVirtualNetworkApplianceManager extends ManagerBase implement
     }
 
     /* (non-Javadoc)
+     * @see com.cloud.network.router.VpcVirtualNetworkApplianceManager#refreshSite2SiteVpn(com.cloud.network.Site2SiteVpnConnection, com.cloud.network.router.VirtualRouter)
+     */
+    @Override
+    public boolean refreshSite2SiteVpn(final Site2SiteVpnConnection conn, final VirtualRouter router) throws ResourceUnavailableException {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    /* (non-Javadoc)
      * @see com.cloud.network.router.VpcVirtualNetworkApplianceManager#stopSite2SiteVpn(com.cloud.network.Site2SiteVpnConnection, com.cloud.network.router.VirtualRouter)
      */
     @Override


### PR DESCRIPTION
Changes to the `VPN Customer Gateway` are now also propagated to the router. This means you can for example edit the CIDRlist:

Before:
```
# Connection for 100.64.0.6
conn vpn-100.64.0.6-1
 right=100.64.0.6
 ike=3des-md5-modp1536
 esp=3des-md5-modp1536
 forceencaps=no
 leftsubnet=10.0.0.0/16
 ikelifetime=86400
 lifetime=86400
 left=100.64.0.5
 rightsubnet=10.1.0.0/16
```

After:
```
# Connection for 100.64.0.6
conn vpn-100.64.0.6-1
 right=100.64.0.6
 ike=3des-md5-modp1536
 esp=3des-md5-modp1536
 forceencaps=no
 leftsubnet=10.0.0.0/16
 ikelifetime=86400
 lifetime=86400
 left=100.64.0.5
 rightsubnet=10.1.0.0/16
conn vpn-100.64.0.6-2
 right=100.64.0.6
 ike=3des-md5-modp1536
 esp=3des-md5-modp1536
 forceencaps=no
 leftsubnet=10.0.0.0/16
 ikelifetime=86400
 lifetime=86400
 left=100.64.0.5
 rightsubnet=10.200.2.0/24
```