### PR TITLE
Prevent deleting lswitch that is in use by another network

### DIFF
--- a/cosmic-core/plugins/network/nicira-nvp/src/main/java/com/cloud/network/element/NiciraNvpElement.java
+++ b/cosmic-core/plugins/network/nicira-nvp/src/main/java/com/cloud/network/element/NiciraNvpElement.java
@@ -361,6 +361,12 @@ public class NiciraNvpElement extends AdapterBase implements ConnectivityProvide
             return false;
         }
 
+        // When the lswitch is used in another network in the zone, simply return without deleting the lswitch
+        if (networkDao.countByZoneAndUri(network.getDataCenterId(), network.getBroadcastUri().toString()) > 1) {
+            s_logger.error("There are other networks using this lswitch, so not deleting lswitch!");
+            return true;
+        }
+
         final DeleteLogicalSwitchPortCommand cmd = new DeleteLogicalSwitchPortCommand(nicMap.getLogicalSwitchUuid(), nicMap.getLogicalSwitchPortUuid());
         final DeleteLogicalSwitchPortAnswer answer = (DeleteLogicalSwitchPortAnswer) agentMgr.easySend(niciraNvpHost.getId(), cmd);
 


### PR DESCRIPTION
This fixes #597 