### PR TITLE
Add service group to api calls

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/APICommand.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/APICommand.java
@@ -14,7 +14,9 @@ import java.lang.annotation.Target;
 public @interface APICommand {
     Class<? extends BaseResponse> responseObject();
 
-    String name() default "";
+    String name();
+
+    APICommandGroup group();
 
     String description() default "";
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/APICommandGroup.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/APICommandGroup.java
@@ -1,0 +1,72 @@
+package com.cloud.api;
+
+public enum APICommandGroup {
+    AccountService("Account"),
+    AffinityGroupService("Affinity Group"),
+    AlertService("Alert"),
+    AsyncjobService("Async job"),
+    AuthenticationService("Authentication"),
+    AutoScaleService("AutoScale"),
+    BaseCmdTestService("BaseCmdTest"),
+    CertificateService("Certificate"),
+    CloudOpsService("CloudOps"),
+    ClusterService("Cluster"),
+    ConfigurationService("Configuration"),
+    DiskOfferingService("Disk Offering"),
+    DomainService("Domain"),
+    EventService("Event"),
+    FirewallService("Firewall"),
+    GuestOSService("Guest OS"),
+    HostService("Host"),
+    HypervisorService("Hypervisor"),
+    ImageStoreService("Image Store"),
+    InternalLBService("Internal LB"),
+    ISOService("ISO"),
+    LimitService("Limit"),
+    LoadBalancerService("Load Balancer"),
+    NATService("NAT"),
+    NetworkACLService("Network ACL"),
+    NetworkDeviceService("Network Device"),
+    NetworkOfferingService("Network Offering"),
+    NetworkService("Network"),
+    NiciraNVPService("Nicira NVP"),
+    NicService("Nic"),
+    PodService("Pod"),
+    PortableIPService("Portable IP"),
+    ProjectService("Project"),
+    PublicIPAddressService("Public IP Address"),
+    RegionService("Region"),
+    ResourcemetadataService("Resource metadata"),
+    ResourcetagsService("Resource tags"),
+    RouterService("Router"),
+    SecurityGroupService("Security Group"),
+    ServiceOfferingService("Service Offering"),
+    SnapshotService("Snapshot"),
+    SSHService("SSH"),
+    StoragePoolService("Storage Pool"),
+    SwiftService("Swift"),
+    SystemService("System"),
+    SystemVMService("System VM"),
+    TemplateService("Template"),
+    UsageService("Usage"),
+    UserService("User"),
+    VirtualMachineService("Virtual Machine"),
+    VLANService("VLAN"),
+    VMGroupService("VM Group"),
+    VolumeService("Volume"),
+    VPCService("VPC"),
+    VPNService("VPN"),
+    ZoneService("Zone");
+
+    private String description;
+
+    APICommandGroup(String description) {
+
+        this.description = description;
+    }
+
+    @Override
+    public String toString() {
+        return description;
+    }
+}

--- a/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
@@ -95,6 +95,8 @@ public class ApiConstants {
     public static final String GATEWAY = "gateway";
     public static final String IP6_GATEWAY = "ip6gateway";
     public static final String GROUP = "group";
+    public static final String GROUP_NAME = "groupname";
+    public static final String GROUP_DESCRIPTION = "groupdescription";
     public static final String GROUP_ID = "groupid";
     public static final String GUEST_CIDR_ADDRESS = "guestcidraddress";
     public static final String GUEST_VLAN_RANGE = "guestvlanrange";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/account/CreateAccountCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/account/CreateAccountCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.account;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -20,7 +21,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createAccount", description = "Creates an account", responseObject = AccountResponse.class, entityType = {Account.class},
+@APICommand(name = "createAccount", group = APICommandGroup.AccountService, description = "Creates an account", responseObject = AccountResponse.class, entityType = {Account.class},
         requestHasSensitiveInfo = true, responseHasSensitiveInfo = true)
 public class CreateAccountCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateAccountCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/account/DeleteAccountCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/account/DeleteAccountCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.admin.account;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -22,7 +23,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteAccount", description = "Deletes a account, and all users associated with this account", responseObject = SuccessResponse.class, entityType = {Account
+@APICommand(name = "deleteAccount", group = APICommandGroup.AccountService, description = "Deletes a account, and all users associated with this account", responseObject = SuccessResponse.class, entityType = {Account
         .class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteAccountCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/account/DisableAccountCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/account/DisableAccountCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.admin.account;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -24,7 +25,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "disableAccount", description = "Disables an account", responseObject = AccountResponse.class, entityType = {Account.class},
+@APICommand(name = "disableAccount", group = APICommandGroup.AccountService, description = "Disables an account", responseObject = AccountResponse.class, entityType = {Account.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class DisableAccountCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DisableAccountCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/account/EnableAccountCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/account/EnableAccountCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.admin.account;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -19,7 +20,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "enableAccount", description = "Enables an account", responseObject = AccountResponse.class, entityType = {Account.class},
+@APICommand(name = "enableAccount", group = APICommandGroup.AccountService, description = "Enables an account", responseObject = AccountResponse.class, entityType = {Account.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class EnableAccountCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(EnableAccountCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/account/ListAccountsCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/account/ListAccountsCmdByAdmin.java
@@ -1,12 +1,13 @@
 package com.cloud.api.command.admin.account;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.command.user.account.ListAccountsCmd;
 import com.cloud.api.response.AccountResponse;
 import com.cloud.user.Account;
 
-@APICommand(name = "listAccounts", description = "Lists accounts and provides detailed account information for listed accounts", responseObject = AccountResponse.class,
+@APICommand(name = "listAccounts", group = APICommandGroup.AccountService, description = "Lists accounts and provides detailed account information for listed accounts", responseObject = AccountResponse.class,
         responseView = ResponseView.Full, entityType = {Account.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class ListAccountsCmdByAdmin extends ListAccountsCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/account/LockAccountCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/account/LockAccountCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.account;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -12,7 +13,7 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "lockAccount",
+@APICommand(name = "lockAccount", group = APICommandGroup.AccountService,
         description = "This deprecated function used to locks an account. Look for the API DisableAccount instead",
         responseObject = AccountResponse.class,
         entityType = {Account.class},

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/account/UpdateAccountCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/account/UpdateAccountCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.admin.account;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -21,7 +22,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateAccount", description = "Updates account information for the authenticated user", responseObject = AccountResponse.class, entityType = {Account.class},
+@APICommand(name = "updateAccount", group = APICommandGroup.AccountService, description = "Updates account information for the authenticated user", responseObject = AccountResponse.class, entityType = {Account.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class UpdateAccountCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateAccountCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/address/AssociateIPAddrCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/address/AssociateIPAddrCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.address;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -16,7 +17,7 @@ import com.cloud.network.IpAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "associateIpAddress", description = "Acquires and associates a public IP to an account.", responseObject = IPAddressResponse.class, responseView =
+@APICommand(name = "associateIpAddress", group = APICommandGroup.PublicIPAddressService, description = "Acquires and associates a public IP to an account.", responseObject = IPAddressResponse.class, responseView =
         ResponseView.Full,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AssociateIPAddrCmdByAdmin extends AssociateIPAddrCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/address/ListPublicIpAddressesCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/address/ListPublicIpAddressesCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.address;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.command.user.address.ListPublicIpAddressesCmd;
 import com.cloud.api.response.IPAddressResponse;
@@ -14,7 +15,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listPublicIpAddresses", description = "Lists all public ip addresses", responseObject = IPAddressResponse.class, responseView = ResponseView.Full,
+@APICommand(name = "listPublicIpAddresses", group = APICommandGroup.PublicIPAddressService, description = "Lists all public ip addresses", responseObject = IPAddressResponse.class, responseView = ResponseView.Full,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, entityType = {IpAddress.class})
 public class ListPublicIpAddressesCmdByAdmin extends ListPublicIpAddressesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListPublicIpAddressesCmdByAdmin.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/affinitygroup/UpdateVMAffinityGroupCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/affinitygroup/UpdateVMAffinityGroupCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.affinitygroup;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants.VMDetails;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
@@ -19,7 +20,7 @@ import java.util.EnumSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateVMAffinityGroup", description = "Updates the affinity/anti-affinity group associations of a virtual machine. The VM has to be stopped and restarted for" +
+@APICommand(name = "updateVMAffinityGroup", group = APICommandGroup.AffinityGroupService, description = "Updates the affinity/anti-affinity group associations of a virtual machine. The VM has to be stopped and restarted for" +
         " the "
         + "new properties to take effect.", responseObject = UserVmResponse.class, responseView = ResponseView.Full,
         entityType = {VirtualMachine.class},

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/alert/GenerateAlertCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/alert/GenerateAlertCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.admin.alert;
 import com.cloud.alert.AlertService;
 import com.cloud.alert.AlertService.AlertType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -16,7 +17,7 @@ import com.cloud.event.EventTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "generateAlert", description = "Generates an alert", responseObject = SuccessResponse.class, since = "4.3",
+@APICommand(name = "generateAlert", group = APICommandGroup.AlertService, description = "Generates an alert", responseObject = SuccessResponse.class, since = "4.3",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class GenerateAlertCmd extends BaseAsyncCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/cloudops/ListHAWorkersCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/cloudops/ListHAWorkersCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.cloudops;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListDomainResourcesCmd;
 import com.cloud.api.Parameter;
@@ -8,7 +9,7 @@ import com.cloud.api.response.HAWorkerResponse;
 import com.cloud.api.response.HostResponse;
 import com.cloud.api.response.ListResponse;
 
-@APICommand(name = "listHAWorkers", description = "Lists all HA workers", responseObject = HAWorkerResponse.class)
+@APICommand(name = "listHAWorkers", group = APICommandGroup.CloudOpsService, description = "Lists all HA workers", responseObject = HAWorkerResponse.class)
 public class ListHAWorkersCmd extends BaseListDomainResourcesCmd {
 
     private static final String COMMAND_NAME = "listhaworkersresponse";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/cloudops/ListWhoHasThisIpCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/cloudops/ListWhoHasThisIpCmd.java
@@ -1,13 +1,14 @@
 package com.cloud.api.command.admin.cloudops;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListDomainResourcesCmd;
 import com.cloud.api.Parameter;
 import com.cloud.api.response.ListResponse;
 import com.cloud.api.response.WhoHasThisAddressResponse;
 
-@APICommand(name = "listWhoHasThisIp", description = "Lists all for this IP address", responseObject = WhoHasThisAddressResponse.class)
+@APICommand(name = "listWhoHasThisIp", group = APICommandGroup.CloudOpsService, description = "Lists all for this IP address", responseObject = WhoHasThisAddressResponse.class)
 public class ListWhoHasThisIpCmd extends BaseListDomainResourcesCmd {
 
     private static final String COMMAND_NAME = "listwhohasthisipresponse";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/cloudops/ListWhoHasThisMacCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/cloudops/ListWhoHasThisMacCmd.java
@@ -1,13 +1,14 @@
 package com.cloud.api.command.admin.cloudops;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListDomainResourcesCmd;
 import com.cloud.api.Parameter;
 import com.cloud.api.response.ListResponse;
 import com.cloud.api.response.WhoHasThisAddressResponse;
 
-@APICommand(name = "listWhoHasThisMac", description = "Lists all for this MAC address", responseObject = WhoHasThisAddressResponse.class)
+@APICommand(name = "listWhoHasThisMac", group = APICommandGroup.CloudOpsService, description = "Lists all for this MAC address", responseObject = WhoHasThisAddressResponse.class)
 public class ListWhoHasThisMacCmd extends BaseListDomainResourcesCmd {
 
     private static final String COMMAND_NAME = "listwhohasthismacresponse";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/cluster/AddClusterCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/cluster/AddClusterCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.cluster;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -21,7 +22,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addCluster", description = "Adds a new cluster", responseObject = ClusterResponse.class,
+@APICommand(name = "addCluster", group = APICommandGroup.ClusterService, description = "Adds a new cluster", responseObject = ClusterResponse.class,
         requestHasSensitiveInfo = true, responseHasSensitiveInfo = false)
 public class AddClusterCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AddClusterCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/cluster/DeleteClusterCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/cluster/DeleteClusterCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.cluster;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteCluster", description = "Deletes a cluster.", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteCluster", group = APICommandGroup.ClusterService, description = "Deletes a cluster.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteClusterCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteClusterCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/cluster/ListClustersCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/cluster/ListClustersCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.cluster;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -18,7 +19,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listClusters", description = "Lists clusters.", responseObject = ClusterResponse.class,
+@APICommand(name = "listClusters", group = APICommandGroup.ClusterService, description = "Lists clusters.", responseObject = ClusterResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListClustersCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListServiceOfferingsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/cluster/UpdateClusterCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/cluster/UpdateClusterCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.cluster;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -14,7 +15,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateCluster", description = "Updates an existing cluster", responseObject = ClusterResponse.class,
+@APICommand(name = "updateCluster", group = APICommandGroup.ClusterService, description = "Updates an existing cluster", responseObject = ClusterResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateClusterCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AddClusterCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/config/ListCfgsByCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/config/ListCfgsByCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.config;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -19,7 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listConfigurations", description = "Lists all configurations.", responseObject = ConfigurationResponse.class,
+@APICommand(name = "listConfigurations", group = APICommandGroup.ConfigurationService, description = "Lists all configurations.", responseObject = ConfigurationResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListCfgsByCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListCfgsByCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/config/ListDeploymentPlannersCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/config/ListDeploymentPlannersCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.config;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.response.DeploymentPlannersResponse;
 import com.cloud.api.response.ListResponse;
@@ -11,7 +12,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listDeploymentPlanners", description = "Lists all DeploymentPlanners available.", responseObject = DeploymentPlannersResponse.class,
+@APICommand(name = "listDeploymentPlanners", group = APICommandGroup.ConfigurationService, description = "Lists all DeploymentPlanners available.", responseObject = DeploymentPlannersResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListDeploymentPlannersCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListDeploymentPlannersCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/config/ListHypervisorCapabilitiesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/config/ListHypervisorCapabilitiesCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.config;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -16,7 +17,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listHypervisorCapabilities",
+@APICommand(name = "listHypervisorCapabilities", group = APICommandGroup.HypervisorService,
         description = "Lists all hypervisor capabilities.",
         responseObject = HypervisorCapabilitiesResponse.class,
         since = "3.0.0",

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/config/UpdateCfgCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/config/UpdateCfgCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.config;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -17,7 +18,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateConfiguration", description = "Updates a configuration.", responseObject = ConfigurationResponse.class,
+@APICommand(name = "updateConfiguration", group = APICommandGroup.ConfigurationService, description = "Updates a configuration.", responseObject = ConfigurationResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateCfgCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateCfgCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/config/UpdateHypervisorCapabilitiesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/config/UpdateHypervisorCapabilitiesCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.config;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateHypervisorCapabilities",
+@APICommand(name = "updateHypervisorCapabilities", group = APICommandGroup.HypervisorService,
         description = "Updates a hypervisor capabilities.",
         responseObject = HypervisorCapabilitiesResponse.class,
         since = "3.0.0",

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/domain/CreateDomainCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/domain/CreateDomainCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.domain;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -14,7 +15,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createDomain", description = "Creates a domain", responseObject = DomainResponse.class,
+@APICommand(name = "createDomain", group = APICommandGroup.DomainService, description = "Creates a domain", responseObject = DomainResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateDomainCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateDomainCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/domain/DeleteDomainCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/domain/DeleteDomainCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.domain;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -19,7 +20,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteDomain", description = "Deletes a specified domain", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteDomain", group = APICommandGroup.DomainService, description = "Deletes a specified domain", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteDomainCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteDomainCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/domain/ListDomainChildrenCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/domain/ListDomainChildrenCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.domain;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -15,7 +16,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listDomainChildren", description = "Lists all children domains belonging to a specified domain", responseObject = DomainResponse.class,
+@APICommand(name = "listDomainChildren", group = APICommandGroup.DomainService, description = "Lists all children domains belonging to a specified domain", responseObject = DomainResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListDomainChildrenCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListDomainChildrenCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/domain/ListDomainsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/domain/ListDomainsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.domain;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -12,7 +13,7 @@ import com.cloud.domain.Domain;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listDomains", description = "Lists domains and provides detailed information for listed domains", responseObject = DomainResponse.class, responseView =
+@APICommand(name = "listDomains", group = APICommandGroup.DomainService, description = "Lists domains and provides detailed information for listed domains", responseObject = DomainResponse.class, responseView =
         ResponseView.Restricted, entityType = {Domain.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListDomainsCmd extends BaseListCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/domain/ListDomainsCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/domain/ListDomainsCmdByAdmin.java
@@ -1,11 +1,12 @@
 package com.cloud.api.command.admin.domain;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.response.DomainResponse;
 import com.cloud.domain.Domain;
 
-@APICommand(name = "listDomains", description = "Lists domains and provides detailed information for listed domains", responseObject = DomainResponse.class, responseView =
+@APICommand(name = "listDomains", group = APICommandGroup.DomainService, description = "Lists domains and provides detailed information for listed domains", responseObject = DomainResponse.class, responseView =
         ResponseView.Full, entityType = {Domain.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListDomainsCmdByAdmin extends ListDomainsCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/domain/UpdateDomainCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/domain/UpdateDomainCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.domain;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -17,7 +18,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateDomain", description = "Updates a domain with a new name", responseObject = DomainResponse.class,
+@APICommand(name = "updateDomain", group = APICommandGroup.DomainService, description = "Updates a domain with a new name", responseObject = DomainResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateDomainCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateDomainCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/guest/AddGuestOsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/guest/AddGuestOsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.guest;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -17,7 +18,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addGuestOs", description = "Add a new guest OS type", responseObject = GuestOSResponse.class,
+@APICommand(name = "addGuestOs", group = APICommandGroup.GuestOSService, description = "Add a new guest OS type", responseObject = GuestOSResponse.class,
         since = "4.4.0", requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AddGuestOsCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AddGuestOsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/guest/AddGuestOsMappingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/guest/AddGuestOsMappingCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.guest;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addGuestOsMapping", description = "Adds a guest OS name to hypervisor OS name mapping", responseObject = GuestOsMappingResponse.class,
+@APICommand(name = "addGuestOsMapping", group = APICommandGroup.GuestOSService, description = "Adds a guest OS name to hypervisor OS name mapping", responseObject = GuestOsMappingResponse.class,
         since = "4.4.0", requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AddGuestOsMappingCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AddGuestOsMappingCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/guest/ListGuestOsMappingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/guest/ListGuestOsMappingCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.guest;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -16,7 +17,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listGuestOsMapping", description = "Lists all available OS mappings for given hypervisor", responseObject = GuestOsMappingResponse.class,
+@APICommand(name = "listGuestOsMapping", group = APICommandGroup.GuestOSService, description = "Lists all available OS mappings for given hypervisor", responseObject = GuestOsMappingResponse.class,
         since = "4.4.0", requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListGuestOsMappingCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListGuestOsMappingCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/guest/RemoveGuestOsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/guest/RemoveGuestOsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.guest;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "removeGuestOs", description = "Removes a Guest OS from listing.", responseObject = SuccessResponse.class, since = "4.4.0",
+@APICommand(name = "removeGuestOs", group = APICommandGroup.GuestOSService, description = "Removes a Guest OS from listing.", responseObject = SuccessResponse.class, since = "4.4.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RemoveGuestOsCmd extends BaseAsyncCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/guest/RemoveGuestOsMappingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/guest/RemoveGuestOsMappingCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.guest;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "removeGuestOsMapping", description = "Removes a Guest OS Mapping.", responseObject = SuccessResponse.class, since = "4.4.0",
+@APICommand(name = "removeGuestOsMapping", group = APICommandGroup.GuestOSService, description = "Removes a Guest OS Mapping.", responseObject = SuccessResponse.class, since = "4.4.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RemoveGuestOsMappingCmd extends BaseAsyncCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/guest/UpdateGuestOsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/guest/UpdateGuestOsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.guest;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -15,7 +16,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateGuestOs", description = "Updates the information about Guest OS", responseObject = GuestOSResponse.class,
+@APICommand(name = "updateGuestOs", group = APICommandGroup.GuestOSService, description = "Updates the information about Guest OS", responseObject = GuestOSResponse.class,
         since = "4.4.0", requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateGuestOsCmd extends BaseAsyncCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/guest/UpdateGuestOsMappingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/guest/UpdateGuestOsMappingCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.guest;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -15,7 +16,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateGuestOsMapping", description = "Updates the information about Guest OS to Hypervisor specific name mapping", responseObject = GuestOsMappingResponse
+@APICommand(name = "updateGuestOsMapping", group = APICommandGroup.GuestOSService, description = "Updates the information about Guest OS to Hypervisor specific name mapping", responseObject = GuestOsMappingResponse
         .class,
         since = "4.4.0", requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateGuestOsMappingCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/AddHostCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/AddHostCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.host;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -21,7 +22,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addHost", description = "Adds a new host.", responseObject = HostResponse.class,
+@APICommand(name = "addHost", group = APICommandGroup.HostService, description = "Adds a new host.", responseObject = HostResponse.class,
         requestHasSensitiveInfo = true, responseHasSensitiveInfo = false)
 public class AddHostCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AddHostCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/AddSecondaryStorageCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/AddSecondaryStorageCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.host;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -15,7 +16,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addSecondaryStorage", description = "Adds secondary storage.", responseObject = ImageStoreResponse.class,
+@APICommand(name = "addSecondaryStorage", group = APICommandGroup.HostService, description = "Adds secondary storage.", responseObject = ImageStoreResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AddSecondaryStorageCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AddSecondaryStorageCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/CancelMaintenanceCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/CancelMaintenanceCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.host;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "cancelHostMaintenance", description = "Cancels host maintenance.", responseObject = HostResponse.class,
+@APICommand(name = "cancelHostMaintenance", group = APICommandGroup.HostService, description = "Cancels host maintenance.", responseObject = HostResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CancelMaintenanceCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CancelMaintenanceCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/DeleteHostCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/DeleteHostCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.host;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteHost", description = "Deletes a host.", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteHost", group = APICommandGroup.HostService, description = "Deletes a host.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteHostCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteHostCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/FindHostsForMigrationCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/FindHostsForMigrationCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.host;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -18,7 +19,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "findHostsForMigration", description = "Find hosts suitable for migrating a virtual machine.", responseObject = HostForMigrationResponse.class,
+@APICommand(name = "findHostsForMigration", group = APICommandGroup.HostService, description = "Find hosts suitable for migrating a virtual machine.", responseObject = HostForMigrationResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class FindHostsForMigrationCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(FindHostsForMigrationCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/ListHostTagsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/ListHostTagsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.host;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.response.HostTagResponse;
@@ -9,7 +10,7 @@ import com.cloud.api.response.ListResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listHostTags", description = "Lists host tags", responseObject = HostTagResponse.class, requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
+@APICommand(name = "listHostTags", group = APICommandGroup.HostService, description = "Lists host tags", responseObject = HostTagResponse.class, requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListHostTagsCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListHostTagsCmd.class.getName());
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/ListHostsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/ListHostsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.host;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiConstants.HostDetails;
@@ -26,7 +27,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listHosts", description = "Lists hosts.", responseObject = HostResponse.class,
+@APICommand(name = "listHosts", group = APICommandGroup.HostService, description = "Lists hosts.", responseObject = HostResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListHostsCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListHostsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/PrepareForMaintenanceCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/PrepareForMaintenanceCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.host;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "prepareHostForMaintenance", description = "Prepares a host for maintenance.", responseObject = HostResponse.class,
+@APICommand(name = "prepareHostForMaintenance", group = APICommandGroup.HostService, description = "Prepares a host for maintenance.", responseObject = HostResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class PrepareForMaintenanceCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(PrepareForMaintenanceCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/ReconnectHostCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/ReconnectHostCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.host;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "reconnectHost", description = "Reconnects a host.", responseObject = HostResponse.class,
+@APICommand(name = "reconnectHost", group = APICommandGroup.HostService, description = "Reconnects a host.", responseObject = HostResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ReconnectHostCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ReconnectHostCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/ReleaseHostReservationCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/ReleaseHostReservationCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.host;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "releaseHostReservation", description = "Releases host reservation.", responseObject = SuccessResponse.class,
+@APICommand(name = "releaseHostReservation", group = APICommandGroup.HostService, description = "Releases host reservation.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ReleaseHostReservationCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ReleaseHostReservationCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/UpdateHostCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/UpdateHostCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.host;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -16,7 +17,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateHost", description = "Updates a host.", responseObject = HostResponse.class,
+@APICommand(name = "updateHost", group = APICommandGroup.HostService, description = "Updates a host.", responseObject = HostResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateHostCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateHostCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/UpdateHostPasswordCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/host/UpdateHostPasswordCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.host;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -12,7 +13,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateHostPassword", description = "Update password of a host/pool on management server.", responseObject = SuccessResponse.class,
+@APICommand(name = "updateHostPassword", group = APICommandGroup.HostService, description = "Update password of a host/pool on management server.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = true, responseHasSensitiveInfo = false)
 public class UpdateHostPasswordCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateHostPasswordCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/iso/AttachIsoCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/iso/AttachIsoCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -13,7 +14,7 @@ import com.cloud.uservm.UserVm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "attachIso", description = "Attaches an ISO to a virtual machine.", responseObject = UserVmResponse.class, responseView = ResponseView.Full,
+@APICommand(name = "attachIso", group = APICommandGroup.ISOService, description = "Attaches an ISO to a virtual machine.", responseObject = UserVmResponse.class, responseView = ResponseView.Full,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class AttachIsoCmdByAdmin extends AttachIsoCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AttachIsoCmdByAdmin.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/iso/CopyIsoCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/iso/CopyIsoCmdByAdmin.java
@@ -1,11 +1,12 @@
 package com.cloud.api.command.admin.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.command.user.iso.CopyIsoCmd;
 import com.cloud.api.response.TemplateResponse;
 
-@APICommand(name = "copyIso", description = "Copies an iso from one zone to another.", responseObject = TemplateResponse.class, responseView = ResponseView.Full,
+@APICommand(name = "copyIso", group = APICommandGroup.ISOService, description = "Copies an iso from one zone to another.", responseObject = TemplateResponse.class, responseView = ResponseView.Full,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CopyIsoCmdByAdmin extends CopyIsoCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/iso/DetachIsoCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/iso/DetachIsoCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -12,7 +13,7 @@ import com.cloud.uservm.UserVm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "detachIso", description = "Detaches any ISO file (if any) currently attached to a virtual machine.", responseObject = UserVmResponse.class, responseView =
+@APICommand(name = "detachIso", group = APICommandGroup.ISOService, description = "Detaches any ISO file (if any) currently attached to a virtual machine.", responseObject = UserVmResponse.class, responseView =
         ResponseView.Full,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class DetachIsoCmdByAdmin extends DetachIsoCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/iso/ListIsoPermissionsCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/iso/ListIsoPermissionsCmdByAdmin.java
@@ -17,11 +17,12 @@
 package com.cloud.api.command.admin.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.command.user.iso.ListIsoPermissionsCmd;
 import com.cloud.api.response.TemplatePermissionsResponse;
 
-@APICommand(name = "listIsoPermissions", description = "List iso visibility and all accounts that have permissions to view this iso.", responseObject =
+@APICommand(name = "listIsoPermissions", group = APICommandGroup.ISOService, description = "List iso visibility and all accounts that have permissions to view this iso.", responseObject =
         TemplatePermissionsResponse.class, responseView = ResponseView.Full,
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = false)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/iso/ListIsosCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/iso/ListIsosCmdByAdmin.java
@@ -1,11 +1,12 @@
 package com.cloud.api.command.admin.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.command.user.iso.ListIsosCmd;
 import com.cloud.api.response.TemplateResponse;
 
-@APICommand(name = "listIsos", description = "Lists all available ISO files.", responseObject = TemplateResponse.class, responseView = ResponseView.Full,
+@APICommand(name = "listIsos", group = APICommandGroup.ISOService, description = "Lists all available ISO files.", responseObject = TemplateResponse.class, responseView = ResponseView.Full,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListIsosCmdByAdmin extends ListIsosCmd {
 }

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/iso/RegisterIsoCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/iso/RegisterIsoCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -15,7 +16,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "registerIso", responseObject = TemplateResponse.class, description = "Registers an existing ISO into the CloudStack Cloud.", responseView = ResponseView.Full,
+@APICommand(name = "registerIso", group = APICommandGroup.ISOService, responseObject = TemplateResponse.class, description = "Registers an existing ISO into the CloudStack Cloud.", responseView = ResponseView.Full,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RegisterIsoCmdByAdmin extends RegisterIsoCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(RegisterIsoCmdByAdmin.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/iso/UpdateIsoCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/iso/UpdateIsoCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -11,7 +12,7 @@ import com.cloud.template.VirtualMachineTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateIso", description = "Updates an ISO file.", responseObject = TemplateResponse.class, responseView = ResponseView.Full,
+@APICommand(name = "updateIso", group = APICommandGroup.ISOService, description = "Updates an ISO file.", responseObject = TemplateResponse.class, responseView = ResponseView.Full,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateIsoCmdByAdmin extends UpdateIsoCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateIsoCmdByAdmin.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/loadbalancer/ListLoadBalancerRuleInstancesCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/loadbalancer/ListLoadBalancerRuleInstancesCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.loadbalancer;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.command.user.loadbalancer.ListLoadBalancerRuleInstancesCmd;
 import com.cloud.api.response.ListResponse;
@@ -16,7 +17,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listLoadBalancerRuleInstances", description = "List all virtual machine instances that are assigned to a load balancer rule.", responseObject =
+@APICommand(name = "listLoadBalancerRuleInstances", group = APICommandGroup.LoadBalancerService, description = "List all virtual machine instances that are assigned to a load balancer rule.", responseObject =
         LoadBalancerRuleVmMapResponse.class, responseView = ResponseView.Full,
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = true)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/AddNetworkDeviceCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/AddNetworkDeviceCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -22,7 +23,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addNetworkDevice",
+@APICommand(name = "addNetworkDevice", group = APICommandGroup.NetworkDeviceService,
         description = "Adds a network device of one of the following types: ExternalDhcp, ExternalLoadBalancer",
         responseObject = NetworkDeviceResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/AddNetworkServiceProviderCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/AddNetworkServiceProviderCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -20,7 +21,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addNetworkServiceProvider",
+@APICommand(name = "addNetworkServiceProvider", group = APICommandGroup.NetworkService,
         description = "Adds a network serviceProvider to a physical network",
         responseObject = ProviderResponse.class,
         since = "3.0.0",

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/CreateNetworkCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/CreateNetworkCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.Parameter;
@@ -16,7 +17,7 @@ import com.cloud.network.Network;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createNetwork", description = "Creates a network", responseObject = NetworkResponse.class, responseView = ResponseView.Full, entityType = {Network.class},
+@APICommand(name = "createNetwork", group = APICommandGroup.NetworkService, description = "Creates a network", responseObject = NetworkResponse.class, responseView = ResponseView.Full, entityType = {Network.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateNetworkCmdByAdmin extends CreateNetworkCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateNetworkCmdByAdmin.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/CreateNetworkOfferingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/CreateNetworkOfferingCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -25,7 +26,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createNetworkOffering", description = "Creates a network offering.", responseObject = NetworkOfferingResponse.class, since = "3.0.0",
+@APICommand(name = "createNetworkOffering", group = APICommandGroup.NetworkOfferingService, description = "Creates a network offering.", responseObject = NetworkOfferingResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateNetworkOfferingCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateNetworkOfferingCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/CreatePhysicalNetworkCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/CreatePhysicalNetworkCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -21,7 +22,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createPhysicalNetwork", description = "Creates a physical network", responseObject = PhysicalNetworkResponse.class, since = "3.0.0",
+@APICommand(name = "createPhysicalNetwork", group = APICommandGroup.NetworkService, description = "Creates a physical network", responseObject = PhysicalNetworkResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreatePhysicalNetworkCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreatePhysicalNetworkCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/CreateStorageNetworkIpRangeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/CreateStorageNetworkIpRangeCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -19,7 +20,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createStorageNetworkIpRange",
+@APICommand(name = "createStorageNetworkIpRange", group = APICommandGroup.NetworkService,
         description = "Creates a Storage network IP range.",
         responseObject = StorageNetworkIpRangeResponse.class,
         since = "3.0.0",

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/DedicateGuestVlanRangeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/DedicateGuestVlanRangeCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -18,7 +19,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "dedicateGuestVlanRange", description = "Dedicates a guest vlan range to an account", responseObject = GuestVlanRangeResponse.class,
+@APICommand(name = "dedicateGuestVlanRange", group = APICommandGroup.VLANService, description = "Dedicates a guest vlan range to an account", responseObject = GuestVlanRangeResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DedicateGuestVlanRangeCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DedicateGuestVlanRangeCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/DeleteNetworkDeviceCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/DeleteNetworkDeviceCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -21,7 +22,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteNetworkDevice", description = "Deletes network device.", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteNetworkDevice", group = APICommandGroup.NetworkDeviceService, description = "Deletes network device.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteNetworkDeviceCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteNetworkDeviceCmd.class);

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/DeleteNetworkOfferingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/DeleteNetworkOfferingCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteNetworkOffering", description = "Deletes a network offering.", responseObject = SuccessResponse.class, since = "3.0.0",
+@APICommand(name = "deleteNetworkOffering", group = APICommandGroup.NetworkOfferingService, description = "Deletes a network offering.", responseObject = SuccessResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteNetworkOfferingCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteNetworkOfferingCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/DeleteNetworkServiceProviderCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/DeleteNetworkServiceProviderCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -17,7 +18,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteNetworkServiceProvider", description = "Deletes a Network Service Provider.", responseObject = SuccessResponse.class, since = "3.0.0",
+@APICommand(name = "deleteNetworkServiceProvider", group = APICommandGroup.NetworkService, description = "Deletes a Network Service Provider.", responseObject = SuccessResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteNetworkServiceProviderCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteNetworkServiceProviderCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/DeletePhysicalNetworkCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/DeletePhysicalNetworkCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deletePhysicalNetwork", description = "Deletes a Physical Network.", responseObject = SuccessResponse.class, since = "3.0.0",
+@APICommand(name = "deletePhysicalNetwork", group = APICommandGroup.NetworkService, description = "Deletes a Physical Network.", responseObject = SuccessResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeletePhysicalNetworkCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeletePhysicalNetworkCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/DeleteStorageNetworkIpRangeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/DeleteStorageNetworkIpRangeCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -18,7 +19,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteStorageNetworkIpRange", description = "Deletes a storage network IP Range.", responseObject = SuccessResponse.class, since = "3.0.0",
+@APICommand(name = "deleteStorageNetworkIpRange", group = APICommandGroup.NetworkService, description = "Deletes a storage network IP Range.", responseObject = SuccessResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteStorageNetworkIpRangeCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteStorageNetworkIpRangeCmd.class);

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ListDedicatedGuestVlanRangesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ListDedicatedGuestVlanRangesCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -20,7 +21,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listDedicatedGuestVlanRanges", description = "Lists dedicated guest vlan ranges", responseObject = GuestVlanRangeResponse.class,
+@APICommand(name = "listDedicatedGuestVlanRanges", group = APICommandGroup.VLANService, description = "Lists dedicated guest vlan ranges", responseObject = GuestVlanRangeResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListDedicatedGuestVlanRangesCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListDedicatedGuestVlanRangesCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ListNetworkDeviceCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ListNetworkDeviceCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseListCmd;
@@ -25,7 +26,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listNetworkDevice", description = "List network devices", responseObject = NetworkDeviceResponse.class,
+@APICommand(name = "listNetworkDevice", group = APICommandGroup.NetworkDeviceService, description = "List network devices", responseObject = NetworkDeviceResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListNetworkDeviceCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListNetworkDeviceCmd.class);

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ListNetworkIsolationMethodsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ListNetworkIsolationMethodsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.response.IsolationMethodResponse;
 import com.cloud.api.response.ListResponse;
@@ -9,7 +10,7 @@ import com.cloud.network.Networks;
 import java.util.ArrayList;
 import java.util.List;
 
-@APICommand(name = "listNetworkIsolationMethods",
+@APICommand(name = "listNetworkIsolationMethods", group = APICommandGroup.NetworkService,
         description = "Lists supported methods of network isolation",
         responseObject = IsolationMethodResponse.class,
         since = "4.2.0",

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ListNetworkServiceProvidersCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ListNetworkServiceProvidersCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -17,7 +18,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listNetworkServiceProviders",
+@APICommand(name = "listNetworkServiceProviders", group = APICommandGroup.NetworkService,
         description = "Lists network serviceproviders for a given physical network.",
         responseObject = ProviderResponse.class,
         since = "3.0.0",

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ListNetworksCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ListNetworksCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.command.user.network.ListNetworksCmd;
 import com.cloud.api.response.ListResponse;
@@ -14,7 +15,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listNetworks", description = "Lists all available networks.", responseObject = NetworkResponse.class, responseView = ResponseView.Full, entityType = {Network
+@APICommand(name = "listNetworks", group = APICommandGroup.NetworkService, description = "Lists all available networks.", responseObject = NetworkResponse.class, responseView = ResponseView.Full, entityType = {Network
         .class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListNetworksCmdByAdmin extends ListNetworksCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ListPhysicalNetworksCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ListPhysicalNetworksCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseListCmd;
@@ -19,7 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listPhysicalNetworks", description = "Lists physical networks", responseObject = PhysicalNetworkResponse.class, since = "3.0.0",
+@APICommand(name = "listPhysicalNetworks", group = APICommandGroup.NetworkService, description = "Lists physical networks", responseObject = PhysicalNetworkResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListPhysicalNetworksCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListPhysicalNetworksCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ListStorageNetworkIpRangeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ListStorageNetworkIpRangeCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseListCmd;
@@ -23,7 +24,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listStorageNetworkIpRange", description = "List a storage network IP range.", responseObject = StorageNetworkIpRangeResponse.class, since = "3.0.0",
+@APICommand(name = "listStorageNetworkIpRange", group = APICommandGroup.NetworkService, description = "List a storage network IP range.", responseObject = StorageNetworkIpRangeResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListStorageNetworkIpRangeCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListStorageNetworkIpRangeCmd.class);

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ListSupportedNetworkServicesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ListSupportedNetworkServicesCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -17,7 +18,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listSupportedNetworkServices",
+@APICommand(name = "listSupportedNetworkServices", group = APICommandGroup.NetworkService,
         description = "Lists all network services provided by CloudStack or for the given Provider.",
         responseObject = ServiceResponse.class,
         since = "3.0.0",

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ReleaseDedicatedGuestVlanRangeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/ReleaseDedicatedGuestVlanRangeCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "releaseDedicatedGuestVlanRange", description = "Releases a dedicated guest vlan range to the system", responseObject = SuccessResponse.class,
+@APICommand(name = "releaseDedicatedGuestVlanRange", group = APICommandGroup.VLANService, description = "Releases a dedicated guest vlan range to the system", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ReleaseDedicatedGuestVlanRangeCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ReleaseDedicatedGuestVlanRangeCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/UpdateNetworkCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/UpdateNetworkCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -17,7 +18,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateNetwork", description = "Updates a network", responseObject = NetworkResponse.class, responseView = ResponseView.Full, entityType = {Network.class},
+@APICommand(name = "updateNetwork", group = APICommandGroup.NetworkService, description = "Updates a network", responseObject = NetworkResponse.class, responseView = ResponseView.Full, entityType = {Network.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateNetworkCmdByAdmin extends UpdateNetworkCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateNetworkCmdByAdmin.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/UpdateNetworkOfferingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/UpdateNetworkOfferingCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateNetworkOffering", description = "Updates a network offering.", responseObject = NetworkOfferingResponse.class,
+@APICommand(name = "updateNetworkOffering", group = APICommandGroup.NetworkOfferingService, description = "Updates a network offering.", responseObject = NetworkOfferingResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateNetworkOfferingCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateNetworkOfferingCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/UpdateNetworkServiceProviderCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/UpdateNetworkServiceProviderCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -17,7 +18,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateNetworkServiceProvider",
+@APICommand(name = "updateNetworkServiceProvider", group = APICommandGroup.NetworkService,
         description = "Updates a network serviceProvider of a physical network",
         responseObject = ProviderResponse.class,
         since = "3.0.0",

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/UpdatePhysicalNetworkCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/UpdatePhysicalNetworkCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseAsyncCmd;
@@ -15,7 +16,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updatePhysicalNetwork", description = "Updates a physical network", responseObject = PhysicalNetworkResponse.class, since = "3.0.0",
+@APICommand(name = "updatePhysicalNetwork", group = APICommandGroup.NetworkService, description = "Updates a physical network", responseObject = PhysicalNetworkResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdatePhysicalNetworkCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdatePhysicalNetworkCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/UpdateStorageNetworkIpRangeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/network/UpdateStorageNetworkIpRangeCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -18,7 +19,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateStorageNetworkIpRange",
+@APICommand(name = "updateStorageNetworkIpRange", group = APICommandGroup.NetworkService,
         description = "Update a Storage network IP range, only allowed when no IPs in this range have been allocated.",
         responseObject = StorageNetworkIpRangeResponse.class,
         since = "3.0.0",

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/offering/CreateDiskOfferingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/offering/CreateDiskOfferingCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.offering;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createDiskOffering", description = "Creates a disk offering.", responseObject = DiskOfferingResponse.class,
+@APICommand(name = "createDiskOffering", group = APICommandGroup.DiskOfferingService, description = "Creates a disk offering.", responseObject = DiskOfferingResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateDiskOfferingCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateDiskOfferingCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/offering/CreateServiceOfferingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/offering/CreateServiceOfferingCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.offering;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -20,7 +21,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createServiceOffering", description = "Creates a service offering.", responseObject = ServiceOfferingResponse.class,
+@APICommand(name = "createServiceOffering", group = APICommandGroup.ServiceOfferingService, description = "Creates a service offering.", responseObject = ServiceOfferingResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateServiceOfferingCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateServiceOfferingCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/offering/DeleteDiskOfferingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/offering/DeleteDiskOfferingCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.offering;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteDiskOffering", description = "Updates a disk offering.", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteDiskOffering", group = APICommandGroup.DiskOfferingService, description = "Updates a disk offering.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteDiskOfferingCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteDiskOfferingCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/offering/DeleteServiceOfferingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/offering/DeleteServiceOfferingCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.offering;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteServiceOffering", description = "Deletes a service offering.", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteServiceOffering", group = APICommandGroup.ServiceOfferingService, description = "Deletes a service offering.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteServiceOfferingCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteServiceOfferingCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/offering/UpdateDiskOfferingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/offering/UpdateDiskOfferingCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.offering;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateDiskOffering", description = "Updates a disk offering.", responseObject = DiskOfferingResponse.class,
+@APICommand(name = "updateDiskOffering", group = APICommandGroup.DiskOfferingService, description = "Updates a disk offering.", responseObject = DiskOfferingResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateDiskOfferingCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateDiskOfferingCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/offering/UpdateServiceOfferingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/offering/UpdateServiceOfferingCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.offering;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateServiceOffering", description = "Updates a service offering.", responseObject = ServiceOfferingResponse.class,
+@APICommand(name = "updateServiceOffering", group = APICommandGroup.ServiceOfferingService, description = "Updates a service offering.", responseObject = ServiceOfferingResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateServiceOfferingCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateServiceOfferingCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/pod/CreatePodCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/pod/CreatePodCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.pod;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -14,7 +15,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createPod", description = "Creates a new Pod.", responseObject = PodResponse.class,
+@APICommand(name = "createPod", group = APICommandGroup.PodService, description = "Creates a new Pod.", responseObject = PodResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreatePodCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreatePodCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/pod/DeletePodCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/pod/DeletePodCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.pod;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deletePod", description = "Deletes a Pod.", responseObject = SuccessResponse.class,
+@APICommand(name = "deletePod", group = APICommandGroup.PodService, description = "Deletes a Pod.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeletePodCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeletePodCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/pod/ListPodsByCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/pod/ListPodsByCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.pod;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -16,7 +17,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listPods", description = "Lists all Pods.", responseObject = PodResponse.class,
+@APICommand(name = "listPods", group = APICommandGroup.PodService, description = "Lists all Pods.", responseObject = PodResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListPodsByCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListPodsByCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/pod/UpdatePodCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/pod/UpdatePodCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.pod;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updatePod", description = "Updates a Pod.", responseObject = PodResponse.class,
+@APICommand(name = "updatePod", group = APICommandGroup.PodService, description = "Updates a Pod.", responseObject = PodResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdatePodCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdatePodCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/region/AddRegionCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/region/AddRegionCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.region;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -16,7 +17,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addRegion", description = "Adds a Region", responseObject = RegionResponse.class,
+@APICommand(name = "addRegion", group = APICommandGroup.RegionService, description = "Adds a Region", responseObject = RegionResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AddRegionCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AddRegionCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/region/RemoveRegionCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/region/RemoveRegionCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.region;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -15,7 +16,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "removeRegion", description = "Removes specified region", responseObject = SuccessResponse.class,
+@APICommand(name = "removeRegion", group = APICommandGroup.RegionService, description = "Removes specified region", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RemoveRegionCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(RemoveRegionCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/region/UpdateRegionCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/region/UpdateRegionCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.region;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -16,7 +17,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateRegion", description = "Updates a region", responseObject = RegionResponse.class,
+@APICommand(name = "updateRegion", group = APICommandGroup.RegionService, description = "Updates a region", responseObject = RegionResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateRegionCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateRegionCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/resource/ArchiveAlertsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/resource/ArchiveAlertsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.resource;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -17,7 +18,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "archiveAlerts", description = "Archive one or more alerts.", responseObject = SuccessResponse.class,
+@APICommand(name = "archiveAlerts", group = APICommandGroup.AlertService, description = "Archive one or more alerts.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ArchiveAlertsCmd extends BaseCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/resource/CleanVMReservationsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/resource/CleanVMReservationsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.resource;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
 import com.cloud.api.ServerApiException;
@@ -12,7 +13,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "cleanVMReservations", description = "Cleanups VM reservations in the database.", responseObject = SuccessResponse.class,
+@APICommand(name = "cleanVMReservations", group = APICommandGroup.VirtualMachineService, description = "Cleanups VM reservations in the database.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CleanVMReservationsCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CleanVMReservationsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/resource/DeleteAlertsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/resource/DeleteAlertsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.resource;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -17,7 +18,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteAlerts", description = "Delete one or more alerts.", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteAlerts", group = APICommandGroup.AlertService, description = "Delete one or more alerts.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteAlertsCmd extends BaseCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/resource/ListAlertsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/resource/ListAlertsCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.admin.resource;
 
 import com.cloud.alert.Alert;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -15,7 +16,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listAlerts", description = "Lists all alerts.", responseObject = AlertResponse.class,
+@APICommand(name = "listAlerts", group = APICommandGroup.AlertService, description = "Lists all alerts.", responseObject = AlertResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListAlertsCmd extends BaseListCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/resource/ListCapacityCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/resource/ListCapacityCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.resource;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -18,7 +19,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listCapacity", description = "Lists all the system wide capacities.", responseObject = CapacityResponse.class,
+@APICommand(name = "listCapacity", group = APICommandGroup.SystemService, description = "Lists all the system wide capacities.", responseObject = CapacityResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListCapacityCmd extends BaseListCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/resource/UploadCustomCertificateCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/resource/UploadCustomCertificateCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.resource;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "uploadCustomCertificate",
+@APICommand(name = "uploadCustomCertificate", group = APICommandGroup.CertificateService,
         responseObject = CustomCertificateResponse.class,
         description = "Uploads a custom certificate for the console proxy VMs to use for SSL. Can be used to upload a single certificate signed by a known CA. Can also be used, " +
                 "through multiple calls, to upload a chain of certificates from CA to the custom certificate itself.",

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/ConfigureVirtualRouterElementCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/ConfigureVirtualRouterElementCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.router;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -23,7 +24,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "configureVirtualRouterElement", responseObject = VirtualRouterProviderResponse.class, description = "Configures a virtual router element.",
+@APICommand(name = "configureVirtualRouterElement", group = APICommandGroup.RouterService, responseObject = VirtualRouterProviderResponse.class, description = "Configures a virtual router element.",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ConfigureVirtualRouterElementCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ConfigureVirtualRouterElementCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/CreateVirtualRouterElementCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/CreateVirtualRouterElementCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.router;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCreateCmd;
@@ -23,7 +24,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createVirtualRouterElement", responseObject = VirtualRouterProviderResponse.class, description = "Create a virtual router element.",
+@APICommand(name = "createVirtualRouterElement", group = APICommandGroup.RouterService, responseObject = VirtualRouterProviderResponse.class, description = "Create a virtual router element.",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateVirtualRouterElementCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateVirtualRouterElementCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/DestroyRouterCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/DestroyRouterCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.router;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -19,7 +20,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "destroyRouter", description = "Destroys a router.", responseObject = DomainRouterResponse.class, entityType = {VirtualMachine.class},
+@APICommand(name = "destroyRouter", group = APICommandGroup.RouterService, description = "Destroys a router.", responseObject = DomainRouterResponse.class, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DestroyRouterCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DestroyRouterCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/ListRoutersCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/ListRoutersCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.router;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListProjectAndAccountResourcesCmd;
@@ -20,7 +21,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listRouters", description = "List routers.", responseObject = DomainRouterResponse.class, entityType = {VirtualMachine.class},
+@APICommand(name = "listRouters", group = APICommandGroup.RouterService, description = "List routers.", responseObject = DomainRouterResponse.class, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListRoutersCmd extends BaseListProjectAndAccountResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListRoutersCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/ListVirtualRouterElementsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/ListVirtualRouterElementsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.router;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -23,7 +24,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listVirtualRouterElements", description = "Lists all available virtual router elements.", responseObject = VirtualRouterProviderResponse.class,
+@APICommand(name = "listVirtualRouterElements", group = APICommandGroup.RouterService, description = "Lists all available virtual router elements.", responseObject = VirtualRouterProviderResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListVirtualRouterElementsCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListNetworkOfferingsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/RebootRouterCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/RebootRouterCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.router;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -20,7 +21,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "rebootRouter", description = "Starts a router.", responseObject = DomainRouterResponse.class, entityType = {VirtualMachine.class},
+@APICommand(name = "rebootRouter", group = APICommandGroup.RouterService, description = "Starts a router.", responseObject = DomainRouterResponse.class, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RebootRouterCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(RebootRouterCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/StartRouterCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/StartRouterCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.router;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -22,7 +23,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "startRouter", responseObject = DomainRouterResponse.class, description = "Starts a router.", entityType = {VirtualMachine.class},
+@APICommand(name = "startRouter", group = APICommandGroup.RouterService, responseObject = DomainRouterResponse.class, description = "Starts a router.", entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class StartRouterCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(StartRouterCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/StopRouterCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/StopRouterCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.router;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -21,7 +22,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "stopRouter", description = "Stops a router.", responseObject = DomainRouterResponse.class, entityType = {VirtualMachine.class},
+@APICommand(name = "stopRouter", group = APICommandGroup.RouterService, description = "Stops a router.", responseObject = DomainRouterResponse.class, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class StopRouterCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(StopRouterCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/UpgradeRouterCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/UpgradeRouterCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.router;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -15,7 +16,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "changeServiceForRouter", description = "Upgrades domain router to a new service offering", responseObject = DomainRouterResponse.class, entityType =
+@APICommand(name = "changeServiceForRouter", group = APICommandGroup.RouterService, description = "Upgrades domain router to a new service offering", responseObject = DomainRouterResponse.class, entityType =
         {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpgradeRouterCmd extends BaseCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/UpgradeRouterTemplateCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/router/UpgradeRouterTemplateCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.router;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -26,7 +27,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "upgradeRouterTemplate", description = "Upgrades router to use newer template", responseObject = BaseResponse.class,
+@APICommand(name = "upgradeRouterTemplate", group = APICommandGroup.TemplateService, description = "Upgrades router to use newer template", responseObject = BaseResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpgradeRouterTemplateCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpgradeRouterTemplateCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/AddImageStoreCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/AddImageStoreCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.storage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -20,7 +21,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addImageStore", description = "Adds backup image store.", responseObject = ImageStoreResponse.class, since = "4.2.0",
+@APICommand(name = "addImageStore", group = APICommandGroup.ImageStoreService, description = "Adds backup image store.", responseObject = ImageStoreResponse.class, since = "4.2.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AddImageStoreCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AddImageStoreCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/CancelPrimaryStorageMaintenanceCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/CancelPrimaryStorageMaintenanceCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.storage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -17,7 +18,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "cancelStorageMaintenance", description = "Cancels maintenance for primary storage", responseObject = StoragePoolResponse.class,
+@APICommand(name = "cancelStorageMaintenance", group = APICommandGroup.StoragePoolService, description = "Cancels maintenance for primary storage", responseObject = StoragePoolResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CancelPrimaryStorageMaintenanceCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CancelPrimaryStorageMaintenanceCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/CreateSecondaryStagingStoreCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/CreateSecondaryStagingStoreCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.storage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -17,7 +18,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createSecondaryStagingStore", description = "create secondary staging store.", responseObject = ImageStoreResponse.class,
+@APICommand(name = "createSecondaryStagingStore", group = APICommandGroup.ImageStoreService, description = "create secondary staging store.", responseObject = ImageStoreResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateSecondaryStagingStoreCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AddImageStoreCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/CreateStoragePoolCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/CreateStoragePoolCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.storage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -21,7 +22,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createStoragePool", description = "Creates a storage pool.", responseObject = StoragePoolResponse.class,
+@APICommand(name = "createStoragePool", group = APICommandGroup.StoragePoolService, description = "Creates a storage pool.", responseObject = StoragePoolResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateStoragePoolCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateStoragePoolCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/DeleteImageStoreCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/DeleteImageStoreCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.storage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteImageStore", description = "Deletes an image store or Secondary Storage.", responseObject = SuccessResponse.class, since = "4.2.0",
+@APICommand(name = "deleteImageStore", group = APICommandGroup.ImageStoreService, description = "Deletes an image store or Secondary Storage.", responseObject = SuccessResponse.class, since = "4.2.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteImageStoreCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteImageStoreCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/DeletePoolCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/DeletePoolCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.storage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -15,7 +16,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteStoragePool", description = "Deletes a storage pool.", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteStoragePool", group = APICommandGroup.StoragePoolService, description = "Deletes a storage pool.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeletePoolCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeletePoolCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/DeleteSecondaryStagingStoreCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/DeleteSecondaryStagingStoreCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.storage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteSecondaryStagingStore", description = "Deletes a secondary staging store .", responseObject = SuccessResponse.class, since = "4.2.0",
+@APICommand(name = "deleteSecondaryStagingStore", group = APICommandGroup.ImageStoreService, description = "Deletes a secondary staging store .", responseObject = SuccessResponse.class, since = "4.2.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteSecondaryStagingStoreCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteSecondaryStagingStoreCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/FindStoragePoolsForMigrationCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/FindStoragePoolsForMigrationCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.storage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
@@ -17,7 +18,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "findStoragePoolsForMigration", description = "Lists storage pools available for migration of a volume.", responseObject = StoragePoolResponse.class,
+@APICommand(name = "findStoragePoolsForMigration", group = APICommandGroup.StoragePoolService, description = "Lists storage pools available for migration of a volume.", responseObject = StoragePoolResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class FindStoragePoolsForMigrationCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(FindStoragePoolsForMigrationCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/ListImageStoresCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/ListImageStoresCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.storage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -11,7 +12,7 @@ import com.cloud.api.response.ZoneResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listImageStores", description = "Lists image stores.", responseObject = ImageStoreResponse.class, since = "4.2.0",
+@APICommand(name = "listImageStores", group = APICommandGroup.ImageStoreService, description = "Lists image stores.", responseObject = ImageStoreResponse.class, since = "4.2.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListImageStoresCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListImageStoresCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/ListSecondaryStagingStoresCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/ListSecondaryStagingStoresCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.storage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -11,7 +12,7 @@ import com.cloud.api.response.ZoneResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listSecondaryStagingStores", description = "Lists secondary staging stores.", responseObject = ImageStoreResponse.class, since = "4.2.0",
+@APICommand(name = "listSecondaryStagingStores", group = APICommandGroup.ImageStoreService, description = "Lists secondary staging stores.", responseObject = ImageStoreResponse.class, since = "4.2.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListSecondaryStagingStoresCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListSecondaryStagingStoresCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/ListStoragePoolsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/ListStoragePoolsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.storage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
@@ -14,7 +15,7 @@ import com.cloud.api.response.ZoneResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listStoragePools", description = "Lists storage pools.", responseObject = StoragePoolResponse.class,
+@APICommand(name = "listStoragePools", group = APICommandGroup.StoragePoolService, description = "Lists storage pools.", responseObject = StoragePoolResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListStoragePoolsCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListStoragePoolsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/ListStorageProvidersCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/ListStorageProvidersCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.storage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseListCmd;
@@ -19,7 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listStorageProviders", description = "Lists storage providers.", responseObject = StorageProviderResponse.class,
+@APICommand(name = "listStorageProviders", group = APICommandGroup.StoragePoolService, description = "Lists storage providers.", responseObject = StorageProviderResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListStorageProvidersCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListStorageProvidersCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/ListStorageTagsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/ListStorageTagsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.storage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.response.ListResponse;
@@ -9,7 +10,7 @@ import com.cloud.api.response.StorageTagResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listStorageTags", description = "Lists storage tags", responseObject = StorageTagResponse.class, requestHasSensitiveInfo = false, responseHasSensitiveInfo =
+@APICommand(name = "listStorageTags", group = APICommandGroup.ResourcetagsService, description = "Lists storage tags", responseObject = StorageTagResponse.class, requestHasSensitiveInfo = false, responseHasSensitiveInfo =
         false)
 public class ListStorageTagsCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListStorageTagsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/PreparePrimaryStorageForMaintenanceCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/PreparePrimaryStorageForMaintenanceCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.storage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -18,7 +19,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "enableStorageMaintenance", description = "Puts storage pool into maintenance state", responseObject = StoragePoolResponse.class,
+@APICommand(name = "enableStorageMaintenance", group = APICommandGroup.StoragePoolService, description = "Puts storage pool into maintenance state", responseObject = StoragePoolResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class PreparePrimaryStorageForMaintenanceCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(PreparePrimaryStorageForMaintenanceCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/UpdateStoragePoolCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/storage/UpdateStoragePoolCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.storage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -15,7 +16,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateStoragePool", description = "Updates a storage pool.", responseObject = StoragePoolResponse.class, since = "3.0.0",
+@APICommand(name = "updateStoragePool", group = APICommandGroup.StoragePoolService, description = "Updates a storage pool.", responseObject = StoragePoolResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateStoragePoolCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateStoragePoolCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/systemvm/DestroySystemVmCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/systemvm/DestroySystemVmCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.admin.systemvm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -18,7 +19,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "destroySystemVm", responseObject = SystemVmResponse.class, description = "Destroyes a system virtual machine.", entityType = {VirtualMachine.class},
+@APICommand(name = "destroySystemVm", group = APICommandGroup.SystemVMService, responseObject = SystemVmResponse.class, description = "Destroyes a system virtual machine.", entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DestroySystemVmCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DestroySystemVmCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/systemvm/ListSystemVMsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/systemvm/ListSystemVMsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.systemvm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
@@ -20,7 +21,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listSystemVms", description = "List system virtual machines.", responseObject = SystemVmResponse.class, entityType = {VirtualMachine.class},
+@APICommand(name = "listSystemVms", group = APICommandGroup.SystemVMService, description = "List system virtual machines.", responseObject = SystemVmResponse.class, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListSystemVMsCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListSystemVMsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/systemvm/MigrateSystemVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/systemvm/MigrateSystemVMCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.admin.systemvm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -24,7 +25,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "migrateSystemVm", description = "Attempts Migration of a system virtual machine to the host specified.", responseObject = SystemVmResponse.class, entityType
+@APICommand(name = "migrateSystemVm", group = APICommandGroup.SystemVMService, description = "Attempts Migration of a system virtual machine to the host specified.", responseObject = SystemVmResponse.class, entityType
         = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class MigrateSystemVMCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/systemvm/RebootSystemVmCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/systemvm/RebootSystemVmCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.admin.systemvm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -18,7 +19,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "rebootSystemVm", description = "Reboots a system VM.", responseObject = SystemVmResponse.class, entityType = {VirtualMachine.class},
+@APICommand(name = "rebootSystemVm", group = APICommandGroup.SystemVMService, description = "Reboots a system VM.", responseObject = SystemVmResponse.class, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RebootSystemVmCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(RebootSystemVmCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/systemvm/ScaleSystemVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/systemvm/ScaleSystemVMCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.admin.systemvm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -27,7 +28,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "scaleSystemVm", responseObject = SystemVmResponse.class, description = "Scale the service offering for a system vm (console proxy or secondary storage). "
+@APICommand(name = "scaleSystemVm", group = APICommandGroup.SystemVMService, responseObject = SystemVmResponse.class, description = "Scale the service offering for a system vm (console proxy or secondary storage). "
         + "The system vm must be in a \"Stopped\" state for " + "this command to take effect.", entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ScaleSystemVMCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/systemvm/StartSystemVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/systemvm/StartSystemVMCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.admin.systemvm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -18,7 +19,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "startSystemVm", responseObject = SystemVmResponse.class, description = "Starts a system virtual machine.", entityType = {VirtualMachine.class},
+@APICommand(name = "startSystemVm", group = APICommandGroup.SystemVMService, responseObject = SystemVmResponse.class, description = "Starts a system virtual machine.", entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class StartSystemVMCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(StartSystemVMCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/systemvm/StopSystemVmCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/systemvm/StopSystemVmCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.admin.systemvm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -20,7 +21,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "stopSystemVm", description = "Stops a system VM.", responseObject = SystemVmResponse.class, entityType = {VirtualMachine.class},
+@APICommand(name = "stopSystemVm", group = APICommandGroup.SystemVMService, description = "Stops a system VM.", responseObject = SystemVmResponse.class, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class StopSystemVmCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(StopSystemVmCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/systemvm/UpgradeSystemVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/systemvm/UpgradeSystemVMCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.admin.systemvm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -22,7 +23,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "changeServiceForSystemVm", responseObject = SystemVmResponse.class, description = "Changes the service offering for a system vm (console proxy or secondary " +
+@APICommand(name = "changeServiceForSystemVm", group = APICommandGroup.SystemVMService, responseObject = SystemVmResponse.class, description = "Changes the service offering for a system vm (console proxy or secondary " +
         "storage). "
         + "The system vm must be in a \"Stopped\" state for " + "this command to take effect.", entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/template/CopyTemplateCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/template/CopyTemplateCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.template;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -16,7 +17,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "copyTemplate", description = "Copies a template from one zone to another.", responseObject = TemplateResponse.class, responseView = ResponseView.Full,
+@APICommand(name = "copyTemplate", group = APICommandGroup.TemplateService, description = "Copies a template from one zone to another.", responseObject = TemplateResponse.class, responseView = ResponseView.Full,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CopyTemplateCmdByAdmin extends CopyTemplateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CopyTemplateCmdByAdmin.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/template/CreateTemplateCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/template/CreateTemplateCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.template;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -14,7 +15,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createTemplate", responseObject = TemplateResponse.class, description = "Creates a template of a virtual machine. " + "The virtual machine must be in a " +
+@APICommand(name = "createTemplate", group = APICommandGroup.TemplateService, responseObject = TemplateResponse.class, description = "Creates a template of a virtual machine. " + "The virtual machine must be in a " +
         "STOPPED state. "
         + "A template created from this command is automatically designated as a private template visible to the account that created it.", responseView = ResponseView.Full,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/template/ListTemplatePermissionsCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/template/ListTemplatePermissionsCmdByAdmin.java
@@ -17,11 +17,12 @@
 package com.cloud.api.command.admin.template;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.command.user.template.ListTemplatePermissionsCmd;
 import com.cloud.api.response.TemplatePermissionsResponse;
 
-@APICommand(name = "listTemplatePermissions", description = "List template visibility and all accounts that have permissions to view this template.", responseObject =
+@APICommand(name = "listTemplatePermissions", group = APICommandGroup.TemplateService, description = "List template visibility and all accounts that have permissions to view this template.", responseObject =
         TemplatePermissionsResponse.class, responseView = ResponseView.Full,
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = false)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/template/ListTemplatesCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/template/ListTemplatesCmdByAdmin.java
@@ -1,12 +1,13 @@
 package com.cloud.api.command.admin.template;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.command.user.template.ListTemplatesCmd;
 import com.cloud.api.response.TemplateResponse;
 import com.cloud.template.VirtualMachineTemplate;
 
-@APICommand(name = "listTemplates", description = "List all public, private, and privileged templates.", responseObject = TemplateResponse.class, entityType =
+@APICommand(name = "listTemplates", group = APICommandGroup.TemplateService, description = "List all public, private, and privileged templates.", responseObject = TemplateResponse.class, entityType =
         {VirtualMachineTemplate.class}, responseView = ResponseView.Full,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListTemplatesCmdByAdmin extends ListTemplatesCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/template/PrepareTemplateCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/template/PrepareTemplateCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.admin.template;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -19,7 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "prepareTemplate", responseObject = TemplateResponse.class, description = "load template into primary storage", entityType = {VirtualMachineTemplate.class},
+@APICommand(name = "prepareTemplate", group = APICommandGroup.TemplateService, responseObject = TemplateResponse.class, description = "load template into primary storage", entityType = {VirtualMachineTemplate.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class PrepareTemplateCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(PrepareTemplateCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/template/RegisterTemplateCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/template/RegisterTemplateCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.template;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -16,7 +17,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "registerTemplate", description = "Registers an existing template into the CloudStack cloud.", responseObject = TemplateResponse.class, responseView =
+@APICommand(name = "registerTemplate", group = APICommandGroup.TemplateService, description = "Registers an existing template into the CloudStack cloud.", responseObject = TemplateResponse.class, responseView =
         ResponseView.Full,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RegisterTemplateCmdByAdmin extends RegisterTemplateCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/template/UpdateTemplateCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/template/UpdateTemplateCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.template;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -11,7 +12,7 @@ import com.cloud.template.VirtualMachineTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateTemplate", description = "Updates attributes of a template.", responseObject = TemplateResponse.class, responseView = ResponseView.Full,
+@APICommand(name = "updateTemplate", group = APICommandGroup.TemplateService, description = "Updates attributes of a template.", responseObject = TemplateResponse.class, responseView = ResponseView.Full,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateTemplateCmdByAdmin extends UpdateTemplateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateTemplateCmdByAdmin.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/usage/AddTrafficTypeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/usage/AddTrafficTypeCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.usage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -18,7 +19,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addTrafficType", description = "Adds traffic type to a physical network", responseObject = TrafficTypeResponse.class, since = "3.0.0",
+@APICommand(name = "addTrafficType", group = APICommandGroup.UsageService, description = "Adds traffic type to a physical network", responseObject = TrafficTypeResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AddTrafficTypeCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AddTrafficTypeCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/usage/DeleteTrafficTypeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/usage/DeleteTrafficTypeCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.usage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -15,7 +16,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteTrafficType", description = "Deletes traffic type of a physical network", responseObject = SuccessResponse.class, since = "3.0.0",
+@APICommand(name = "deleteTrafficType", group = APICommandGroup.UsageService, description = "Deletes traffic type of a physical network", responseObject = SuccessResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteTrafficTypeCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteTrafficTypeCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/usage/ListTrafficTypesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/usage/ListTrafficTypesCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.usage;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -18,7 +19,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listTrafficTypes", description = "Lists traffic types of a given physical network.", responseObject = ProviderResponse.class, since = "3.0.0",
+@APICommand(name = "listTrafficTypes", group = APICommandGroup.UsageService, description = "Lists traffic types of a given physical network.", responseObject = ProviderResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListTrafficTypesCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListTrafficTypesCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/CreateUserCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/CreateUserCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.user;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -16,7 +17,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createUser", description = "Creates a user for an account that already exists", responseObject = UserResponse.class,
+@APICommand(name = "createUser", group = APICommandGroup.UserService, description = "Creates a user for an account that already exists", responseObject = UserResponse.class,
         requestHasSensitiveInfo = true, responseHasSensitiveInfo = true)
 public class CreateUserCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateUserCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/DeleteUserCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/DeleteUserCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.user;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -18,7 +19,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteUser", description = "Deletes a user for an account", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteUser", group = APICommandGroup.UserService, description = "Deletes a user for an account", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteUserCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteUserCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/DisableUserCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/DisableUserCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.user;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -20,7 +21,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "disableUser", description = "Disables a user account", responseObject = UserResponse.class,
+@APICommand(name = "disableUser", group = APICommandGroup.UserService, description = "Disables a user account", responseObject = UserResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class DisableUserCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DisableUserCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/EnableUserCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/EnableUserCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.user;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -18,7 +19,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "enableUser", description = "Enables a user account", responseObject = UserResponse.class,
+@APICommand(name = "enableUser", group = APICommandGroup.UserService, description = "Enables a user account", responseObject = UserResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class EnableUserCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(EnableUserCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/GetUserCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/GetUserCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.user;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -12,7 +13,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "getUser", description = "Find user account by API key", responseObject = UserResponse.class,
+@APICommand(name = "getUser", group = APICommandGroup.UserService, description = "Find user account by API key", responseObject = UserResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class GetUserCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(GetUserCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/ListUsersCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/ListUsersCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.user;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -13,7 +14,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listUsers", description = "Lists user accounts", responseObject = UserResponse.class,
+@APICommand(name = "listUsers", group = APICommandGroup.UserService, description = "Lists user accounts", responseObject = UserResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class ListUsersCmd extends BaseListAccountResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListUsersCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/LockUserCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/LockUserCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.user;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -14,7 +15,7 @@ import com.cloud.user.UserAccount;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "lockUser", description = "Locks a user account", responseObject = UserResponse.class,
+@APICommand(name = "lockUser", group = APICommandGroup.UserService, description = "Locks a user account", responseObject = UserResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class LockUserCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(LockUserCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/RegisterCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/RegisterCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.user;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -12,7 +13,7 @@ import com.cloud.user.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "registerUserKeys",
+@APICommand(name = "registerUserKeys", group = APICommandGroup.UserService,
         responseObject = RegisterResponse.class,
         description = "This command allows a user to register for the developer API, returning a secret key and an API key. This request is made through the integration API " +
                 "port, so it is a privileged command and must be made on behalf of a user. It is up to the implementer just how the username and password are entered, and then " +

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/UpdateUserCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/user/UpdateUserCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.user;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -18,7 +19,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateUser", description = "Updates a user account", responseObject = UserResponse.class,
+@APICommand(name = "updateUser", group = APICommandGroup.UserService, description = "Updates a user account", responseObject = UserResponse.class,
         requestHasSensitiveInfo = true, responseHasSensitiveInfo = true)
 public class UpdateUserCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateUserCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vlan/CreateVlanIpRangeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vlan/CreateVlanIpRangeCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vlan;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -24,7 +25,7 @@ import com.cloud.utils.net.NetUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createVlanIpRange", description = "Creates a VLAN IP range.", responseObject = VlanIpRangeResponse.class,
+@APICommand(name = "createVlanIpRange", group = APICommandGroup.VLANService, description = "Creates a VLAN IP range.", responseObject = VlanIpRangeResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateVlanIpRangeCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateVlanIpRangeCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vlan/DedicatePublicIpRangeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vlan/DedicatePublicIpRangeCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vlan;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -17,7 +18,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "dedicatePublicIpRange", description = "Dedicates a Public IP range to an account", responseObject = VlanIpRangeResponse.class,
+@APICommand(name = "dedicatePublicIpRange", group = APICommandGroup.NetworkService, description = "Dedicates a Public IP range to an account", responseObject = VlanIpRangeResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DedicatePublicIpRangeCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DedicatePublicIpRangeCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vlan/DeleteVlanIpRangeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vlan/DeleteVlanIpRangeCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vlan;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteVlanIpRange", description = "Creates a VLAN IP range.", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteVlanIpRange", group = APICommandGroup.VLANService, description = "Creates a VLAN IP range.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteVlanIpRangeCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteVlanIpRangeCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vlan/ListVlanIpRangesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vlan/ListVlanIpRangesCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vlan;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -21,7 +22,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listVlanIpRanges", description = "Lists all VLAN IP ranges.", responseObject = VlanIpRangeResponse.class,
+@APICommand(name = "listVlanIpRanges", group = APICommandGroup.VLANService, description = "Lists all VLAN IP ranges.", responseObject = VlanIpRangeResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListVlanIpRangesCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListVlanIpRangesCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vlan/ReleasePublicIpRangeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vlan/ReleasePublicIpRangeCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vlan;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "releasePublicIpRange", description = "Releases a Public IP range back to the system pool", responseObject = SuccessResponse.class,
+@APICommand(name = "releasePublicIpRange", group = APICommandGroup.NetworkService, description = "Releases a Public IP range back to the system pool", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ReleasePublicIpRangeCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ReleasePublicIpRangeCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/AddNicToVMCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/AddNicToVMCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants.VMDetails;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
@@ -17,7 +18,7 @@ import java.util.EnumSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addNicToVirtualMachine", description = "Adds VM to specified network by creating a NIC", responseObject = UserVmResponse.class, responseView = ResponseView
+@APICommand(name = "addNicToVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Adds VM to specified network by creating a NIC", responseObject = UserVmResponse.class, responseView = ResponseView
         .Full, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class AddNicToVMCmdByAdmin extends AddNicToVMCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/AssignVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/AssignVMCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -20,7 +21,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "assignVirtualMachine",
+@APICommand(name = "assignVirtualMachine", group = APICommandGroup.VirtualMachineService,
         description = "Change ownership of a VM from one account to another. This API is available for Basic zones with security groups and Advanced zones with guest networks. A" +
                 " root administrator can reassign a VM from any account to any other account in any domain. A domain administrator can reassign a VM to any account in the same " +
                 "domain.",

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/DeployVMCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/DeployVMCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -17,7 +18,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deployVirtualMachine", description = "Creates and automatically starts a virtual machine based on a service offering, disk offering, and template.",
+@APICommand(name = "deployVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Creates and automatically starts a virtual machine based on a service offering, disk offering, and template.",
         responseObject = UserVmResponse.class, responseView = ResponseView.Full, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class DeployVMCmdByAdmin extends DeployVMCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/DestroyVMCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/DestroyVMCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -17,7 +18,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "destroyVirtualMachine", description = "Destroys a virtual machine. Once destroyed, only the administrator can recover it.", responseObject = UserVmResponse
+@APICommand(name = "destroyVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Destroys a virtual machine. Once destroyed, only the administrator can recover it.", responseObject = UserVmResponse
         .class, responseView = ResponseView.Full, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = true)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/ExpungeVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/ExpungeVMCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.admin.vm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -24,7 +25,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "expungeVirtualMachine", description = "Expunge a virtual machine. Once expunged, it cannot be recoverd.", responseObject = SuccessResponse.class, entityType
+@APICommand(name = "expungeVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Expunge a virtual machine. Once expunged, it cannot be recoverd.", responseObject = SuccessResponse.class, entityType
         = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ExpungeVMCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/GetVMUserDataCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/GetVMUserDataCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -12,7 +13,7 @@ import com.cloud.uservm.UserVm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "getVirtualMachineUserData", description = "Returns user data associated with the VM", responseObject = VMUserDataResponse.class, since = "4.4",
+@APICommand(name = "getVirtualMachineUserData", group = APICommandGroup.UserService, description = "Returns user data associated with the VM", responseObject = VMUserDataResponse.class, since = "4.4",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class GetVMUserDataCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(GetVMUserDataCmd.class);

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/ListVMsCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/ListVMsCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.Parameter;
 import com.cloud.api.ResponseObject.ResponseView;
@@ -14,7 +15,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listVirtualMachines", description = "List the virtual machines owned by the account.", responseObject = UserVmResponse.class, responseView = ResponseView
+@APICommand(name = "listVirtualMachines", group = APICommandGroup.VirtualMachineService, description = "List the virtual machines owned by the account.", responseObject = UserVmResponse.class, responseView = ResponseView
         .Full, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class ListVMsCmdByAdmin extends ListVMsCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/MigrateVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/MigrateVMCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -26,7 +27,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "migrateVirtualMachine",
+@APICommand(name = "migrateVirtualMachine", group = APICommandGroup.VirtualMachineService,
         description = "Attempts Migration of a VM to a different host or Root volume of the vm to a different storage pool",
         responseObject = UserVmResponse.class, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false,

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/MigrateVirtualMachineWithVolumeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/MigrateVirtualMachineWithVolumeCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -27,7 +28,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "migrateVirtualMachineWithVolume",
+@APICommand(name = "migrateVirtualMachineWithVolume", group = APICommandGroup.VirtualMachineService,
         description = "Attempts Migration of a VM with its volumes to a different host",
         responseObject = UserVmResponse.class, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false,

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/RebootVMCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/RebootVMCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -15,7 +16,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "rebootVirtualMachine", description = "Reboots a virtual machine.", responseObject = UserVmResponse.class, responseView = ResponseView.Full, entityType =
+@APICommand(name = "rebootVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Reboots a virtual machine.", responseObject = UserVmResponse.class, responseView = ResponseView.Full, entityType =
         {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class RebootVMCmdByAdmin extends RebootVMCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/RecoverVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/RecoverVMCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -16,7 +17,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "recoverVirtualMachine", description = "Recovers a virtual machine.", responseObject = UserVmResponse.class, entityType = {VirtualMachine.class},
+@APICommand(name = "recoverVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Recovers a virtual machine.", responseObject = UserVmResponse.class, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class RecoverVMCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(RecoverVMCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/RemoveNicFromVMCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/RemoveNicFromVMCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants.VMDetails;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
@@ -17,7 +18,7 @@ import java.util.EnumSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "removeNicFromVirtualMachine", description = "Removes VM from specified network by deleting a NIC", responseObject = UserVmResponse.class, responseView =
+@APICommand(name = "removeNicFromVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Removes VM from specified network by deleting a NIC", responseObject = UserVmResponse.class, responseView =
         ResponseView.Full, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class RemoveNicFromVMCmdByAdmin extends RemoveNicFromVMCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/ResetVMPasswordCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/ResetVMPasswordCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -15,7 +16,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "resetPasswordForVirtualMachine", responseObject = UserVmResponse.class, description = "Resets the password for virtual machine. " +
+@APICommand(name = "resetPasswordForVirtualMachine", group = APICommandGroup.VirtualMachineService, responseObject = UserVmResponse.class, description = "Resets the password for virtual machine. " +
         "The virtual machine must be in a \"Stopped\" state and the template must already " +
         "support this feature for this command to take effect. [async]", responseView = ResponseView.Full, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/ResetVMSSHKeyCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/ResetVMSSHKeyCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -15,7 +16,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "resetSSHKeyForVirtualMachine", responseObject = UserVmResponse.class, description = "Resets the SSH Key for virtual machine. " +
+@APICommand(name = "resetSSHKeyForVirtualMachine", group = APICommandGroup.SSHService, responseObject = UserVmResponse.class, description = "Resets the SSH Key for virtual machine. " +
         "The virtual machine must be in a \"Stopped\" state. [async]", responseView = ResponseView.Full, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class ResetVMSSHKeyCmdByAdmin extends ResetVMSSHKeyCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/RestoreVMCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/RestoreVMCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -17,7 +18,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "restoreVirtualMachine", description = "Restore a VM to original template/ISO or new template/ISO", responseObject = UserVmResponse.class, since = "3.0.0",
+@APICommand(name = "restoreVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Restore a VM to original template/ISO or new template/ISO", responseObject = UserVmResponse.class, since = "3.0.0",
         responseView = ResponseView.Full, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = true)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/ScaleVMCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/ScaleVMCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -19,7 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "scaleVirtualMachine", description = "Scales the virtual machine to a new service offering.", responseObject = SuccessResponse.class, responseView =
+@APICommand(name = "scaleVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Scales the virtual machine to a new service offering.", responseObject = SuccessResponse.class, responseView =
         ResponseView.Full, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ScaleVMCmdByAdmin extends ScaleVMCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/StartVMCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/StartVMCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -20,7 +21,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "startVirtualMachine", responseObject = UserVmResponse.class, description = "Starts a virtual machine.", responseView = ResponseView.Full, entityType =
+@APICommand(name = "startVirtualMachine", group = APICommandGroup.VirtualMachineService, responseObject = UserVmResponse.class, description = "Starts a virtual machine.", responseView = ResponseView.Full, entityType =
         {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class StartVMCmdByAdmin extends StartVMCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/StopVMCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/StopVMCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -14,7 +15,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "stopVirtualMachine", responseObject = UserVmResponse.class, description = "Stops a virtual machine.", responseView = ResponseView.Full, entityType =
+@APICommand(name = "stopVirtualMachine", group = APICommandGroup.VirtualMachineService, responseObject = UserVmResponse.class, description = "Stops a virtual machine.", responseView = ResponseView.Full, entityType =
         {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class StopVMCmdByAdmin extends StopVMCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/UpdateDefaultNicForVMCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/UpdateDefaultNicForVMCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants.VMDetails;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
@@ -17,7 +18,7 @@ import java.util.EnumSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateDefaultNicForVirtualMachine", description = "Changes the default NIC on a VM", responseObject = UserVmResponse.class, responseView = ResponseView.Full,
+@APICommand(name = "updateDefaultNicForVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Changes the default NIC on a VM", responseObject = UserVmResponse.class, responseView = ResponseView.Full,
         entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class UpdateDefaultNicForVMCmdByAdmin extends UpdateDefaultNicForVMCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/UpdateVMCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/UpdateVMCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -15,7 +16,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateVirtualMachine", description = "Updates properties of a virtual machine. The VM has to be stopped and restarted for the " +
+@APICommand(name = "updateVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Updates properties of a virtual machine. The VM has to be stopped and restarted for the " +
         "new properties to take effect. UpdateVirtualMachine does not first check whether the VM is stopped. " +
         "Therefore, stop the VM manually before issuing this call.", responseObject = UserVmResponse.class, responseView = ResponseView.Full, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/UpgradeVMCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vm/UpgradeVMCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -16,7 +17,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "changeServiceForVirtualMachine", responseObject = UserVmResponse.class, description = "Changes the service offering for a virtual machine. " +
+@APICommand(name = "changeServiceForVirtualMachine", group = APICommandGroup.VirtualMachineService, responseObject = UserVmResponse.class, description = "Changes the service offering for a virtual machine. " +
         "The virtual machine must be in a \"Stopped\" state for " +
         "this command to take effect.", responseView = ResponseView.Full, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vmsnapshot/RevertToVMSnapshotCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vmsnapshot/RevertToVMSnapshotCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vmsnapshot;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -16,7 +17,7 @@ import com.cloud.uservm.UserVm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "revertToVMSnapshot", description = "Revert VM from a vmsnapshot.", responseObject = UserVmResponse.class, since = "4.2.0", responseView = ResponseView.Full,
+@APICommand(name = "revertToVMSnapshot", group = APICommandGroup.SnapshotService, description = "Revert VM from a vmsnapshot.", responseObject = UserVmResponse.class, since = "4.2.0", responseView = ResponseView.Full,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class RevertToVMSnapshotCmdByAdmin extends RevertToVMSnapshotCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(RevertToVMSnapshotCmdByAdmin.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/AttachVolumeCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/AttachVolumeCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.volume;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -13,7 +14,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "attachVolume", description = "Attaches a disk volume to a virtual machine.", responseObject = VolumeResponse.class, responseView = ResponseView.Full,
+@APICommand(name = "attachVolume", group = APICommandGroup.VolumeService, description = "Attaches a disk volume to a virtual machine.", responseObject = VolumeResponse.class, responseView = ResponseView.Full,
         entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AttachVolumeCmdByAdmin extends AttachVolumeCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/CreateVolumeCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/CreateVolumeCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.volume;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -14,7 +15,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createVolume", responseObject = VolumeResponse.class, description = "Creates a disk volume from a disk offering. This disk volume must still be attached to a" +
+@APICommand(name = "createVolume", group = APICommandGroup.VolumeService, responseObject = VolumeResponse.class, description = "Creates a disk volume from a disk offering. This disk volume must still be attached to a" +
         " virtual machine to make use of it.", responseView = ResponseView.Full, entityType = {
         Volume.class, VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/DetachVolumeCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/DetachVolumeCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.volume;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -13,7 +14,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "detachVolume", description = "Detaches a disk volume from a virtual machine.", responseObject = VolumeResponse.class, responseView = ResponseView.Full,
+@APICommand(name = "detachVolume", group = APICommandGroup.VolumeService, description = "Detaches a disk volume from a virtual machine.", responseObject = VolumeResponse.class, responseView = ResponseView.Full,
         entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DetachVolumeCmdByAdmin extends DetachVolumeCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/ListVolumesCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/ListVolumesCmdByAdmin.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.admin.volume;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.Parameter;
 import com.cloud.api.ResponseObject.ResponseView;
@@ -14,7 +15,7 @@ import com.cloud.storage.Volume;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listVolumes", description = "Lists all volumes.", responseObject = VolumeResponse.class, responseView = ResponseView.Full, entityType = {Volume.class},
+@APICommand(name = "listVolumes", group = APICommandGroup.VolumeService, description = "Lists all volumes.", responseObject = VolumeResponse.class, responseView = ResponseView.Full, entityType = {Volume.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListVolumesCmdByAdmin extends ListVolumesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListVolumesCmdByAdmin.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/MigrateVolumeCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/MigrateVolumeCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.volume;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -8,7 +9,7 @@ import com.cloud.api.command.user.volume.MigrateVolumeCmd;
 import com.cloud.api.response.VolumeResponse;
 import com.cloud.storage.Volume;
 
-@APICommand(name = "migrateVolume", description = "Migrate volume", responseObject = VolumeResponse.class, since = "3.0.0", responseView = ResponseView.Full, entityType =
+@APICommand(name = "migrateVolume", group = APICommandGroup.VolumeService, description = "Migrate volume", responseObject = VolumeResponse.class, since = "3.0.0", responseView = ResponseView.Full, entityType =
         {Volume.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class MigrateVolumeCmdByAdmin extends MigrateVolumeCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/ResizeVolumeCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/ResizeVolumeCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.volume;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -11,7 +12,7 @@ import com.cloud.exception.ResourceAllocationException;
 import com.cloud.storage.Volume;
 import com.cloud.utils.exception.InvalidParameterValueException;
 
-@APICommand(name = "resizeVolume", description = "Resizes a volume", responseObject = VolumeResponse.class, responseView = ResponseView.Full, entityType = {Volume.class},
+@APICommand(name = "resizeVolume", group = APICommandGroup.VolumeService, description = "Resizes a volume", responseObject = VolumeResponse.class, responseView = ResponseView.Full, entityType = {Volume.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ResizeVolumeCmdByAdmin extends ResizeVolumeCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/UpdateVolumeCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/UpdateVolumeCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.volume;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -9,7 +10,7 @@ import com.cloud.api.response.VolumeResponse;
 import com.cloud.context.CallContext;
 import com.cloud.storage.Volume;
 
-@APICommand(name = "updateVolume", description = "Updates the volume.", responseObject = VolumeResponse.class, responseView = ResponseView.Full, entityType = {Volume.class},
+@APICommand(name = "updateVolume", group = APICommandGroup.VolumeService, description = "Updates the volume.", responseObject = VolumeResponse.class, responseView = ResponseView.Full, entityType = {Volume.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateVolumeCmdByAdmin extends UpdateVolumeCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/UploadVolumeCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/UploadVolumeCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.volume;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -16,7 +17,7 @@ import com.cloud.storage.Volume;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "uploadVolume", description = "Uploads a data disk.", responseObject = VolumeResponse.class, responseView = ResponseView.Full, entityType = {Volume.class},
+@APICommand(name = "uploadVolume", group = APICommandGroup.VolumeService, description = "Uploads a data disk.", responseObject = VolumeResponse.class, responseView = ResponseView.Full, entityType = {Volume.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UploadVolumeCmdByAdmin extends UploadVolumeCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UploadVolumeCmdByAdmin.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/CreatePrivateGatewayCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/CreatePrivateGatewayCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vpc;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -27,7 +28,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createPrivateGateway", description = "Creates a private gateway", responseObject = PrivateGatewayResponse.class, entityType = {VpcGateway.class},
+@APICommand(name = "createPrivateGateway", group = APICommandGroup.VPCService, description = "Creates a private gateway", responseObject = PrivateGatewayResponse.class, entityType = {VpcGateway.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreatePrivateGatewayCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreatePrivateGatewayCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/CreateVPCCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/CreateVPCCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vpc;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
@@ -15,7 +16,7 @@ import com.cloud.network.vpc.Vpc;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createVPC", description = "Creates a VPC", responseObject = VpcResponse.class, responseView = ResponseView.Full, entityType = {Vpc.class},
+@APICommand(name = "createVPC", group = APICommandGroup.VPCService, description = "Creates a VPC", responseObject = VpcResponse.class, responseView = ResponseView.Full, entityType = {Vpc.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateVPCCmdByAdmin extends CreateVPCCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateVPCCmdByAdmin.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/CreateVPCOfferingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/CreateVPCOfferingCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vpc;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCreateCmd;
@@ -23,7 +24,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createVPCOffering", description = "Creates VPC offering", responseObject = VpcOfferingResponse.class,
+@APICommand(name = "createVPCOffering", group = APICommandGroup.VPCService, description = "Creates VPC offering", responseObject = VpcOfferingResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateVPCOfferingCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateVPCOfferingCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/DeletePrivateGatewayCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/DeletePrivateGatewayCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vpc;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -20,7 +21,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deletePrivateGateway", description = "Deletes a Private gateway", responseObject = SuccessResponse.class, entityType = {VpcGateway.class},
+@APICommand(name = "deletePrivateGateway", group = APICommandGroup.VPCService, description = "Deletes a Private gateway", responseObject = SuccessResponse.class, entityType = {VpcGateway.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeletePrivateGatewayCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeletePrivateGatewayCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/DeleteVPCOfferingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/DeleteVPCOfferingCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vpc;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -14,7 +15,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteVPCOffering", description = "Deletes VPC offering", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteVPCOffering", group = APICommandGroup.VPCService, description = "Deletes VPC offering", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteVPCOfferingCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteVPCOfferingCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/ListVPCsCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/ListVPCsCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vpc;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.command.user.vpc.ListVPCsCmd;
 import com.cloud.api.response.ListResponse;
@@ -14,7 +15,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listVPCs", description = "Lists VPCs", responseObject = VpcResponse.class, responseView = ResponseView.Full, entityType = {Vpc.class},
+@APICommand(name = "listVPCs", group = APICommandGroup.VPCService, description = "Lists VPCs", responseObject = VpcResponse.class, responseView = ResponseView.Full, entityType = {Vpc.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListVPCsCmdByAdmin extends ListVPCsCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListVPCsCmdByAdmin.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/UpdateVPCCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/UpdateVPCCmdByAdmin.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vpc;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.ServerApiException;
@@ -11,7 +12,7 @@ import com.cloud.network.vpc.Vpc;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateVPC", description = "Updates a VPC", responseObject = VpcResponse.class, responseView = ResponseView.Full, entityType = {Vpc.class},
+@APICommand(name = "updateVPC", group = APICommandGroup.VPCService, description = "Updates a VPC", responseObject = VpcResponse.class, responseView = ResponseView.Full, entityType = {Vpc.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateVPCCmdByAdmin extends UpdateVPCCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateVPCCmdByAdmin.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/UpdateVPCOfferingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/UpdateVPCOfferingCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.vpc;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -14,7 +15,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateVPCOffering", description = "Updates VPC offering", responseObject = VpcOfferingResponse.class,
+@APICommand(name = "updateVPCOffering", group = APICommandGroup.VPCService, description = "Updates VPC offering", responseObject = VpcOfferingResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateVPCOfferingCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateVPCOfferingCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/zone/CreateZoneCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/zone/CreateZoneCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.zone;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createZone", description = "Creates a Zone.", responseObject = ZoneResponse.class,
+@APICommand(name = "createZone", group = APICommandGroup.ZoneService, description = "Creates a Zone.", responseObject = ZoneResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateZoneCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateZoneCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/zone/DeleteZoneCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/zone/DeleteZoneCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.zone;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -14,7 +15,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteZone", description = "Deletes a Zone.", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteZone", group = APICommandGroup.ZoneService, description = "Deletes a Zone.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteZoneCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteZoneCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/zone/ListZonesCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/zone/ListZonesCmdByAdmin.java
@@ -1,11 +1,12 @@
 package com.cloud.api.command.admin.zone;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.command.user.zone.ListZonesCmd;
 import com.cloud.api.response.ZoneResponse;
 
-@APICommand(name = "listZones", description = "Lists zones", responseObject = ZoneResponse.class, responseView = ResponseView.Full,
+@APICommand(name = "listZones", group = APICommandGroup.ZoneService, description = "Lists zones", responseObject = ZoneResponse.class, responseView = ResponseView.Full,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListZonesCmdByAdmin extends ListZonesCmd {
 }

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/zone/MarkDefaultZoneForAccountCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/zone/MarkDefaultZoneForAccountCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.zone;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -17,7 +18,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "markDefaultZoneForAccount", description = "Marks a default zone for this account", responseObject = AccountResponse.class, since = "4.0",
+@APICommand(name = "markDefaultZoneForAccount", group = APICommandGroup.AccountService, description = "Marks a default zone for this account", responseObject = AccountResponse.class, since = "4.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class MarkDefaultZoneForAccountCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(MarkDefaultZoneForAccountCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/zone/UpdateZoneCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/zone/UpdateZoneCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.admin.zone;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -18,7 +19,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateZone", description = "Updates a Zone.", responseObject = ZoneResponse.class,
+@APICommand(name = "updateZone", group = APICommandGroup.ZoneService, description = "Updates a Zone.", responseObject = ZoneResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateZoneCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateZoneCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/account/AddAccountToProjectCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/account/AddAccountToProjectCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.account;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -16,7 +17,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addAccountToProject", description = "Adds account to a project", responseObject = SuccessResponse.class, since = "3.0.0",
+@APICommand(name = "addAccountToProject", group = APICommandGroup.AccountService, description = "Adds account to a project", responseObject = SuccessResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AddAccountToProjectCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AddAccountToProjectCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/account/DeleteAccountFromProjectCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/account/DeleteAccountFromProjectCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.account;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -17,7 +18,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteAccountFromProject", description = "Deletes account from the project", responseObject = SuccessResponse.class, since = "3.0.0",
+@APICommand(name = "deleteAccountFromProject", group = APICommandGroup.AccountService, description = "Deletes account from the project", responseObject = SuccessResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteAccountFromProjectCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteProjectCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/account/ListAccountsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/account/ListAccountsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.account;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListDomainResourcesCmd;
 import com.cloud.api.Parameter;
@@ -12,7 +13,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listAccounts", description = "Lists accounts and provides detailed account information for listed accounts", responseObject = AccountResponse.class,
+@APICommand(name = "listAccounts", group = APICommandGroup.AccountService, description = "Lists accounts and provides detailed account information for listed accounts", responseObject = AccountResponse.class,
         responseView = ResponseView.Restricted, entityType = {Account.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class ListAccountsCmd extends BaseListDomainResourcesCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/account/ListProjectAccountsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/account/ListProjectAccountsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.account;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -12,7 +13,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listProjectAccounts", description = "Lists project's accounts", responseObject = ProjectResponse.class, since = "3.0.0",
+@APICommand(name = "listProjectAccounts", group = APICommandGroup.AccountService, description = "Lists project's accounts", responseObject = ProjectResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListProjectAccountsCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListProjectAccountsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/address/AssociateIPAddrCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/address/AssociateIPAddrCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.address;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -39,7 +40,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "associateIpAddress", description = "Acquires and associates a public IP to an account.", responseObject = IPAddressResponse.class, responseView =
+@APICommand(name = "associateIpAddress", group = APICommandGroup.PublicIPAddressService, description = "Acquires and associates a public IP to an account.", responseObject = IPAddressResponse.class, responseView =
         ResponseView.Restricted,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AssociateIPAddrCmd extends BaseAsyncCreateCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/address/DisassociateIPAddrCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/address/DisassociateIPAddrCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.address;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -20,7 +21,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "disassociateIpAddress", description = "Disassociates an IP address from the account.", responseObject = SuccessResponse.class,
+@APICommand(name = "disassociateIpAddress", group = APICommandGroup.PublicIPAddressService, description = "Disassociates an IP address from the account.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, entityType = {IpAddress.class})
 public class DisassociateIPAddrCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DisassociateIPAddrCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/address/ListPublicIpAddressesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/address/ListPublicIpAddressesCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.address;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListTaggedResourcesCmd;
@@ -23,7 +24,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listPublicIpAddresses", description = "Lists all public IP addresses", responseObject = IPAddressResponse.class, responseView = ResponseView.Restricted,
+@APICommand(name = "listPublicIpAddresses", group = APICommandGroup.PublicIPAddressService, description = "Lists all public IP addresses", responseObject = IPAddressResponse.class, responseView = ResponseView.Restricted,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, entityType = {IpAddress.class})
 public class ListPublicIpAddressesCmd extends BaseListTaggedResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListPublicIpAddressesCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/address/UpdateIPAddrCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/address/UpdateIPAddrCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.address;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseAsyncCustomIdCmd;
 import com.cloud.api.Parameter;
@@ -22,7 +23,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateIpAddress", description = "Updates an IP address", responseObject = IPAddressResponse.class,
+@APICommand(name = "updateIpAddress", group = APICommandGroup.PublicIPAddressService, description = "Updates an IP address", responseObject = IPAddressResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, entityType = {IpAddress.class})
 public class UpdateIPAddrCmd extends BaseAsyncCustomIdCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateIPAddrCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/affinitygroup/CreateAffinityGroupCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/affinitygroup/CreateAffinityGroupCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.affinitygroup;
 import com.cloud.affinity.AffinityGroup;
 import com.cloud.affinity.AffinityGroupResponse;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -19,7 +20,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createAffinityGroup", responseObject = AffinityGroupResponse.class, description = "Creates an affinity/anti-affinity group", entityType = {AffinityGroup.class},
+@APICommand(name = "createAffinityGroup", group = APICommandGroup.AffinityGroupService, responseObject = AffinityGroupResponse.class, description = "Creates an affinity/anti-affinity group", entityType = {AffinityGroup.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateAffinityGroupCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateAffinityGroupCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/affinitygroup/DeleteAffinityGroupCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/affinitygroup/DeleteAffinityGroupCmd.java
@@ -5,6 +5,7 @@ import com.cloud.affinity.AffinityGroup;
 import com.cloud.affinity.AffinityGroupResponse;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -21,7 +22,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteAffinityGroup", description = "Deletes affinity group", responseObject = SuccessResponse.class, entityType = {AffinityGroup.class},
+@APICommand(name = "deleteAffinityGroup", group = APICommandGroup.AffinityGroupService, description = "Deletes affinity group", responseObject = SuccessResponse.class, entityType = {AffinityGroup.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteAffinityGroupCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteAffinityGroupCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/affinitygroup/ListAffinityGroupTypesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/affinitygroup/ListAffinityGroupTypesCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.affinitygroup;
 
 import com.cloud.affinity.AffinityGroupTypeResponse;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.response.ListResponse;
 import com.cloud.user.Account;
@@ -12,7 +13,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listAffinityGroupTypes", description = "Lists affinity group types available", responseObject = AffinityGroupTypeResponse.class,
+@APICommand(name = "listAffinityGroupTypes", group = APICommandGroup.AffinityGroupService, description = "Lists affinity group types available", responseObject = AffinityGroupTypeResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListAffinityGroupTypesCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListAffinityGroupTypesCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/affinitygroup/ListAffinityGroupsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/affinitygroup/ListAffinityGroupsCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.affinitygroup;
 import com.cloud.affinity.AffinityGroup;
 import com.cloud.affinity.AffinityGroupResponse;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListProjectAndAccountResourcesCmd;
@@ -13,7 +14,7 @@ import com.cloud.api.response.UserVmResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listAffinityGroups", description = "Lists affinity groups", responseObject = AffinityGroupResponse.class, entityType = {AffinityGroup.class},
+@APICommand(name = "listAffinityGroups", group = APICommandGroup.AffinityGroupService, description = "Lists affinity groups", responseObject = AffinityGroupResponse.class, entityType = {AffinityGroup.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListAffinityGroupsCmd extends BaseListProjectAndAccountResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListAffinityGroupsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/affinitygroup/UpdateVMAffinityGroupCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/affinitygroup/UpdateVMAffinityGroupCmd.java
@@ -4,6 +4,7 @@ import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.affinity.AffinityGroupResponse;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiConstants.VMDetails;
@@ -29,7 +30,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateVMAffinityGroup",
+@APICommand(name = "updateVMAffinityGroup", group = APICommandGroup.AffinityGroupService,
         description = "Updates the affinity/anti-affinity group associations of a virtual machine. The VM has to be stopped and restarted for the "
                 + "new properties to take effect.",
         responseObject = UserVmResponse.class,

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/config/ListCapabilitiesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/config/ListCapabilitiesCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.config;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.response.CapabilitiesResponse;
 import com.cloud.user.Account;
@@ -10,7 +11,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listCapabilities", description = "Lists capabilities", responseObject = CapabilitiesResponse.class,
+@APICommand(name = "listCapabilities", group = APICommandGroup.ConfigurationService, description = "Lists capabilities", responseObject = CapabilitiesResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListCapabilitiesCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListCapabilitiesCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/event/ArchiveEventsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/event/ArchiveEventsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.event;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -19,7 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "archiveEvents", description = "Archive one or more events.", responseObject = SuccessResponse.class, entityType = {Event.class},
+@APICommand(name = "archiveEvents", group = APICommandGroup.EventService, description = "Archive one or more events.", responseObject = SuccessResponse.class, entityType = {Event.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ArchiveEventsCmd extends BaseCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/event/DeleteEventsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/event/DeleteEventsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.event;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -19,7 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteEvents", description = "Delete one or more events.", responseObject = SuccessResponse.class, entityType = {Event.class},
+@APICommand(name = "deleteEvents", group = APICommandGroup.EventService, description = "Delete one or more events.", responseObject = SuccessResponse.class, entityType = {Event.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteEventsCmd extends BaseCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/event/ListEventTypesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/event/ListEventTypesCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.event;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.response.EventTypeResponse;
 import com.cloud.api.response.ListResponse;
@@ -11,7 +12,7 @@ import java.util.ArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listEventTypes", description = "List Event Types", responseObject = EventTypeResponse.class,
+@APICommand(name = "listEventTypes", group = APICommandGroup.EventService, description = "List Event Types", responseObject = EventTypeResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListEventTypesCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListEventTypesCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/event/ListEventsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/event/ListEventsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.event;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListProjectAndAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -13,7 +14,7 @@ import java.util.Date;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listEvents", description = "A command to list events.", responseObject = EventResponse.class, entityType = {Event.class},
+@APICommand(name = "listEvents", group = APICommandGroup.EventService, description = "A command to list events.", responseObject = EventResponse.class, entityType = {Event.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListEventsCmd extends BaseListProjectAndAccountResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListEventsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/CreateEgressFirewallRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/CreateEgressFirewallRuleCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.firewall;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -27,7 +28,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createEgressFirewallRule", description = "Creates a egress firewall rule for a given network ", responseObject = FirewallResponse.class, entityType =
+@APICommand(name = "createEgressFirewallRule", group = APICommandGroup.FirewallService, description = "Creates a egress firewall rule for a given network ", responseObject = FirewallResponse.class, entityType =
         {FirewallRule.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateEgressFirewallRuleCmd extends BaseAsyncCreateCmd implements FirewallRule {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/CreateFirewallRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/CreateFirewallRuleCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.firewall;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -27,7 +28,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createFirewallRule", description = "Creates a firewall rule for a given IP address", responseObject = FirewallResponse.class, entityType = {FirewallRule.class},
+@APICommand(name = "createFirewallRule", group = APICommandGroup.FirewallService, description = "Creates a firewall rule for a given IP address", responseObject = FirewallResponse.class, entityType = {FirewallRule.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateFirewallRuleCmd extends BaseAsyncCreateCmd implements FirewallRule {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateFirewallRuleCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/CreatePortForwardingRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/CreatePortForwardingRuleCmd.java
@@ -4,6 +4,7 @@ import com.cloud.acl.RoleType;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -33,7 +34,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createPortForwardingRule", description = "Creates a port forwarding rule", responseObject = FirewallRuleResponse.class, entityType = {FirewallRule.class,
+@APICommand(name = "createPortForwardingRule", group = APICommandGroup.FirewallService, description = "Creates a port forwarding rule", responseObject = FirewallRuleResponse.class, entityType = {FirewallRule.class,
         VirtualMachine.class, IpAddress.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreatePortForwardingRuleCmd extends BaseAsyncCreateCmd implements PortForwardingRule {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/DeleteEgressFirewallRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/DeleteEgressFirewallRuleCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.firewall;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -21,7 +22,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteEgressFirewallRule", description = "Deletes an egress firewall rule", responseObject = SuccessResponse.class, entityType = {FirewallRule.class},
+@APICommand(name = "deleteEgressFirewallRule", group = APICommandGroup.FirewallService, description = "Deletes an egress firewall rule", responseObject = SuccessResponse.class, entityType = {FirewallRule.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteEgressFirewallRuleCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteEgressFirewallRuleCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/DeleteFirewallRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/DeleteFirewallRuleCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.firewall;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -21,7 +22,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteFirewallRule", description = "Deletes a firewall rule", responseObject = SuccessResponse.class, entityType = {FirewallRule.class},
+@APICommand(name = "deleteFirewallRule", group = APICommandGroup.FirewallService, description = "Deletes a firewall rule", responseObject = SuccessResponse.class, entityType = {FirewallRule.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteFirewallRuleCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteFirewallRuleCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/DeletePortForwardingRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/DeletePortForwardingRuleCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.firewall;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -20,7 +21,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deletePortForwardingRule", description = "Deletes a port forwarding rule", responseObject = SuccessResponse.class, entityType = {PortForwardingRule.class},
+@APICommand(name = "deletePortForwardingRule", group = APICommandGroup.FirewallService, description = "Deletes a port forwarding rule", responseObject = SuccessResponse.class, entityType = {PortForwardingRule.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeletePortForwardingRuleCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeletePortForwardingRuleCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/ListEgressFirewallRulesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/ListEgressFirewallRulesCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.firewall;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListTaggedResourcesCmd;
 import com.cloud.api.Parameter;
@@ -19,7 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listEgressFirewallRules", description = "Lists all egress firewall rules for network ID.", responseObject = FirewallResponse.class, entityType =
+@APICommand(name = "listEgressFirewallRules", group = APICommandGroup.FirewallService, description = "Lists all egress firewall rules for network ID.", responseObject = FirewallResponse.class, entityType =
         {FirewallRule.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListEgressFirewallRulesCmd extends BaseListTaggedResourcesCmd implements IListFirewallRulesCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/ListFirewallRulesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/ListFirewallRulesCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.firewall;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListTaggedResourcesCmd;
 import com.cloud.api.Parameter;
@@ -19,7 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listFirewallRules", description = "Lists all firewall rules for an IP address.", responseObject = FirewallResponse.class, entityType = {FirewallRule.class},
+@APICommand(name = "listFirewallRules", group = APICommandGroup.FirewallService, description = "Lists all firewall rules for an IP address.", responseObject = FirewallResponse.class, entityType = {FirewallRule.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListFirewallRulesCmd extends BaseListTaggedResourcesCmd implements IListFirewallRulesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListFirewallRulesCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/ListPortForwardingRulesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/ListPortForwardingRulesCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.firewall;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListTaggedResourcesCmd;
 import com.cloud.api.Parameter;
@@ -18,7 +19,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listPortForwardingRules", description = "Lists all port forwarding rules for an IP address.", responseObject = FirewallRuleResponse.class, entityType =
+@APICommand(name = "listPortForwardingRules", group = APICommandGroup.FirewallService, description = "Lists all port forwarding rules for an IP address.", responseObject = FirewallRuleResponse.class, entityType =
         {PortForwardingRule.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListPortForwardingRulesCmd extends BaseListTaggedResourcesCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/UpdateEgressFirewallRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/UpdateEgressFirewallRuleCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.firewall;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseAsyncCustomIdCmd;
 import com.cloud.api.Parameter;
@@ -18,7 +19,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateEgressFirewallRule", description = "Updates egress firewall rule ", responseObject = FirewallResponse.class, since = "4.4",
+@APICommand(name = "updateEgressFirewallRule", group = APICommandGroup.FirewallService, description = "Updates egress firewall rule ", responseObject = FirewallResponse.class, since = "4.4",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateEgressFirewallRuleCmd extends BaseAsyncCustomIdCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateEgressFirewallRuleCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/UpdateFirewallRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/UpdateFirewallRuleCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.firewall;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseAsyncCustomIdCmd;
 import com.cloud.api.Parameter;
@@ -18,7 +19,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateFirewallRule", description = "Updates firewall rule ", responseObject = FirewallResponse.class, since = "4.4",
+@APICommand(name = "updateFirewallRule", group = APICommandGroup.FirewallService, description = "Updates firewall rule ", responseObject = FirewallResponse.class, since = "4.4",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateFirewallRuleCmd extends BaseAsyncCustomIdCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateFirewallRuleCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/UpdatePortForwardingRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/firewall/UpdatePortForwardingRuleCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.firewall;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseAsyncCmd;
 import com.cloud.api.BaseAsyncCustomIdCmd;
@@ -18,7 +19,7 @@ import com.cloud.utils.net.Ip;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updatePortForwardingRule",
+@APICommand(name = "updatePortForwardingRule", group = APICommandGroup.FirewallService,
         responseObject = FirewallRuleResponse.class,
         description = "Updates a port forwarding rule. Only the private port and the virtual machine can be updated.", entityType = {PortForwardingRule.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/guest/ListGuestOsCategoriesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/guest/ListGuestOsCategoriesCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.guest;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -16,7 +17,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listOsCategories", description = "Lists all supported OS categories for this cloud.", responseObject = GuestOSCategoryResponse.class,
+@APICommand(name = "listOsCategories", group = APICommandGroup.GuestOSService, description = "Lists all supported OS categories for this cloud.", responseObject = GuestOSCategoryResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListGuestOsCategoriesCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListIsosCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/guest/ListGuestOsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/guest/ListGuestOsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.guest;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -17,7 +18,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listOsTypes", description = "Lists all supported OS types for this cloud.", responseObject = GuestOSResponse.class,
+@APICommand(name = "listOsTypes", group = APICommandGroup.GuestOSService, description = "Lists all supported OS types for this cloud.", responseObject = GuestOSResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListGuestOsCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListIsosCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/AttachIsoCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/AttachIsoCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -18,7 +19,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "attachIso", description = "Attaches an ISO to a virtual machine.", responseObject = UserVmResponse.class, responseView = ResponseView.Restricted,
+@APICommand(name = "attachIso", group = APICommandGroup.ISOService, description = "Attaches an ISO to a virtual machine.", responseObject = UserVmResponse.class, responseView = ResponseView.Restricted,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class AttachIsoCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AttachIsoCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/CopyIsoCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/CopyIsoCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.command.user.template.CopyTemplateCmd;
 import com.cloud.api.response.TemplateResponse;
@@ -8,7 +9,7 @@ import com.cloud.api.response.TemplateResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "copyIso", description = "Copies an ISO from one zone to another.", responseObject = TemplateResponse.class, responseView = ResponseView.Restricted,
+@APICommand(name = "copyIso", group = APICommandGroup.ISOService, description = "Copies an ISO from one zone to another.", responseObject = TemplateResponse.class, responseView = ResponseView.Restricted,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CopyIsoCmd extends CopyTemplateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CopyIsoCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/DeleteIsoCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/DeleteIsoCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -18,7 +19,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteIso", description = "Deletes an ISO file.", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteIso", group = APICommandGroup.ISOService, description = "Deletes an ISO file.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteIsoCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteIsoCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/DetachIsoCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/DetachIsoCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -16,7 +17,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "detachIso", description = "Detaches any ISO file (if any) currently attached to a virtual machine.", responseObject = UserVmResponse.class, responseView =
+@APICommand(name = "detachIso", group = APICommandGroup.ISOService, description = "Detaches any ISO file (if any) currently attached to a virtual machine.", responseObject = UserVmResponse.class, responseView =
         ResponseView.Restricted,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class DetachIsoCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/ExtractIsoCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/ExtractIsoCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -19,7 +20,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "extractIso", description = "Extracts an ISO", responseObject = ExtractResponse.class,
+@APICommand(name = "extractIso", group = APICommandGroup.ISOService, description = "Extracts an ISO", responseObject = ExtractResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ExtractIsoCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ExtractIsoCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/ListIsoPermissionsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/ListIsoPermissionsCmd.java
@@ -17,6 +17,7 @@
 package com.cloud.api.command.user.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.BaseListTemplateOrIsoPermissionsCmd;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.response.TemplatePermissionsResponse;
@@ -26,7 +27,7 @@ import com.cloud.template.VirtualMachineTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listIsoPermissions", description = "List ISO visibility and all accounts that have permissions to view this ISO.", responseObject =
+@APICommand(name = "listIsoPermissions", group = APICommandGroup.ISOService, description = "List ISO visibility and all accounts that have permissions to view this ISO.", responseObject =
         TemplatePermissionsResponse.class, responseView = ResponseView.Restricted,
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = false)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/ListIsosCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/ListIsosCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListTaggedResourcesCmd;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listIsos", description = "Lists all available ISO files.", responseObject = TemplateResponse.class, responseView = ResponseView.Restricted,
+@APICommand(name = "listIsos", group = APICommandGroup.ISOService, description = "Lists all available ISO files.", responseObject = TemplateResponse.class, responseView = ResponseView.Restricted,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListIsosCmd extends BaseListTaggedResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListIsosCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/RegisterIsoCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/RegisterIsoCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -22,7 +23,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "registerIso", responseObject = TemplateResponse.class, description = "Registers an existing ISO into the CloudStack Cloud.", responseView = ResponseView
+@APICommand(name = "registerIso", group = APICommandGroup.ISOService, responseObject = TemplateResponse.class, description = "Registers an existing ISO into the CloudStack Cloud.", responseView = ResponseView
         .Restricted,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RegisterIsoCmd extends BaseCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/UpdateIsoCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/UpdateIsoCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseUpdateTemplateOrIsoCmd;
 import com.cloud.api.ResponseObject.ResponseView;
@@ -12,7 +13,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateIso", description = "Updates an ISO file.", responseObject = TemplateResponse.class, responseView = ResponseView.Restricted,
+@APICommand(name = "updateIso", group = APICommandGroup.ISOService, description = "Updates an ISO file.", responseObject = TemplateResponse.class, responseView = ResponseView.Restricted,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateIsoCmd extends BaseUpdateTemplateOrIsoCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateIsoCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/UpdateIsoPermissionsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/iso/UpdateIsoPermissionsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.iso;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.BaseUpdateTemplateOrIsoPermissionsCmd;
 import com.cloud.api.response.SuccessResponse;
 import com.cloud.template.VirtualMachineTemplate;
@@ -9,7 +10,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateIsoPermissions", description = "Updates ISO permissions", responseObject = SuccessResponse.class,
+@APICommand(name = "updateIsoPermissions", group = APICommandGroup.ISOService, description = "Updates ISO permissions", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateIsoPermissionsCmd extends BaseUpdateTemplateOrIsoPermissionsCmd {
     @Override

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/job/ListAsyncJobsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/job/ListAsyncJobsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.job;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -9,7 +10,7 @@ import com.cloud.api.response.ListResponse;
 
 import java.util.Date;
 
-@APICommand(name = "listAsyncJobs", description = "Lists all pending asynchronous jobs for the account.", responseObject = AsyncJobResponse.class,
+@APICommand(name = "listAsyncJobs", group = APICommandGroup.AsyncjobService, description = "Lists all pending asynchronous jobs for the account.", responseObject = AsyncJobResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListAsyncJobsCmd extends BaseListAccountResourcesCmd {
     private static final String s_name = "listasyncjobsresponse";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/job/QueryAsyncJobResultCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/job/QueryAsyncJobResultCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.job;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -10,7 +11,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "queryAsyncJobResult", description = "Retrieves the current status of asynchronous job.", responseObject = AsyncJobResponse.class,
+@APICommand(name = "queryAsyncJobResult", group = APICommandGroup.AsyncjobService, description = "Retrieves the current status of asynchronous job.", responseObject = AsyncJobResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class QueryAsyncJobResultCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(QueryAsyncJobResultCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/AssignCertToLoadBalancerCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/AssignCertToLoadBalancerCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -21,7 +22,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "assignCertToLoadBalancer", description = "Assigns a certificate to a load balancer rule", responseObject = SuccessResponse.class,
+@APICommand(name = "assignCertToLoadBalancer", group = APICommandGroup.LoadBalancerService, description = "Assigns a certificate to a load balancer rule", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AssignCertToLoadBalancerCmd extends BaseAsyncCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/AssignToLoadBalancerRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/AssignToLoadBalancerRuleCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -29,7 +30,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "assignToLoadBalancerRule",
+@APICommand(name = "assignToLoadBalancerRule", group = APICommandGroup.LoadBalancerService,
         description = "Assigns virtual machine or a list of virtual machines to a load balancer rule.",
         responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false,

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/CreateLBHealthCheckPolicyCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/CreateLBHealthCheckPolicyCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCreateCmd;
@@ -21,7 +22,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createLBHealthCheckPolicy",
+@APICommand(name = "createLBHealthCheckPolicy", group = APICommandGroup.LoadBalancerService,
         description = "Creates a load balancer health check policy",
         responseObject = LBHealthCheckResponse.class,
         since = "4.2.0",

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/CreateLBStickinessPolicyCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/CreateLBStickinessPolicyCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -25,7 +26,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createLBStickinessPolicy", description = "Creates a load balancer stickiness policy ", responseObject = LBStickinessResponse.class, since = "3.0.0",
+@APICommand(name = "createLBStickinessPolicy", group = APICommandGroup.LoadBalancerService, description = "Creates a load balancer stickiness policy ", responseObject = LBStickinessResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateLBStickinessPolicyCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateLBStickinessPolicyCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/CreateLoadBalancerRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/CreateLoadBalancerRuleCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -34,7 +35,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createLoadBalancerRule", description = "Creates a load balancer rule", responseObject = LoadBalancerResponse.class,
+@APICommand(name = "createLoadBalancerRule", group = APICommandGroup.LoadBalancerService, description = "Creates a load balancer rule", responseObject = LoadBalancerResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateLoadBalancerRuleCmd extends BaseAsyncCreateCmd /*implements LoadBalancer */ {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateLoadBalancerRuleCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/DeleteLBHealthCheckPolicyCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/DeleteLBHealthCheckPolicyCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -18,7 +19,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteLBHealthCheckPolicy", description = "Deletes a load balancer health check policy.", responseObject = SuccessResponse.class, since = "4.2.0",
+@APICommand(name = "deleteLBHealthCheckPolicy", group = APICommandGroup.LoadBalancerService, description = "Deletes a load balancer health check policy.", responseObject = SuccessResponse.class, since = "4.2.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteLBHealthCheckPolicyCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteLBHealthCheckPolicyCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/DeleteLBStickinessPolicyCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/DeleteLBStickinessPolicyCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -18,7 +19,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteLBStickinessPolicy", description = "Deletes a load balancer stickiness policy.", responseObject = SuccessResponse.class, since = "3.0.0",
+@APICommand(name = "deleteLBStickinessPolicy", group = APICommandGroup.LoadBalancerService, description = "Deletes a load balancer stickiness policy.", responseObject = SuccessResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteLBStickinessPolicyCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteLBStickinessPolicyCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/DeleteLoadBalancerRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/DeleteLoadBalancerRuleCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -18,7 +19,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteLoadBalancerRule", description = "Deletes a load balancer rule.", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteLoadBalancerRule", group = APICommandGroup.LoadBalancerService, description = "Deletes a load balancer rule.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteLoadBalancerRuleCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteLoadBalancerRuleCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/DeleteSslCertCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/DeleteSslCertCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -21,7 +22,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteSslCert", description = "Delete a certificate to CloudStack", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteSslCert", group = APICommandGroup.LoadBalancerService, description = "Delete a certificate to CloudStack", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteSslCertCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteSslCertCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/ListLBHealthCheckPoliciesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/ListLBHealthCheckPoliciesCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -18,7 +19,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listLBHealthCheckPolicies", description = "Lists load balancer health check policies.", responseObject = LBHealthCheckResponse.class, since = "4.2.0",
+@APICommand(name = "listLBHealthCheckPolicies", group = APICommandGroup.LoadBalancerService, description = "Lists load balancer health check policies.", responseObject = LBHealthCheckResponse.class, since = "4.2.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListLBHealthCheckPoliciesCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListLBHealthCheckPoliciesCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/ListLBStickinessPoliciesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/ListLBStickinessPoliciesCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -20,7 +21,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listLBStickinessPolicies", description = "Lists load balancer stickiness policies.", responseObject = LBStickinessResponse.class, since = "3.0.0",
+@APICommand(name = "listLBStickinessPolicies", group = APICommandGroup.LoadBalancerService, description = "Lists load balancer stickiness policies.", responseObject = LBStickinessResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListLBStickinessPoliciesCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListLBStickinessPoliciesCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/ListLoadBalancerRuleInstancesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/ListLoadBalancerRuleInstancesCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -19,7 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listLoadBalancerRuleInstances", description = "List all virtual machine instances that are assigned to a load balancer rule.", responseObject =
+@APICommand(name = "listLoadBalancerRuleInstances", group = APICommandGroup.LoadBalancerService, description = "List all virtual machine instances that are assigned to a load balancer rule.", responseObject =
         LoadBalancerRuleVmMapResponse.class, responseView = ResponseView.Restricted,
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = true)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/ListLoadBalancerRulesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/ListLoadBalancerRulesCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListTaggedResourcesCmd;
 import com.cloud.api.Parameter;
@@ -21,7 +22,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listLoadBalancerRules", description = "Lists load balancer rules.", responseObject = LoadBalancerResponse.class,
+@APICommand(name = "listLoadBalancerRules", group = APICommandGroup.LoadBalancerService, description = "Lists load balancer rules.", responseObject = LoadBalancerResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListLoadBalancerRulesCmd extends BaseListTaggedResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListLoadBalancerRulesCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/ListSslCertsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/ListSslCertsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -19,7 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listSslCerts", description = "Lists SSL certificates", responseObject = SslCertResponse.class,
+@APICommand(name = "listSslCerts", group = APICommandGroup.LoadBalancerService, description = "Lists SSL certificates", responseObject = SslCertResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListSslCertsCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteSslCertCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/RemoveCertFromLoadBalancerCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/RemoveCertFromLoadBalancerCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -20,7 +21,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "removeCertFromLoadBalancer", description = "Removes a certificate from a load balancer rule", responseObject = SuccessResponse.class,
+@APICommand(name = "removeCertFromLoadBalancer", group = APICommandGroup.LoadBalancerService, description = "Removes a certificate from a load balancer rule", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RemoveCertFromLoadBalancerCmd extends BaseAsyncCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/RemoveFromLoadBalancerRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/RemoveFromLoadBalancerRuleCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -27,7 +28,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "removeFromLoadBalancerRule",
+@APICommand(name = "removeFromLoadBalancerRule", group = APICommandGroup.LoadBalancerService,
         description = "Removes a virtual machine or a list of virtual machines from a load balancer rule.",
         responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false,

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/UpdateLBHealthCheckPolicyCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/UpdateLBHealthCheckPolicyCmd.java
@@ -14,6 +14,7 @@ package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseAsyncCustomIdCmd;
 import com.cloud.api.Parameter;
@@ -28,7 +29,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateLBHealthCheckPolicy", description = "Updates load balancer health check policy", responseObject = LBHealthCheckResponse.class, since = "4.4",
+@APICommand(name = "updateLBHealthCheckPolicy", group = APICommandGroup.LoadBalancerService, description = "Updates load balancer health check policy", responseObject = LBHealthCheckResponse.class, since = "4.4",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateLBHealthCheckPolicyCmd extends BaseAsyncCustomIdCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateLBHealthCheckPolicyCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/UpdateLBStickinessPolicyCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/UpdateLBStickinessPolicyCmd.java
@@ -14,6 +14,7 @@ package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseAsyncCustomIdCmd;
 import com.cloud.api.Parameter;
@@ -27,7 +28,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateLBStickinessPolicy", description = "Updates load balancer stickiness policy", responseObject = LBStickinessResponse.class, since = "4.4",
+@APICommand(name = "updateLBStickinessPolicy", group = APICommandGroup.LoadBalancerService, description = "Updates load balancer stickiness policy", responseObject = LBStickinessResponse.class, since = "4.4",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateLBStickinessPolicyCmd extends BaseAsyncCustomIdCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateLBStickinessPolicyCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/UpdateLoadBalancerRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/UpdateLoadBalancerRuleCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -20,7 +21,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateLoadBalancerRule", description = "Updates load balancer", responseObject = LoadBalancerResponse.class,
+@APICommand(name = "updateLoadBalancerRule", group = APICommandGroup.LoadBalancerService, description = "Updates load balancer", responseObject = LoadBalancerResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateLoadBalancerRuleCmd extends BaseAsyncCustomIdCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateLoadBalancerRuleCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/UploadSslCertCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/UploadSslCertCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.loadbalancer;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -22,7 +23,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "uploadSslCert", description = "Upload a certificate to CloudStack", responseObject = SslCertResponse.class,
+@APICommand(name = "uploadSslCert", group = APICommandGroup.LoadBalancerService, description = "Upload a certificate to CloudStack", responseObject = SslCertResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UploadSslCertCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UploadSslCertCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/nat/CreateIpForwardingRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/nat/CreateIpForwardingRuleCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.nat;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -26,7 +27,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createIpForwardingRule", description = "Creates an IP forwarding rule", responseObject = FirewallRuleResponse.class,
+@APICommand(name = "createIpForwardingRule", group = APICommandGroup.NATService, description = "Creates an IP forwarding rule", responseObject = FirewallRuleResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateIpForwardingRuleCmd extends BaseAsyncCreateCmd implements StaticNatRule {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateIpForwardingRuleCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/nat/DeleteIpForwardingRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/nat/DeleteIpForwardingRuleCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.nat;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -18,7 +19,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteIpForwardingRule", description = "Deletes an IP forwarding rule", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteIpForwardingRule", group = APICommandGroup.NATService, description = "Deletes an IP forwarding rule", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteIpForwardingRuleCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteIpForwardingRuleCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/nat/DisableStaticNatCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/nat/DisableStaticNatCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.nat;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -19,7 +20,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "disableStaticNat", description = "Disables static rule for given IP address", responseObject = SuccessResponse.class,
+@APICommand(name = "disableStaticNat", group = APICommandGroup.NATService, description = "Disables static rule for given IP address", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DisableStaticNatCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeletePortForwardingRuleCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/nat/EnableStaticNatCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/nat/EnableStaticNatCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.nat;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -20,7 +21,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "enableStaticNat", description = "Enables static NAT for given IP address", responseObject = SuccessResponse.class,
+@APICommand(name = "enableStaticNat", group = APICommandGroup.NATService, description = "Enables static NAT for given IP address", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class EnableStaticNatCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateIpForwardingRuleCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/nat/ListIpForwardingRulesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/nat/ListIpForwardingRulesCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.nat;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListProjectAndAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -19,7 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listIpForwardingRules", description = "List the IP forwarding rules", responseObject = FirewallRuleResponse.class,
+@APICommand(name = "listIpForwardingRules", group = APICommandGroup.NATService, description = "List the IP forwarding rules", responseObject = FirewallRuleResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListIpForwardingRulesCmd extends BaseListProjectAndAccountResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListIpForwardingRulesCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/CreateNetworkACLCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/CreateNetworkACLCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.network;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCreateCmd;
@@ -25,7 +26,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createNetworkACL",
+@APICommand(name = "createNetworkACL", group = APICommandGroup.NetworkACLService,
         description = "Creates a ACL rule in the given network (the network has to belong to VPC)",
         responseObject = NetworkACLItemResponse.class,
         requestHasSensitiveInfo = false,

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/CreateNetworkACLListCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/CreateNetworkACLListCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.network;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCreateCmd;
@@ -19,7 +20,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createNetworkACLList", description = "Creates a network ACL for the given VPC", responseObject = NetworkACLResponse.class,
+@APICommand(name = "createNetworkACLList", group = APICommandGroup.NetworkACLService, description = "Creates a network ACL for the given VPC", responseObject = NetworkACLResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateNetworkACLListCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateNetworkACLListCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/CreateNetworkCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/CreateNetworkCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.network;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -30,7 +31,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createNetwork", description = "Creates a network", responseObject = NetworkResponse.class, responseView = ResponseView.Restricted, entityType = {Network.class},
+@APICommand(name = "createNetwork", group = APICommandGroup.NetworkService, description = "Creates a network", responseObject = NetworkResponse.class, responseView = ResponseView.Restricted, entityType = {Network.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateNetworkCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateNetworkCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/DeleteNetworkACLCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/DeleteNetworkACLCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteNetworkACL", description = "Deletes a network ACL", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteNetworkACL", group = APICommandGroup.NetworkACLService, description = "Deletes a network ACL", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteNetworkACLCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteNetworkACLCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/DeleteNetworkACLListCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/DeleteNetworkACLListCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteNetworkACLList", description = "Deletes a network ACL", responseObject = SuccessResponse.class,
+@APICommand(name = "deleteNetworkACLList", group = APICommandGroup.NetworkACLService, description = "Deletes a network ACL", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteNetworkACLListCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteNetworkACLListCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/DeleteNetworkCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/DeleteNetworkCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.network;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -20,7 +21,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteNetwork", description = "Deletes a network", responseObject = SuccessResponse.class, entityType = {Network.class},
+@APICommand(name = "deleteNetwork", group = APICommandGroup.NetworkService, description = "Deletes a network", responseObject = SuccessResponse.class, entityType = {Network.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteNetworkCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteNetworkOfferingCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/ListNetworkACLListsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/ListNetworkACLListsCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.network;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListProjectAndAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -18,7 +19,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listNetworkACLLists", description = "Lists all network ACLs", responseObject = NetworkACLResponse.class,
+@APICommand(name = "listNetworkACLLists", group = APICommandGroup.NetworkACLService, description = "Lists all network ACLs", responseObject = NetworkACLResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListNetworkACLListsCmd extends BaseListProjectAndAccountResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListNetworkACLListsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/ListNetworkACLsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/ListNetworkACLsCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.network;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListTaggedResourcesCmd;
 import com.cloud.api.Parameter;
@@ -18,7 +19,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listNetworkACLs", description = "Lists all network ACL items", responseObject = NetworkACLItemResponse.class,
+@APICommand(name = "listNetworkACLs", group = APICommandGroup.NetworkACLService, description = "Lists all network ACL items", responseObject = NetworkACLItemResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListNetworkACLsCmd extends BaseListTaggedResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListNetworkACLsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/ListNetworkOfferingsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/ListNetworkOfferingsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -17,7 +18,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listNetworkOfferings", description = "Lists all available network offerings.", responseObject = NetworkOfferingResponse.class,
+@APICommand(name = "listNetworkOfferings", group = APICommandGroup.NetworkOfferingService, description = "Lists all available network offerings.", responseObject = NetworkOfferingResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListNetworkOfferingsCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListNetworkOfferingsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/ListNetworksCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/ListNetworksCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.network;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListTaggedResourcesCmd;
 import com.cloud.api.Parameter;
@@ -20,7 +21,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listNetworks", description = "Lists all available networks.", responseObject = NetworkResponse.class, responseView = ResponseView.Restricted, entityType =
+@APICommand(name = "listNetworks", group = APICommandGroup.NetworkService, description = "Lists all available networks.", responseObject = NetworkResponse.class, responseView = ResponseView.Restricted, entityType =
         {Network.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListNetworksCmd extends BaseListTaggedResourcesCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/ReplaceNetworkACLListCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/ReplaceNetworkACLListCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.network;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -19,7 +20,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "replaceNetworkACLList", description = "Replaces ACL associated with a network or private gateway", responseObject = SuccessResponse.class,
+@APICommand(name = "replaceNetworkACLList", group = APICommandGroup.NetworkACLService, description = "Replaces ACL associated with a network or private gateway", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ReplaceNetworkACLListCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ReplaceNetworkACLListCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/RestartNetworkCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/RestartNetworkCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.network;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -22,7 +23,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "restartNetwork",
+@APICommand(name = "restartNetwork", group = APICommandGroup.NetworkService,
         description = "Restarts the network; includes 1) restarting network elements - virtual routers, DHCP servers 2) reapplying all public IPs 3) reapplying " +
                 "loadBalancing/portForwarding rules",
         responseObject = IPAddressResponse.class, entityType = {Network.class},

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/UpdateNetworkACLItemCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/UpdateNetworkACLItemCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.network;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCustomIdCmd;
@@ -19,7 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateNetworkACLItem", description = "Updates ACL item with specified ID", responseObject = NetworkACLItemResponse.class,
+@APICommand(name = "updateNetworkACLItem", group = APICommandGroup.NetworkACLService, description = "Updates ACL item with specified ID", responseObject = NetworkACLItemResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateNetworkACLItemCmd extends BaseAsyncCustomIdCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateNetworkACLItemCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/UpdateNetworkACLListCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/UpdateNetworkACLListCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.network;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseAsyncCustomIdCmd;
 import com.cloud.api.Parameter;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateNetworkACLList", description = "Updates network ACL list", responseObject = SuccessResponse.class, since = "4.4",
+@APICommand(name = "updateNetworkACLList", group = APICommandGroup.NetworkACLService, description = "Updates network ACL list", responseObject = SuccessResponse.class, since = "4.4",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateNetworkACLListCmd extends BaseAsyncCustomIdCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateNetworkACLListCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/UpdateNetworkCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/network/UpdateNetworkCmd.java
@@ -4,6 +4,7 @@ import com.cloud.acl.RoleType;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -27,7 +28,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateNetwork", description = "Updates a network", responseObject = NetworkResponse.class, responseView = ResponseView.Restricted, entityType = {Network.class},
+@APICommand(name = "updateNetwork", group = APICommandGroup.NetworkService, description = "Updates a network", responseObject = NetworkResponse.class, responseView = ResponseView.Restricted, entityType = {Network.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateNetworkCmd extends BaseAsyncCustomIdCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateNetworkCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/offering/ListDiskOfferingsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/offering/ListDiskOfferingsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.offering;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListDomainResourcesCmd;
 import com.cloud.api.Parameter;
@@ -10,7 +11,7 @@ import com.cloud.api.response.ListResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listDiskOfferings", description = "Lists all available disk offerings.", responseObject = DiskOfferingResponse.class,
+@APICommand(name = "listDiskOfferings", group = APICommandGroup.DiskOfferingService, description = "Lists all available disk offerings.", responseObject = DiskOfferingResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListDiskOfferingsCmd extends BaseListDomainResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListDiskOfferingsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/offering/ListServiceOfferingsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/offering/ListServiceOfferingsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.offering;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListDomainResourcesCmd;
 import com.cloud.api.Parameter;
@@ -11,7 +12,7 @@ import com.cloud.api.response.UserVmResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listServiceOfferings", description = "Lists all available service offerings.", responseObject = ServiceOfferingResponse.class,
+@APICommand(name = "listServiceOfferings", group = APICommandGroup.ServiceOfferingService, description = "Lists all available service offerings.", responseObject = ServiceOfferingResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListServiceOfferingsCmd extends BaseListDomainResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListServiceOfferingsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/ActivateProjectCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/ActivateProjectCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.project;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -15,7 +16,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "activateProject", description = "Activates a project", responseObject = ProjectResponse.class, since = "3.0.0",
+@APICommand(name = "activateProject", group = APICommandGroup.ProjectService, description = "Activates a project", responseObject = ProjectResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ActivateProjectCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ActivateProjectCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/CreateProjectCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/CreateProjectCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.project;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCreateCmd;
@@ -18,7 +19,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createProject", description = "Creates a project", responseObject = ProjectResponse.class, since = "3.0.0",
+@APICommand(name = "createProject", group = APICommandGroup.ProjectService, description = "Creates a project", responseObject = ProjectResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateProjectCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateProjectCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/DeleteProjectCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/DeleteProjectCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.project;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -16,7 +17,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteProject", description = "Deletes a project", responseObject = SuccessResponse.class, since = "3.0.0",
+@APICommand(name = "deleteProject", group = APICommandGroup.ProjectService, description = "Deletes a project", responseObject = SuccessResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteProjectCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteProjectCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/DeleteProjectInvitationCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/DeleteProjectInvitationCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.project;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -15,7 +16,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteProjectInvitation", description = "Deletes project invitation", responseObject = SuccessResponse.class, since = "3.0.0",
+@APICommand(name = "deleteProjectInvitation", group = APICommandGroup.ProjectService, description = "Deletes project invitation", responseObject = SuccessResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteProjectInvitationCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteProjectInvitationCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/ListProjectInvitationsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/ListProjectInvitationsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.project;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -11,7 +12,7 @@ import com.cloud.api.response.ProjectResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listProjectInvitations",
+@APICommand(name = "listProjectInvitations", group = APICommandGroup.ProjectService,
         description = "Lists project invitations and provides detailed information for listed invitations",
         responseObject = ProjectInvitationResponse.class,
         since = "3.0.0",

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/ListProjectsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/ListProjectsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.project;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -16,7 +17,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listProjects",
+@APICommand(name = "listProjects", group = APICommandGroup.ProjectService,
         description = "Lists projects and provides detailed information for listed projects",
         responseObject = ProjectResponse.class,
         since = "3.0.0",

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/SuspendProjectCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/SuspendProjectCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.project;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -17,7 +18,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "suspendProject", description = "Suspends a project", responseObject = ProjectResponse.class, since = "3.0.0",
+@APICommand(name = "suspendProject", group = APICommandGroup.ProjectService, description = "Suspends a project", responseObject = ProjectResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class SuspendProjectCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(SuspendProjectCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/UpdateProjectCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/UpdateProjectCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.project;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -16,7 +17,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateProject", description = "Updates a project", responseObject = ProjectResponse.class, since = "3.0.0",
+@APICommand(name = "updateProject", group = APICommandGroup.ProjectService, description = "Updates a project", responseObject = ProjectResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateProjectCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateProjectCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/UpdateProjectInvitationCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/project/UpdateProjectInvitationCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.project;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -15,7 +16,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateProjectInvitation", description = "Accepts or declines project invitation", responseObject = SuccessResponse.class, since = "3.0.0",
+@APICommand(name = "updateProjectInvitation", group = APICommandGroup.ProjectService, description = "Accepts or declines project invitation", responseObject = SuccessResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateProjectInvitationCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateProjectInvitationCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/region/ListRegionsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/region/ListRegionsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.region;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -16,7 +17,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listRegions", description = "Lists Regions", responseObject = RegionResponse.class,
+@APICommand(name = "listRegions", group = APICommandGroup.RegionService, description = "Lists Regions", responseObject = RegionResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListRegionsCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListRegionsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/resource/GetCloudIdentifierCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/resource/GetCloudIdentifierCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.resource;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -15,7 +16,7 @@ import java.util.ArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "getCloudIdentifier", description = "Retrieves a cloud identifier.", responseObject = CloudIdentifierResponse.class,
+@APICommand(name = "getCloudIdentifier", group = APICommandGroup.SystemService, description = "Retrieves a cloud identifier.", responseObject = CloudIdentifierResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class GetCloudIdentifierCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(GetCloudIdentifierCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/resource/ListHypervisorsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/resource/ListHypervisorsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.resource;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -16,7 +17,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listHypervisors", description = "List hypervisors", responseObject = HypervisorResponse.class,
+@APICommand(name = "listHypervisors", group = APICommandGroup.HypervisorService, description = "List hypervisors", responseObject = HypervisorResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListHypervisorsCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpgradeRouterCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/resource/ListResourceLimitsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/resource/ListResourceLimitsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.resource;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListProjectAndAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -14,7 +15,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listResourceLimits", description = "Lists resource limits.", responseObject = ResourceLimitResponse.class,
+@APICommand(name = "listResourceLimits", group = APICommandGroup.LimitService, description = "Lists resource limits.", responseObject = ResourceLimitResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListResourceLimitsCmd extends BaseListProjectAndAccountResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListResourceLimitsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/resource/UpdateResourceCountCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/resource/UpdateResourceCountCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.resource;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -20,7 +21,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateResourceCount", description = "Recalculate and update resource count for an account or domain.", responseObject = ResourceCountResponse.class,
+@APICommand(name = "updateResourceCount", group = APICommandGroup.LimitService, description = "Recalculate and update resource count for an account or domain.", responseObject = ResourceCountResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateResourceCountCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateResourceCountCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/resource/UpdateResourceLimitCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/resource/UpdateResourceLimitCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.resource;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -15,7 +16,7 @@ import com.cloud.context.CallContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateResourceLimit", description = "Updates resource limits for an account or domain.", responseObject = ResourceLimitResponse.class,
+@APICommand(name = "updateResourceLimit", group = APICommandGroup.LimitService, description = "Updates resource limits for an account or domain.", responseObject = ResourceLimitResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateResourceLimitCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateResourceLimitCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/securitygroup/AuthorizeSecurityGroupEgressCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/securitygroup/AuthorizeSecurityGroupEgressCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.securitygroup;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -29,7 +30,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "authorizeSecurityGroupEgress", responseObject = SecurityGroupRuleResponse.class, description = "Authorizes a particular egress rule for this security group",
+@APICommand(name = "authorizeSecurityGroupEgress", group = APICommandGroup.SecurityGroupService, responseObject = SecurityGroupRuleResponse.class, description = "Authorizes a particular egress rule for this security group",
         since = "3.0.0", entityType = {SecurityGroup.class},
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = false)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/securitygroup/AuthorizeSecurityGroupIngressCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/securitygroup/AuthorizeSecurityGroupIngressCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.securitygroup;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -29,7 +30,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "authorizeSecurityGroupIngress", responseObject = SecurityGroupRuleResponse.class, description = "Authorizes a particular ingress rule for this security " +
+@APICommand(name = "authorizeSecurityGroupIngress", group = APICommandGroup.SecurityGroupService, responseObject = SecurityGroupRuleResponse.class, description = "Authorizes a particular ingress rule for this security " +
         "group", entityType = {SecurityGroup.class},
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = false)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/securitygroup/CreateSecurityGroupCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/securitygroup/CreateSecurityGroupCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.securitygroup;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createSecurityGroup", responseObject = SecurityGroupResponse.class, description = "Creates a security group", entityType = {SecurityGroup.class},
+@APICommand(name = "createSecurityGroup", group = APICommandGroup.SecurityGroupService, responseObject = SecurityGroupResponse.class, description = "Creates a security group", entityType = {SecurityGroup.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateSecurityGroupCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateSecurityGroupCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/securitygroup/DeleteSecurityGroupCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/securitygroup/DeleteSecurityGroupCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.securitygroup;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -20,7 +21,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteSecurityGroup", description = "Deletes security group", responseObject = SuccessResponse.class, entityType = {SecurityGroup.class},
+@APICommand(name = "deleteSecurityGroup", group = APICommandGroup.SecurityGroupService, description = "Deletes security group", responseObject = SuccessResponse.class, entityType = {SecurityGroup.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteSecurityGroupCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteSecurityGroupCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/securitygroup/ListSecurityGroupsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/securitygroup/ListSecurityGroupsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.securitygroup;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListTaggedResourcesCmd;
@@ -13,7 +14,7 @@ import com.cloud.network.security.SecurityGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listSecurityGroups", description = "Lists security groups", responseObject = SecurityGroupResponse.class, entityType = {SecurityGroup.class},
+@APICommand(name = "listSecurityGroups", group = APICommandGroup.SecurityGroupService, description = "Lists security groups", responseObject = SecurityGroupResponse.class, entityType = {SecurityGroup.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListSecurityGroupsCmd extends BaseListTaggedResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListSecurityGroupsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/securitygroup/RevokeSecurityGroupEgressCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/securitygroup/RevokeSecurityGroupEgressCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.securitygroup;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -17,7 +18,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "revokeSecurityGroupEgress", responseObject = SuccessResponse.class, description = "Deletes a particular egress rule from this security group", since = "3.0" +
+@APICommand(name = "revokeSecurityGroupEgress", group = APICommandGroup.SecurityGroupService, responseObject = SuccessResponse.class, description = "Deletes a particular egress rule from this security group", since = "3.0" +
         ".0", entityType = {SecurityGroup.class},
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = false)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/securitygroup/RevokeSecurityGroupIngressCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/securitygroup/RevokeSecurityGroupIngressCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.securitygroup;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -19,7 +20,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "revokeSecurityGroupIngress", responseObject = SuccessResponse.class, description = "Deletes a particular ingress rule from this security group", entityType =
+@APICommand(name = "revokeSecurityGroupIngress", group = APICommandGroup.SecurityGroupService, responseObject = SuccessResponse.class, description = "Deletes a particular ingress rule from this security group", entityType =
         {SecurityGroup.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RevokeSecurityGroupIngressCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/snapshot/CreateSnapshotCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/snapshot/CreateSnapshotCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.snapshot;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -24,7 +25,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createSnapshot", description = "Creates an instant snapshot of a volume.", responseObject = SnapshotResponse.class, entityType = {Snapshot.class},
+@APICommand(name = "createSnapshot", group = APICommandGroup.SnapshotService, description = "Creates an instant snapshot of a volume.", responseObject = SnapshotResponse.class, entityType = {Snapshot.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateSnapshotCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateSnapshotCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/snapshot/CreateSnapshotFromVMSnapshotCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/snapshot/CreateSnapshotFromVMSnapshotCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.snapshot;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -25,7 +26,7 @@ import com.cloud.vm.snapshot.VMSnapshot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createSnapshotFromVMSnapshot", description = "Creates an instant snapshot of a volume from existing vm snapshot.", responseObject = SnapshotResponse.class,
+@APICommand(name = "createSnapshotFromVMSnapshot", group = APICommandGroup.SnapshotService, description = "Creates an instant snapshot of a volume from existing vm snapshot.", responseObject = SnapshotResponse.class,
         entityType = {Snapshot.class}, requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateSnapshotFromVMSnapshotCmd extends BaseAsyncCreateCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/snapshot/DeleteSnapshotCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/snapshot/DeleteSnapshotCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.snapshot;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -19,7 +20,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteSnapshot", description = "Deletes a snapshot of a disk volume.", responseObject = SuccessResponse.class, entityType = {Snapshot.class},
+@APICommand(name = "deleteSnapshot", group = APICommandGroup.SnapshotService, description = "Deletes a snapshot of a disk volume.", responseObject = SuccessResponse.class, entityType = {Snapshot.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteSnapshotCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteSnapshotCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/snapshot/ListSnapshotsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/snapshot/ListSnapshotsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.snapshot;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListTaggedResourcesCmd;
@@ -18,7 +19,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listSnapshots", description = "Lists all available snapshots for the account.", responseObject = SnapshotResponse.class, entityType = {Snapshot.class},
+@APICommand(name = "listSnapshots", group = APICommandGroup.SnapshotService, description = "Lists all available snapshots for the account.", responseObject = SnapshotResponse.class, entityType = {Snapshot.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListSnapshotsCmd extends BaseListTaggedResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListSnapshotsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/snapshot/RevertSnapshotCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/snapshot/RevertSnapshotCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.snapshot;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -19,7 +20,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "revertSnapshot", description = "revert a volume snapshot.", responseObject = SnapshotResponse.class, entityType = {Snapshot.class},
+@APICommand(name = "revertSnapshot", group = APICommandGroup.SnapshotService, description = "revert a volume snapshot.", responseObject = SnapshotResponse.class, entityType = {Snapshot.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RevertSnapshotCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(RevertSnapshotCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/ssh/CreateSSHKeyPairCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/ssh/CreateSSHKeyPairCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.ssh;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -13,7 +14,7 @@ import com.cloud.user.SSHKeyPair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createSSHKeyPair", description = "Create a new keypair and returns the private key", responseObject = CreateSSHKeyPairResponse.class, entityType =
+@APICommand(name = "createSSHKeyPair", group = APICommandGroup.SSHService, description = "Create a new keypair and returns the private key", responseObject = CreateSSHKeyPairResponse.class, entityType =
         {SSHKeyPair.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class CreateSSHKeyPairCmd extends BaseCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/ssh/DeleteSSHKeyPairCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/ssh/DeleteSSHKeyPairCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.ssh;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -14,7 +15,7 @@ import com.cloud.user.SSHKeyPair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteSSHKeyPair", description = "Deletes a keypair by name", responseObject = SuccessResponse.class, entityType = {SSHKeyPair.class},
+@APICommand(name = "deleteSSHKeyPair", group = APICommandGroup.SSHService, description = "Deletes a keypair by name", responseObject = SuccessResponse.class, entityType = {SSHKeyPair.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteSSHKeyPairCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateSSHKeyPairCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/ssh/ListSSHKeyPairsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/ssh/ListSSHKeyPairsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.ssh;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListProjectAndAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -15,7 +16,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listSSHKeyPairs", description = "List registered keypairs", responseObject = SSHKeyPairResponse.class, entityType = {SSHKeyPair.class},
+@APICommand(name = "listSSHKeyPairs", group = APICommandGroup.SSHService, description = "List registered keypairs", responseObject = SSHKeyPairResponse.class, entityType = {SSHKeyPair.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListSSHKeyPairsCmd extends BaseListProjectAndAccountResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListSSHKeyPairsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/ssh/RegisterSSHKeyPairCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/ssh/RegisterSSHKeyPairCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.ssh;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -13,7 +14,7 @@ import com.cloud.user.SSHKeyPair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "registerSSHKeyPair", description = "Register a public key in a keypair under a certain name", responseObject = SSHKeyPairResponse.class, entityType =
+@APICommand(name = "registerSSHKeyPair", group = APICommandGroup.SSHService, description = "Register a public key in a keypair under a certain name", responseObject = SSHKeyPairResponse.class, entityType =
         {SSHKeyPair.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RegisterSSHKeyPairCmd extends BaseCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/tag/CreateTagsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/tag/CreateTagsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.tag;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -20,7 +21,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createTags", description = "Creates resource tag(s)", responseObject = SuccessResponse.class, since = "4.0.0", entityType = {ResourceTag.class},
+@APICommand(name = "createTags", group = APICommandGroup.ResourcetagsService, description = "Creates resource tag(s)", responseObject = SuccessResponse.class, since = "4.0.0", entityType = {ResourceTag.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateTagsCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateTagsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/tag/DeleteTagsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/tag/DeleteTagsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.tag;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -20,7 +21,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteTags", description = "Deleting resource tag(s)", responseObject = SuccessResponse.class, since = "4.0.0", entityType = {ResourceTag.class},
+@APICommand(name = "deleteTags", group = APICommandGroup.ResourcetagsService, description = "Deleting resource tag(s)", responseObject = SuccessResponse.class, since = "4.0.0", entityType = {ResourceTag.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteTagsCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteTagsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/tag/ListTagsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/tag/ListTagsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.tag;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListProjectAndAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -8,7 +9,7 @@ import com.cloud.api.response.ListResponse;
 import com.cloud.api.response.ResourceTagResponse;
 import com.cloud.server.ResourceTag;
 
-@APICommand(name = "listTags", description = "List resource tag(s)", responseObject = ResourceTagResponse.class, since = "4.0.0", entityType = {ResourceTag.class},
+@APICommand(name = "listTags", group = APICommandGroup.ResourcetagsService, description = "List resource tag(s)", responseObject = ResourceTagResponse.class, since = "4.0.0", entityType = {ResourceTag.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListTagsCmd extends BaseListProjectAndAccountResourcesCmd {
     private static final String s_name = "listtagsresponse";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/CopyTemplateCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/CopyTemplateCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.template;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -22,7 +23,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "copyTemplate", description = "Copies a template from one zone to another.", responseObject = TemplateResponse.class, responseView = ResponseView.Restricted,
+@APICommand(name = "copyTemplate", group = APICommandGroup.TemplateService, description = "Copies a template from one zone to another.", responseObject = TemplateResponse.class, responseView = ResponseView.Restricted,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CopyTemplateCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CopyTemplateCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/CreateTemplateCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/CreateTemplateCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.template;
 
 import com.cloud.acl.SecurityChecker;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -33,7 +34,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createTemplate", responseObject = TemplateResponse.class, description = "Creates a template of a virtual machine. " + "The virtual machine must be in a " +
+@APICommand(name = "createTemplate", group = APICommandGroup.TemplateService, responseObject = TemplateResponse.class, description = "Creates a template of a virtual machine. " + "The virtual machine must be in a " +
         "STOPPED state. "
         + "A template created from this command is automatically designated as a private template visible to the account that created it.", responseView = ResponseView.Restricted,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/DeleteTemplateCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/DeleteTemplateCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.template;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -18,7 +19,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteTemplate",
+@APICommand(name = "deleteTemplate", group = APICommandGroup.TemplateService,
         responseObject = SuccessResponse.class,
         description = "Deletes a template from the system. All virtual machines using the deleted template will not be affected.",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/ExtractTemplateCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/ExtractTemplateCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.template;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -19,7 +20,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "extractTemplate", description = "Extracts a template", responseObject = ExtractResponse.class,
+@APICommand(name = "extractTemplate", group = APICommandGroup.TemplateService, description = "Extracts a template", responseObject = ExtractResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ExtractTemplateCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ExtractTemplateCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/GetUploadParamsForTemplateCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/GetUploadParamsForTemplateCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.template;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.AbstractGetUploadParamsCmd;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -18,7 +19,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "getUploadParamsForTemplate", description = "upload an existing template into the CloudStack cloud. ", responseObject = GetUploadParamsResponse.class, since =
+@APICommand(name = "getUploadParamsForTemplate", group = APICommandGroup.TemplateService, description = "upload an existing template into the CloudStack cloud. ", responseObject = GetUploadParamsResponse.class, since =
         "4.6.0", requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class GetUploadParamsForTemplateCmd extends AbstractGetUploadParamsCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(GetUploadParamsForTemplateCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/ListTemplatePermissionsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/ListTemplatePermissionsCmd.java
@@ -17,6 +17,7 @@
 package com.cloud.api.command.user.template;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.BaseListTemplateOrIsoPermissionsCmd;
 import com.cloud.api.ResponseObject.ResponseView;
 import com.cloud.api.response.TemplatePermissionsResponse;
@@ -26,7 +27,7 @@ import com.cloud.template.VirtualMachineTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listTemplatePermissions", description = "List template visibility and all accounts that have permissions to view this template.", responseObject =
+@APICommand(name = "listTemplatePermissions", group = APICommandGroup.TemplateService, description = "List template visibility and all accounts that have permissions to view this template.", responseObject =
         TemplatePermissionsResponse.class, responseView = ResponseView.Restricted,
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = false)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/ListTemplatesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/ListTemplatesCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.template;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListTaggedResourcesCmd;
@@ -17,7 +18,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listTemplates", description = "List all public, private, and privileged templates.", responseObject = TemplateResponse.class, entityType =
+@APICommand(name = "listTemplates", group = APICommandGroup.TemplateService, description = "List all public, private, and privileged templates.", responseObject = TemplateResponse.class, entityType =
         {VirtualMachineTemplate.class}, responseView = ResponseView.Restricted,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListTemplatesCmd extends BaseListTaggedResourcesCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/RegisterTemplateCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/RegisterTemplateCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.template;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -26,7 +27,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "registerTemplate", description = "Registers an existing template into the CloudStack cloud. ", responseObject = TemplateResponse.class, responseView =
+@APICommand(name = "registerTemplate", group = APICommandGroup.TemplateService, description = "Registers an existing template into the CloudStack cloud. ", responseObject = TemplateResponse.class, responseView =
         ResponseView.Restricted,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RegisterTemplateCmd extends BaseCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/UpdateTemplateCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/UpdateTemplateCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.template;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseUpdateTemplateOrIsoCmd;
 import com.cloud.api.ResponseObject.ResponseView;
@@ -12,7 +13,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateTemplate", description = "Updates attributes of a template.", responseObject = TemplateResponse.class, responseView = ResponseView.Restricted,
+@APICommand(name = "updateTemplate", group = APICommandGroup.TemplateService, description = "Updates attributes of a template.", responseObject = TemplateResponse.class, responseView = ResponseView.Restricted,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateTemplateCmd extends BaseUpdateTemplateOrIsoCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateTemplateCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/UpdateTemplatePermissionsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/UpdateTemplatePermissionsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.template;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.BaseUpdateTemplateOrIsoPermissionsCmd;
 import com.cloud.api.response.SuccessResponse;
 import com.cloud.template.VirtualMachineTemplate;
@@ -9,7 +10,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateTemplatePermissions", responseObject = SuccessResponse.class, description = "Updates a template visibility permissions. "
+@APICommand(name = "updateTemplatePermissions", group = APICommandGroup.TemplateService, responseObject = SuccessResponse.class, description = "Updates a template visibility permissions. "
         + "A public template is visible to all accounts within the same domain. " + "A private template is visible only to the owner of the template. "
         + "A priviledged template is a private template with account permissions added. " + "Only accounts specified under the template permissions are visible to them.",
         entityType = {VirtualMachineTemplate.class},

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/AddIpToVmNicCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/AddIpToVmNicCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -28,7 +29,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addIpToNic", description = "Assigns secondary IP to NIC", responseObject = NicSecondaryIpResponse.class,
+@APICommand(name = "addIpToNic", group = APICommandGroup.NicService, description = "Assigns secondary IP to NIC", responseObject = NicSecondaryIpResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AddIpToVmNicCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AddIpToVmNicCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/AddNicToVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/AddNicToVMCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiConstants.VMDetails;
 import com.cloud.api.ApiErrorCode;
@@ -26,7 +27,7 @@ import java.util.EnumSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addNicToVirtualMachine", description = "Adds VM to specified network by creating a NIC", responseObject = UserVmResponse.class, responseView = ResponseView
+@APICommand(name = "addNicToVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Adds VM to specified network by creating a NIC", responseObject = UserVmResponse.class, responseView = ResponseView
         .Restricted, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class AddNicToVMCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/DeployVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/DeployVMCmd.java
@@ -4,6 +4,7 @@ import com.cloud.acl.RoleType;
 import com.cloud.affinity.AffinityGroupResponse;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -53,7 +54,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deployVirtualMachine", description = "Creates and automatically starts a virtual machine based on a service offering, disk offering, and template.",
+@APICommand(name = "deployVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Creates and automatically starts a virtual machine based on a service offering, disk offering, and template.",
         responseObject = UserVmResponse.class, responseView = ResponseView.Restricted, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/DestroyVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/DestroyVMCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -24,7 +25,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "destroyVirtualMachine", description = "Destroys a virtual machine.", responseObject = UserVmResponse.class, responseView = ResponseView.Restricted,
+@APICommand(name = "destroyVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Destroys a virtual machine.", responseObject = UserVmResponse.class, responseView = ResponseView.Restricted,
         entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = true)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/GetVMPasswordCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/GetVMPasswordCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -17,7 +18,7 @@ import java.security.InvalidParameterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "getVMPassword", responseObject = GetVMPasswordResponse.class, description = "Returns an encrypted password for the VM", entityType = {VirtualMachine.class},
+@APICommand(name = "getVMPassword", group = APICommandGroup.VirtualMachineService, responseObject = GetVMPasswordResponse.class, description = "Returns an encrypted password for the VM", entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class GetVMPasswordCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(GetVMPasswordCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/ListNicsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/ListNicsCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.vm;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -26,7 +27,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listNics", description = "list the vm nics  IP to NIC", responseObject = NicResponse.class,
+@APICommand(name = "listNics", group = APICommandGroup.NicService, description = "list the vm nics  IP to NIC", responseObject = NicResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListNicsCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListNicsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/ListVMsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/ListVMsCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vm;
 import com.cloud.acl.RoleType;
 import com.cloud.affinity.AffinityGroupResponse;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiConstants.VMDetails;
@@ -32,7 +33,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listVirtualMachines", description = "List the virtual machines owned by the account.", responseObject = UserVmResponse.class, responseView = ResponseView
+@APICommand(name = "listVirtualMachines", group = APICommandGroup.VirtualMachineService, description = "List the virtual machines owned by the account.", responseObject = UserVmResponse.class, responseView = ResponseView
         .Restricted, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class ListVMsCmd extends BaseListTaggedResourcesCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/RebootVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/RebootVMCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -22,7 +23,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "rebootVirtualMachine", description = "Reboots a virtual machine.", responseObject = UserVmResponse.class, responseView = ResponseView.Restricted, entityType
+@APICommand(name = "rebootVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Reboots a virtual machine.", responseObject = UserVmResponse.class, responseView = ResponseView.Restricted, entityType
         = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class RebootVMCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/RemoveIpFromVmNicCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/RemoveIpFromVmNicCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -21,7 +22,7 @@ import com.cloud.vm.NicSecondaryIp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "removeIpFromNic", description = "Removes secondary IP from the NIC.", responseObject = SuccessResponse.class,
+@APICommand(name = "removeIpFromNic", group = APICommandGroup.NicService, description = "Removes secondary IP from the NIC.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RemoveIpFromVmNicCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(RemoveIpFromVmNicCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/RemoveNicFromVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/RemoveNicFromVMCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiConstants.VMDetails;
 import com.cloud.api.ApiErrorCode;
@@ -24,7 +25,7 @@ import java.util.EnumSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "removeNicFromVirtualMachine", description = "Removes VM from specified network by deleting a NIC", responseObject = UserVmResponse.class, responseView =
+@APICommand(name = "removeNicFromVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Removes VM from specified network by deleting a NIC", responseObject = UserVmResponse.class, responseView =
         ResponseView.Restricted, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class RemoveNicFromVMCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/ResetVMPasswordCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/ResetVMPasswordCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -22,7 +23,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "resetPasswordForVirtualMachine", responseObject = UserVmResponse.class, description = "Resets the password for virtual machine. " +
+@APICommand(name = "resetPasswordForVirtualMachine", group = APICommandGroup.VirtualMachineService, responseObject = UserVmResponse.class, description = "Resets the password for virtual machine. " +
         "The virtual machine must be in a \"Stopped\" state and the template must already " +
         "support this feature for this command to take effect. [async]", responseView = ResponseView.Restricted, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/ResetVMSSHKeyCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/ResetVMSSHKeyCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -24,7 +25,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "resetSSHKeyForVirtualMachine", responseObject = UserVmResponse.class, description = "Resets the SSH Key for virtual machine. " +
+@APICommand(name = "resetSSHKeyForVirtualMachine", group = APICommandGroup.SSHService, responseObject = UserVmResponse.class, description = "Resets the SSH Key for virtual machine. " +
         "The virtual machine must be in a \"Stopped\" state. [async]", responseView = ResponseView.Restricted, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class ResetVMSSHKeyCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/RestoreVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/RestoreVMCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -24,7 +25,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "restoreVirtualMachine", description = "Restore a VM to original template/ISO or new template/ISO", responseObject = UserVmResponse.class, since = "3.0.0",
+@APICommand(name = "restoreVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Restore a VM to original template/ISO or new template/ISO", responseObject = UserVmResponse.class, since = "3.0.0",
         responseView = ResponseView.Restricted, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false,
         responseHasSensitiveInfo = true)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/ScaleVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/ScaleVMCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -31,7 +32,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "scaleVirtualMachine", description = "Scales the virtual machine to a new service offering.", responseObject = SuccessResponse.class, responseView =
+@APICommand(name = "scaleVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Scales the virtual machine to a new service offering.", responseObject = SuccessResponse.class, responseView =
         ResponseView.Restricted, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ScaleVMCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/StartVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/StartVMCmd.java
@@ -4,6 +4,7 @@ import com.cloud.acl.RoleType;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -29,7 +30,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "startVirtualMachine", responseObject = UserVmResponse.class, description = "Starts a virtual machine.", responseView = ResponseView.Restricted, entityType =
+@APICommand(name = "startVirtualMachine", group = APICommandGroup.VirtualMachineService, responseObject = UserVmResponse.class, description = "Starts a virtual machine.", responseView = ResponseView.Restricted, entityType =
         {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class StartVMCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/StopVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/StopVMCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -21,7 +22,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "stopVirtualMachine", responseObject = UserVmResponse.class, description = "Stops a virtual machine.", responseView = ResponseView.Restricted, entityType =
+@APICommand(name = "stopVirtualMachine", group = APICommandGroup.VirtualMachineService, responseObject = UserVmResponse.class, description = "Stops a virtual machine.", responseView = ResponseView.Restricted, entityType =
         {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class StopVMCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/UpdateDefaultNicForVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/UpdateDefaultNicForVMCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiConstants.VMDetails;
 import com.cloud.api.ApiErrorCode;
@@ -24,7 +25,7 @@ import java.util.EnumSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateDefaultNicForVirtualMachine", description = "Changes the default NIC on a VM", responseObject = UserVmResponse.class, responseView = ResponseView
+@APICommand(name = "updateDefaultNicForVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Changes the default NIC on a VM", responseObject = UserVmResponse.class, responseView = ResponseView
         .Restricted, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class UpdateDefaultNicForVMCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/UpdateVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/UpdateVMCmd.java
@@ -4,6 +4,7 @@ import com.cloud.acl.RoleType;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCustomIdCmd;
@@ -25,7 +26,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateVirtualMachine", description = "Updates properties of a virtual machine. The VM has to be stopped and restarted for the " +
+@APICommand(name = "updateVirtualMachine", group = APICommandGroup.VirtualMachineService, description = "Updates properties of a virtual machine. The VM has to be stopped and restarted for the " +
         "new properties to take effect. UpdateVirtualMachine does not first check whether the VM is stopped. " +
         "Therefore, stop the VM manually before issuing this call.", responseObject = UserVmResponse.class, responseView = ResponseView.Restricted, entityType = {VirtualMachine
         .class},

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/UpdateVmNicIpCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/UpdateVmNicIpCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vm;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiConstants.VMDetails;
@@ -31,7 +32,7 @@ import java.util.EnumSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateVmNicIp", description = "Update the default Ip of a VM Nic", responseObject = UserVmResponse.class)
+@APICommand(name = "updateVmNicIp", group = APICommandGroup.NicService, description = "Update the default Ip of a VM Nic", responseObject = UserVmResponse.class)
 public class UpdateVmNicIpCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AddIpToVmNicCmd.class.getName());
     private static final String s_name = "updatevmnicipresponse";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/UpgradeVMCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vm/UpgradeVMCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vm;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -27,7 +28,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "changeServiceForVirtualMachine", responseObject = UserVmResponse.class, description = "Changes the service offering for a virtual machine. " +
+@APICommand(name = "changeServiceForVirtualMachine", group = APICommandGroup.VirtualMachineService, responseObject = UserVmResponse.class, description = "Changes the service offering for a virtual machine. " +
         "The virtual machine must be in a \"Stopped\" state for " +
         "this command to take effect.", responseView = ResponseView.Restricted, entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vmgroup/CreateVMGroupCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vmgroup/CreateVMGroupCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vmgroup;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -15,7 +16,7 @@ import com.cloud.vm.InstanceGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createInstanceGroup", description = "Creates a vm group", responseObject = InstanceGroupResponse.class, entityType = {InstanceGroup.class},
+@APICommand(name = "createInstanceGroup", group = APICommandGroup.VMGroupService, description = "Creates a vm group", responseObject = InstanceGroupResponse.class, entityType = {InstanceGroup.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateVMGroupCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateVMGroupCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vmgroup/DeleteVMGroupCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vmgroup/DeleteVMGroupCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vmgroup;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -16,7 +17,7 @@ import com.cloud.vm.InstanceGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteInstanceGroup", description = "Deletes a vm group", responseObject = SuccessResponse.class, entityType = {InstanceGroup.class},
+@APICommand(name = "deleteInstanceGroup", group = APICommandGroup.VMGroupService, description = "Deletes a vm group", responseObject = SuccessResponse.class, entityType = {InstanceGroup.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteVMGroupCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteVMGroupCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vmgroup/ListVMGroupsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vmgroup/ListVMGroupsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vmgroup;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListProjectAndAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -11,7 +12,7 @@ import com.cloud.vm.InstanceGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listInstanceGroups", description = "Lists vm groups", responseObject = InstanceGroupResponse.class, entityType = {InstanceGroup.class},
+@APICommand(name = "listInstanceGroups", group = APICommandGroup.VMGroupService, description = "Lists vm groups", responseObject = InstanceGroupResponse.class, entityType = {InstanceGroup.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListVMGroupsCmd extends BaseListProjectAndAccountResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListVMGroupsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vmgroup/UpdateVMGroupCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vmgroup/UpdateVMGroupCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vmgroup;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -15,7 +16,7 @@ import com.cloud.vm.InstanceGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateInstanceGroup", description = "Updates a vm group", responseObject = InstanceGroupResponse.class, entityType = {InstanceGroup.class},
+@APICommand(name = "updateInstanceGroup", group = APICommandGroup.VMGroupService, description = "Updates a vm group", responseObject = InstanceGroupResponse.class, entityType = {InstanceGroup.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateVMGroupCmd extends BaseCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vmsnapshot/CreateVMSnapshotCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vmsnapshot/CreateVMSnapshotCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vmsnapshot;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCreateCmd;
@@ -19,7 +20,7 @@ import com.cloud.vm.snapshot.VMSnapshot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createVMSnapshot", description = "Creates snapshot for a vm.", responseObject = VMSnapshotResponse.class, since = "4.2.0", entityType = {VMSnapshot.class},
+@APICommand(name = "createVMSnapshot", group = APICommandGroup.SnapshotService, description = "Creates snapshot for a vm.", responseObject = VMSnapshotResponse.class, since = "4.2.0", entityType = {VMSnapshot.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateVMSnapshotCmd extends BaseAsyncCreateCmd {
 

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vmsnapshot/DeleteVMSnapshotCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vmsnapshot/DeleteVMSnapshotCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vmsnapshot;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -18,7 +19,7 @@ import com.cloud.vm.snapshot.VMSnapshot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteVMSnapshot", description = "Deletes a vmsnapshot.", responseObject = SuccessResponse.class, since = "4.2.0", entityType = {VMSnapshot.class},
+@APICommand(name = "deleteVMSnapshot", group = APICommandGroup.SnapshotService, description = "Deletes a vmsnapshot.", responseObject = SuccessResponse.class, since = "4.2.0", entityType = {VMSnapshot.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteVMSnapshotCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteVMSnapshotCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vmsnapshot/ListVMSnapshotCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vmsnapshot/ListVMSnapshotCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vmsnapshot;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListTaggedResourcesCmd;
 import com.cloud.api.Parameter;
@@ -12,7 +13,7 @@ import com.cloud.vm.snapshot.VMSnapshot;
 import java.util.ArrayList;
 import java.util.List;
 
-@APICommand(name = "listVMSnapshot", description = "List virtual machine snapshot by conditions", responseObject = VMSnapshotResponse.class, since = "4.2.0", entityType =
+@APICommand(name = "listVMSnapshot", group = APICommandGroup.SnapshotService, description = "List virtual machine snapshot by conditions", responseObject = VMSnapshotResponse.class, since = "4.2.0", entityType =
         {VMSnapshot.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListVMSnapshotCmd extends BaseListTaggedResourcesCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vmsnapshot/RevertToVMSnapshotCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vmsnapshot/RevertToVMSnapshotCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vmsnapshot;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -24,7 +25,7 @@ import com.cloud.vm.snapshot.VMSnapshot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "revertToVMSnapshot", description = "Revert VM from a vmsnapshot.", responseObject = UserVmResponse.class, since = "4.2.0", responseView = ResponseView
+@APICommand(name = "revertToVMSnapshot", group = APICommandGroup.SnapshotService, description = "Revert VM from a vmsnapshot.", responseObject = UserVmResponse.class, since = "4.2.0", responseView = ResponseView
         .Restricted,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
 public class RevertToVMSnapshotCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/AddResourceDetailCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/AddResourceDetailCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.volume;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseAsyncCmd;
 import com.cloud.api.Parameter;
@@ -16,7 +17,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addResourceDetail", description = "Adds detail for the Resource.", responseObject = SuccessResponse.class,
+@APICommand(name = "addResourceDetail", group = APICommandGroup.ResourcemetadataService, description = "Adds detail for the Resource.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AddResourceDetailCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AddResourceDetailCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/AttachVolumeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/AttachVolumeCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.volume;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -21,7 +22,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "attachVolume", description = "Attaches a disk volume to a virtual machine.", responseObject = VolumeResponse.class, responseView = ResponseView.Restricted,
+@APICommand(name = "attachVolume", group = APICommandGroup.VolumeService, description = "Attaches a disk volume to a virtual machine.", responseObject = VolumeResponse.class, responseView = ResponseView.Restricted,
         entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AttachVolumeCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/CreateVolumeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/CreateVolumeCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.volume;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -27,7 +28,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createVolume", responseObject = VolumeResponse.class, description = "Creates a disk volume from a disk offering. This disk volume must still be attached to a" +
+@APICommand(name = "createVolume", group = APICommandGroup.VolumeService, responseObject = VolumeResponse.class, description = "Creates a disk volume from a disk offering. This disk volume must still be attached to a" +
         " virtual machine to make use of it.", responseView = ResponseView.Restricted, entityType = {
         Volume.class, VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/DeleteVolumeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/DeleteVolumeCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.volume;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -18,7 +19,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteVolume", description = "Deletes a detached disk volume.", responseObject = SuccessResponse.class, entityType = {Volume.class},
+@APICommand(name = "deleteVolume", group = APICommandGroup.VolumeService, description = "Deletes a detached disk volume.", responseObject = SuccessResponse.class, entityType = {Volume.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteVolumeCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteVolumeCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/DetachVolumeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/DetachVolumeCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.volume;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -22,7 +23,7 @@ import com.cloud.vm.VirtualMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "detachVolume", description = "Detaches a disk volume from a virtual machine.", responseObject = VolumeResponse.class, responseView = ResponseView.Restricted,
+@APICommand(name = "detachVolume", group = APICommandGroup.VolumeService, description = "Detaches a disk volume from a virtual machine.", responseObject = VolumeResponse.class, responseView = ResponseView.Restricted,
         entityType = {VirtualMachine.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DetachVolumeCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/ExtractVolumeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/ExtractVolumeCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.volume;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -22,7 +23,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "extractVolume", description = "Extracts volume", responseObject = ExtractResponse.class, entityType = {Volume.class},
+@APICommand(name = "extractVolume", group = APICommandGroup.VolumeService, description = "Extracts volume", responseObject = ExtractResponse.class, entityType = {Volume.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ExtractVolumeCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ExtractVolumeCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/GetUploadParamsForVolumeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/GetUploadParamsForVolumeCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.volume;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.AbstractGetUploadParamsCmd;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -16,7 +17,7 @@ import java.net.MalformedURLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "getUploadParamsForVolume", description = "Upload a data disk to the cloudstack cloud.", responseObject = GetUploadParamsResponse.class, since = "4.6.0",
+@APICommand(name = "getUploadParamsForVolume", group = APICommandGroup.VolumeService, description = "Upload a data disk to the cloudstack cloud.", responseObject = GetUploadParamsResponse.class, since = "4.6.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class GetUploadParamsForVolumeCmd extends AbstractGetUploadParamsCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(GetUploadParamsForVolumeCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/ListResourceDetailsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/ListResourceDetailsCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.volume;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListProjectAndAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -12,7 +13,7 @@ import com.cloud.server.ResourceTag;
 
 import java.util.List;
 
-@APICommand(name = "listResourceDetails", description = "List resource detail(s)", responseObject = ResourceTagResponse.class, since = "4.2",
+@APICommand(name = "listResourceDetails", group = APICommandGroup.ResourcemetadataService, description = "List resource detail(s)", responseObject = ResourceTagResponse.class, since = "4.2",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListResourceDetailsCmd extends BaseListProjectAndAccountResourcesCmd {
     private static final String s_name = "listresourcedetailsresponse";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/ListVolumesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/ListVolumesCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.volume;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListTaggedResourcesCmd;
@@ -20,7 +21,7 @@ import com.cloud.storage.Volume;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listVolumes", description = "Lists all volumes.", responseObject = VolumeResponse.class, responseView = ResponseView.Restricted, entityType = {Volume.class},
+@APICommand(name = "listVolumes", group = APICommandGroup.VolumeService, description = "Lists all volumes.", responseObject = VolumeResponse.class, responseView = ResponseView.Restricted, entityType = {Volume.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListVolumesCmd extends BaseListTaggedResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListVolumesCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/MigrateVolumeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/MigrateVolumeCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.volume;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -13,7 +14,7 @@ import com.cloud.event.EventTypes;
 import com.cloud.storage.Volume;
 import com.cloud.user.Account;
 
-@APICommand(name = "migrateVolume", description = "Migrate volume", responseObject = VolumeResponse.class, since = "3.0.0", responseView = ResponseView.Restricted, entityType =
+@APICommand(name = "migrateVolume", group = APICommandGroup.VolumeService, description = "Migrate volume", responseObject = VolumeResponse.class, since = "3.0.0", responseView = ResponseView.Restricted, entityType =
         {Volume.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class MigrateVolumeCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/RemoveResourceDetailCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/RemoveResourceDetailCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.volume;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseAsyncCmd;
@@ -12,7 +13,7 @@ import com.cloud.server.ResourceTag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "removeResourceDetail", description = "Removes detail for the Resource.", responseObject = SuccessResponse.class,
+@APICommand(name = "removeResourceDetail", group = APICommandGroup.ResourcemetadataService, description = "Removes detail for the Resource.", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RemoveResourceDetailCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(RemoveResourceDetailCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/ResizeVolumeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/ResizeVolumeCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.volume;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -24,7 +25,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "resizeVolume", description = "Resizes a volume", responseObject = VolumeResponse.class, responseView = ResponseView.Restricted, entityType = {Volume.class},
+@APICommand(name = "resizeVolume", group = APICommandGroup.VolumeService, description = "Resizes a volume", responseObject = VolumeResponse.class, responseView = ResponseView.Restricted, entityType = {Volume.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ResizeVolumeCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ResizeVolumeCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/UpdateVolumeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/UpdateVolumeCmd.java
@@ -4,6 +4,7 @@ import com.cloud.acl.RoleType;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -21,7 +22,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateVolume", description = "Updates the volume.", responseObject = VolumeResponse.class, responseView = ResponseView.Restricted, entityType = {Volume.class},
+@APICommand(name = "updateVolume", group = APICommandGroup.VolumeService, description = "Updates the volume.", responseObject = VolumeResponse.class, responseView = ResponseView.Restricted, entityType = {Volume.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateVolumeCmd extends BaseAsyncCustomIdCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateVolumeCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/UploadVolumeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/UploadVolumeCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.volume;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -24,7 +25,7 @@ import com.cloud.storage.Volume;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "uploadVolume", description = "Uploads a data disk.", responseObject = VolumeResponse.class, responseView = ResponseView.Restricted, entityType = {Volume.class},
+@APICommand(name = "uploadVolume", group = APICommandGroup.VolumeService, description = "Uploads a data disk.", responseObject = VolumeResponse.class, responseView = ResponseView.Restricted, entityType = {Volume.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UploadVolumeCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UploadVolumeCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/CreateStaticRouteCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/CreateStaticRouteCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vpc;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -23,7 +24,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createStaticRoute", description = "Creates a static route", responseObject = StaticRouteResponse.class, entityType = {StaticRoute.class},
+@APICommand(name = "createStaticRoute", group = APICommandGroup.VPCService, description = "Creates a static route", responseObject = StaticRouteResponse.class, entityType = {StaticRoute.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateStaticRouteCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateStaticRouteCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/CreateVPCCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/CreateVPCCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.vpc;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCreateCmd;
@@ -25,7 +26,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createVPC", description = "Creates a VPC", responseObject = VpcResponse.class, responseView = ResponseView.Restricted, entityType = {Vpc.class},
+@APICommand(name = "createVPC", group = APICommandGroup.VPCService, description = "Creates a VPC", responseObject = VpcResponse.class, responseView = ResponseView.Restricted, entityType = {Vpc.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateVPCCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(CreateVPCCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/DeleteStaticRouteCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/DeleteStaticRouteCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vpc;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiCommandJobType;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
@@ -21,7 +22,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteStaticRoute", description = "Deletes a static route", responseObject = SuccessResponse.class, entityType = {StaticRoute.class},
+@APICommand(name = "deleteStaticRoute", group = APICommandGroup.VPCService, description = "Deletes a static route", responseObject = SuccessResponse.class, entityType = {StaticRoute.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteStaticRouteCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteStaticRouteCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/DeleteVPCCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/DeleteVPCCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vpc;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -19,7 +20,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteVPC", description = "Deletes a VPC", responseObject = SuccessResponse.class, entityType = {Vpc.class},
+@APICommand(name = "deleteVPC", group = APICommandGroup.VPCService, description = "Deletes a VPC", responseObject = SuccessResponse.class, entityType = {Vpc.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteVPCCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteVPCCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/ListPrivateGatewaysCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/ListPrivateGatewaysCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vpc;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListProjectAndAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -17,7 +18,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listPrivateGateways", description = "List private gateways", responseObject = PrivateGatewayResponse.class, entityType = {VpcGateway.class},
+@APICommand(name = "listPrivateGateways", group = APICommandGroup.VPCService, description = "List private gateways", responseObject = PrivateGatewayResponse.class, entityType = {VpcGateway.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListPrivateGatewaysCmd extends BaseListProjectAndAccountResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListPrivateGatewaysCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/ListStaticRoutesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/ListStaticRoutesCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vpc;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListTaggedResourcesCmd;
 import com.cloud.api.Parameter;
@@ -15,7 +16,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import java.util.ArrayList;
 import java.util.List;
 
-@APICommand(name = "listStaticRoutes", description = "Lists all static routes", responseObject = StaticRouteResponse.class, entityType = {StaticRoute.class},
+@APICommand(name = "listStaticRoutes", group = APICommandGroup.VPCService, description = "Lists all static routes", responseObject = StaticRouteResponse.class, entityType = {StaticRoute.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListStaticRoutesCmd extends BaseListTaggedResourcesCmd {
     private static final String s_name = "liststaticroutesresponse";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/ListVPCOfferingsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/ListVPCOfferingsCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vpc;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -15,7 +16,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listVPCOfferings", description = "Lists VPC offerings", responseObject = VpcOfferingResponse.class,
+@APICommand(name = "listVPCOfferings", group = APICommandGroup.VPCService, description = "Lists VPC offerings", responseObject = VpcOfferingResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListVPCOfferingsCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListVPCOfferingsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/ListVPCsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/ListVPCsCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.vpc;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListTaggedResourcesCmd;
 import com.cloud.api.Parameter;
@@ -19,7 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listVPCs", description = "Lists VPCs", responseObject = VpcResponse.class, responseView = ResponseView.Restricted, entityType = {Vpc.class},
+@APICommand(name = "listVPCs", group = APICommandGroup.VPCService, description = "Lists VPCs", responseObject = VpcResponse.class, responseView = ResponseView.Restricted, entityType = {Vpc.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListVPCsCmd extends BaseListTaggedResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListVPCsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/RestartVPCCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/RestartVPCCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vpc;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -20,7 +21,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "restartVPC", description = "Restarts a VPC", responseObject = VpcResponse.class, entityType = {Vpc.class},
+@APICommand(name = "restartVPC", group = APICommandGroup.VPCService, description = "Restarts a VPC", responseObject = VpcResponse.class, entityType = {Vpc.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RestartVPCCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(RestartVPCCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/UpdateVPCCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/UpdateVPCCmd.java
@@ -4,6 +4,7 @@ import com.cloud.acl.RoleType;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -21,7 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateVPC", description = "Updates a VPC", responseObject = VpcResponse.class, responseView = ResponseView.Restricted, entityType = {Vpc.class},
+@APICommand(name = "updateVPC", group = APICommandGroup.VPCService, description = "Updates a VPC", responseObject = VpcResponse.class, responseView = ResponseView.Restricted, entityType = {Vpc.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateVPCCmd extends BaseAsyncCustomIdCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateVPCCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/AddVpnUserCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/AddVpnUserCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vpn;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCreateCmd;
@@ -18,7 +19,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addVpnUser", description = "Adds vpn users", responseObject = VpnUsersResponse.class, entityType = {VpnUser.class},
+@APICommand(name = "addVpnUser", group = APICommandGroup.VPNService, description = "Adds vpn users", responseObject = VpnUsersResponse.class, entityType = {VpnUser.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AddVpnUserCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(AddVpnUserCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/CreateRemoteAccessVpnCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/CreateRemoteAccessVpnCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.vpn;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -21,7 +22,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createRemoteAccessVpn", description = "Creates a l2tp/ipsec remote access vpn", responseObject = RemoteAccessVpnResponse.class, entityType = {RemoteAccessVpn
+@APICommand(name = "createRemoteAccessVpn", group = APICommandGroup.VPNService, description = "Creates a l2tp/ipsec remote access vpn", responseObject = RemoteAccessVpnResponse.class, entityType = {RemoteAccessVpn
         .class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateRemoteAccessVpnCmd extends BaseAsyncCreateCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/CreateVpnConnectionCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/CreateVpnConnectionCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.vpn;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -21,7 +22,7 @@ import com.cloud.network.vpc.Vpc;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createVpnConnection", description = "Create site to site vpn connection", responseObject = Site2SiteVpnConnectionResponse.class, entityType =
+@APICommand(name = "createVpnConnection", group = APICommandGroup.VPNService, description = "Create site to site vpn connection", responseObject = Site2SiteVpnConnectionResponse.class, entityType =
         {Site2SiteVpnConnection.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateVpnConnectionCmd extends BaseAsyncCreateCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/CreateVpnCustomerGatewayCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/CreateVpnCustomerGatewayCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vpn;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -18,7 +19,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createVpnCustomerGateway", description = "Creates site to site vpn customer gateway", responseObject = Site2SiteCustomerGatewayResponse.class, entityType =
+@APICommand(name = "createVpnCustomerGateway", group = APICommandGroup.VPNService, description = "Creates site to site vpn customer gateway", responseObject = Site2SiteCustomerGatewayResponse.class, entityType =
         {Site2SiteCustomerGateway.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateVpnCustomerGatewayCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/CreateVpnGatewayCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/CreateVpnGatewayCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.vpn;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -19,7 +20,7 @@ import com.cloud.network.vpc.Vpc;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "createVpnGateway", description = "Creates site to site vpn local gateway", responseObject = Site2SiteVpnGatewayResponse.class, entityType =
+@APICommand(name = "createVpnGateway", group = APICommandGroup.VPNService, description = "Creates site to site vpn local gateway", responseObject = Site2SiteVpnGatewayResponse.class, entityType =
         {Site2SiteVpnGateway.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class CreateVpnGatewayCmd extends BaseAsyncCreateCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/DeleteRemoteAccessVpnCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/DeleteRemoteAccessVpnCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vpn;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -18,7 +19,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteRemoteAccessVpn", description = "Destroys a l2tp/ipsec remote access vpn", responseObject = SuccessResponse.class, entityType = {RemoteAccessVpn.class},
+@APICommand(name = "deleteRemoteAccessVpn", group = APICommandGroup.VPNService, description = "Destroys a l2tp/ipsec remote access vpn", responseObject = SuccessResponse.class, entityType = {RemoteAccessVpn.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteRemoteAccessVpnCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteRemoteAccessVpnCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/DeleteVpnConnectionCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/DeleteVpnConnectionCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vpn;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -16,7 +17,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteVpnConnection", description = "Delete site to site vpn connection", responseObject = SuccessResponse.class, entityType = {Site2SiteVpnConnection.class},
+@APICommand(name = "deleteVpnConnection", group = APICommandGroup.VPNService, description = "Delete site to site vpn connection", responseObject = SuccessResponse.class, entityType = {Site2SiteVpnConnection.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteVpnConnectionCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteVpnConnectionCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/DeleteVpnCustomerGatewayCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/DeleteVpnCustomerGatewayCmd.java
@@ -3,6 +3,7 @@ package com.cloud.api.command.user.vpn;
 import com.cloud.acl.SecurityChecker.AccessType;
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -17,7 +18,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteVpnCustomerGateway", description = "Delete site to site vpn customer gateway", responseObject = SuccessResponse.class, entityType =
+@APICommand(name = "deleteVpnCustomerGateway", group = APICommandGroup.VPNService, description = "Delete site to site vpn customer gateway", responseObject = SuccessResponse.class, entityType =
         {Site2SiteCustomerGateway.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteVpnCustomerGatewayCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/DeleteVpnGatewayCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/DeleteVpnGatewayCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vpn;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -15,7 +16,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteVpnGateway", description = "Delete site to site vpn gateway", responseObject = SuccessResponse.class, entityType = {Site2SiteVpnGateway.class},
+@APICommand(name = "deleteVpnGateway", group = APICommandGroup.VPNService, description = "Delete site to site vpn gateway", responseObject = SuccessResponse.class, entityType = {Site2SiteVpnGateway.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteVpnGatewayCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DeleteVpnGatewayCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/ListRemoteAccessVpnsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/ListRemoteAccessVpnsCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.vpn;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListProjectAndAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -18,7 +19,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listRemoteAccessVpns", description = "Lists remote access vpns", responseObject = RemoteAccessVpnResponse.class, entityType = {RemoteAccessVpn.class},
+@APICommand(name = "listRemoteAccessVpns", group = APICommandGroup.VPNService, description = "Lists remote access vpns", responseObject = RemoteAccessVpnResponse.class, entityType = {RemoteAccessVpn.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListRemoteAccessVpnsCmd extends BaseListProjectAndAccountResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListRemoteAccessVpnsCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/ListVpnConnectionsCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/ListVpnConnectionsCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.vpn;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListProjectAndAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -17,7 +18,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listVpnConnections", description = "Lists site to site vpn connection gateways", responseObject = Site2SiteVpnConnectionResponse.class, entityType =
+@APICommand(name = "listVpnConnections", group = APICommandGroup.VPNService, description = "Lists site to site vpn connection gateways", responseObject = Site2SiteVpnConnectionResponse.class, entityType =
         {Site2SiteVpnConnection.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListVpnConnectionsCmd extends BaseListProjectAndAccountResourcesCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/ListVpnCustomerGatewaysCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/ListVpnCustomerGatewaysCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vpn;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListProjectAndAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -15,7 +16,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listVpnCustomerGateways", description = "Lists site to site vpn customer gateways", responseObject = Site2SiteCustomerGatewayResponse.class, entityType =
+@APICommand(name = "listVpnCustomerGateways", group = APICommandGroup.VPNService, description = "Lists site to site vpn customer gateways", responseObject = Site2SiteCustomerGatewayResponse.class, entityType =
         {Site2SiteCustomerGateway.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListVpnCustomerGatewaysCmd extends BaseListProjectAndAccountResourcesCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/ListVpnGatewaysCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/ListVpnGatewaysCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.vpn;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListProjectAndAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -17,7 +18,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listVpnGateways", description = "Lists site 2 site vpn gateways", responseObject = Site2SiteVpnGatewayResponse.class, entityType = {Site2SiteVpnGateway.class},
+@APICommand(name = "listVpnGateways", group = APICommandGroup.VPNService, description = "Lists site 2 site vpn gateways", responseObject = Site2SiteVpnGatewayResponse.class, entityType = {Site2SiteVpnGateway.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListVpnGatewaysCmd extends BaseListProjectAndAccountResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListVpnGatewaysCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/ListVpnUsersCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/ListVpnUsersCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vpn;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListProjectAndAccountResourcesCmd;
 import com.cloud.api.Parameter;
@@ -15,7 +16,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listVpnUsers", description = "Lists vpn users", responseObject = VpnUsersResponse.class, entityType = {VpnUser.class},
+@APICommand(name = "listVpnUsers", group = APICommandGroup.VPNService, description = "Lists vpn users", responseObject = VpnUsersResponse.class, entityType = {VpnUser.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListVpnUsersCmd extends BaseListProjectAndAccountResourcesCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListVpnUsersCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/RemoveVpnUserCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/RemoveVpnUserCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vpn;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -17,7 +18,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "removeVpnUser", description = "Removes vpn user", responseObject = SuccessResponse.class, entityType = {VpnUser.class},
+@APICommand(name = "removeVpnUser", group = APICommandGroup.VPNService, description = "Removes vpn user", responseObject = SuccessResponse.class, entityType = {VpnUser.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class RemoveVpnUserCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(RemoveVpnUserCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/ResetVpnConnectionCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/ResetVpnConnectionCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vpn;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -17,7 +18,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "resetVpnConnection", description = "Reset site to site vpn connection", responseObject = Site2SiteVpnConnectionResponse.class, entityType =
+@APICommand(name = "resetVpnConnection", group = APICommandGroup.VPNService, description = "Reset site to site vpn connection", responseObject = Site2SiteVpnConnectionResponse.class, entityType =
         {Site2SiteVpnConnection.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ResetVpnConnectionCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/UpdateRemoteAccessVpnCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/UpdateRemoteAccessVpnCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.vpn;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseAsyncCustomIdCmd;
 import com.cloud.api.Parameter;
@@ -14,7 +15,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateRemoteAccessVpn", description = "Updates remote access vpn", responseObject = RemoteAccessVpnResponse.class, since = "4.4",
+@APICommand(name = "updateRemoteAccessVpn", group = APICommandGroup.VPNService, description = "Updates remote access vpn", responseObject = RemoteAccessVpnResponse.class, since = "4.4",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateRemoteAccessVpnCmd extends BaseAsyncCustomIdCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateRemoteAccessVpnCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/UpdateVpnConnectionCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/UpdateVpnConnectionCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.vpn;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseAsyncCustomIdCmd;
 import com.cloud.api.Parameter;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateVpnConnection", description = "Updates site to site vpn connection", responseObject = Site2SiteVpnConnectionResponse.class, since = "4.4",
+@APICommand(name = "updateVpnConnection", group = APICommandGroup.VPNService, description = "Updates site to site vpn connection", responseObject = Site2SiteVpnConnectionResponse.class, since = "4.4",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateVpnConnectionCmd extends BaseAsyncCustomIdCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateVpnConnectionCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/UpdateVpnCustomerGatewayCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/UpdateVpnCustomerGatewayCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.vpn;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -17,7 +18,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateVpnCustomerGateway", description = "Update site to site vpn customer gateway", responseObject = Site2SiteCustomerGatewayResponse.class, entityType =
+@APICommand(name = "updateVpnCustomerGateway", group = APICommandGroup.VPNService, description = "Update site to site vpn customer gateway", responseObject = Site2SiteCustomerGatewayResponse.class, entityType =
         {Site2SiteCustomerGateway.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateVpnCustomerGatewayCmd extends BaseAsyncCmd {

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/UpdateVpnGatewayCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpn/UpdateVpnGatewayCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.user.vpn;
 
 import com.cloud.acl.RoleType;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseAsyncCustomIdCmd;
 import com.cloud.api.Parameter;
@@ -13,7 +14,7 @@ import com.cloud.user.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "updateVpnGateway", description = "Updates site to site vpn local gateway", responseObject = Site2SiteVpnGatewayResponse.class, since = "4.4",
+@APICommand(name = "updateVpnGateway", group = APICommandGroup.VPNService, description = "Updates site to site vpn local gateway", responseObject = Site2SiteVpnGatewayResponse.class, since = "4.4",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UpdateVpnGatewayCmd extends BaseAsyncCustomIdCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(UpdateVpnGatewayCmd.class.getName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/zone/ListZonesCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/zone/ListZonesCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.zone;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
@@ -18,7 +19,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listZones", description = "Lists zones", responseObject = ZoneResponse.class, responseView = ResponseView.Restricted,
+@APICommand(name = "listZones", group = APICommandGroup.ZoneService, description = "Lists zones", responseObject = ZoneResponse.class, responseView = ResponseView.Restricted,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListZonesCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListZonesCmd.class.getName());

--- a/cosmic-core/api/src/test/java/com/cloud/api/BaseCmdTest.java
+++ b/cosmic-core/api/src/test/java/com/cloud/api/BaseCmdTest.java
@@ -28,7 +28,7 @@ public class BaseCmdTest {
     }
 }
 
-@APICommand(name = BaseCmdTest.CMD1_NAME, responseObject = BaseResponse.class)
+@APICommand(name = BaseCmdTest.CMD1_NAME, group = APICommandGroup.BaseCmdTestService, responseObject = BaseResponse.class)
 class Cmd1 extends BaseCmd {
     @Override
     public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException, ConcurrentOperationException, ResourceAllocationException,
@@ -46,7 +46,7 @@ class Cmd1 extends BaseCmd {
     }
 }
 
-@APICommand(name = BaseCmdTest.CMD2_NAME, responseObject = BaseResponse.class)
+@APICommand(name = BaseCmdTest.CMD2_NAME, group = APICommandGroup.BaseCmdTestService, responseObject = BaseResponse.class)
 class Cmd2 extends Cmd1 {
     @Override
     public String getCommandName() {

--- a/cosmic-core/plugins/api/discovery/src/main/java/com/cloud/api/command/user/discovery/ListApisCmd.java
+++ b/cosmic-core/plugins/api/discovery/src/main/java/com/cloud/api/command/user/discovery/ListApisCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.discovery;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -17,7 +18,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listApis",
+@APICommand(name = "listApis", group = APICommandGroup.SystemService,
         responseObject = ApiDiscoveryResponse.class,
         description = "lists all available apis on the server, provided by the Api Discovery plugin",
         since = "4.1.0",

--- a/cosmic-core/plugins/api/discovery/src/main/java/com/cloud/api/response/ApiDiscoveryResponse.java
+++ b/cosmic-core/plugins/api/discovery/src/main/java/com/cloud/api/response/ApiDiscoveryResponse.java
@@ -14,6 +14,14 @@ public class ApiDiscoveryResponse extends BaseResponse {
     @Param(description = "the name of the api command")
     private String name;
 
+    @SerializedName(ApiConstants.GROUP_NAME)
+    @Param(description = "the name of the group this api command belongs to")
+    private String groupName;
+
+    @SerializedName(ApiConstants.GROUP_DESCRIPTION)
+    @Param(description = "the description of the group this api command belongs to")
+    private String groupDescription;
+
     @SerializedName(ApiConstants.DESCRIPTION)
     @Param(description = "description of the api")
     private String description;
@@ -54,6 +62,22 @@ public class ApiDiscoveryResponse extends BaseResponse {
 
     public void setName(final String name) {
         this.name = name;
+    }
+
+    public String getGroupName() {
+        return groupName;
+    }
+
+    public void setGroupName(String groupName) {
+        this.groupName = groupName;
+    }
+
+    public String getGroupDescription() {
+        return groupDescription;
+    }
+
+    public void setGroupDescription(String groupDescription) {
+        this.groupDescription = groupDescription;
     }
 
     public String getDescription() {

--- a/cosmic-core/plugins/api/discovery/src/main/java/com/cloud/discovery/ApiDiscoveryServiceImpl.java
+++ b/cosmic-core/plugins/api/discovery/src/main/java/com/cloud/discovery/ApiDiscoveryServiceImpl.java
@@ -159,6 +159,8 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
         final String apiName = apiCmdAnnotation.name();
         final ApiDiscoveryResponse response = new ApiDiscoveryResponse();
         response.setName(apiName);
+        response.setGroupName(apiCmdAnnotation.group().name());
+        response.setGroupDescription(apiCmdAnnotation.group().toString());
         response.setDescription(apiCmdAnnotation.description());
         if (!apiCmdAnnotation.since().isEmpty()) {
             response.setSince(apiCmdAnnotation.since());

--- a/cosmic-core/plugins/api/rate-limit/src/main/java/com/cloud/api/command/admin/ratelimit/ResetApiLimitCmd.java
+++ b/cosmic-core/plugins/api/rate-limit/src/main/java/com/cloud/api/command/admin/ratelimit/ResetApiLimitCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.command.admin.ratelimit;
 
 import com.cloud.api.ACL;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -21,7 +22,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "resetApiLimit", responseObject = ApiLimitResponse.class, description = "Reset api count",
+@APICommand(name = "resetApiLimit", group = APICommandGroup.LimitService, responseObject = ApiLimitResponse.class, description = "Reset api count",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ResetApiLimitCmd extends BaseCmd {
     private static final Logger s_logger = LoggerFactory.getLogger(ResetApiLimitCmd.class.getName());

--- a/cosmic-core/plugins/api/rate-limit/src/main/java/com/cloud/api/command/user/ratelimit/GetApiLimitCmd.java
+++ b/cosmic-core/plugins/api/rate-limit/src/main/java/com/cloud/api/command/user/ratelimit/GetApiLimitCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command.user.ratelimit;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.ServerApiException;
@@ -16,7 +17,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "getApiLimit", responseObject = ApiLimitResponse.class, description = "Get API limit count for the caller",
+@APICommand(name = "getApiLimit", group = APICommandGroup.LimitService, responseObject = ApiLimitResponse.class, description = "Get API limit count for the caller",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class GetApiLimitCmd extends BaseCmd {
     private static final Logger s_logger = LoggerFactory.getLogger(GetApiLimitCmd.class.getName());

--- a/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LDAPConfigCmd.java
+++ b/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LDAPConfigCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -32,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * @deprecated as of 4.3 use the new api {@link LdapAddConfigurationCmd}
  */
 @Deprecated
-@APICommand(name = "ldapConfig", description = "Configure the LDAP context for this site.", responseObject = LDAPConfigResponse.class, since = "3.0.0",
+@APICommand(name = "ldapConfig", group = APICommandGroup.AuthenticationService, description = "Configure the LDAP context for this site.", responseObject = LDAPConfigResponse.class, since = "3.0.0",
         requestHasSensitiveInfo = true, responseHasSensitiveInfo = false)
 
 public class LDAPConfigCmd extends BaseCmd {

--- a/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LDAPRemoveCmd.java
+++ b/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LDAPRemoveCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.response.LDAPConfigResponse;
 import com.cloud.api.response.LDAPRemoveResponse;
@@ -19,7 +20,7 @@ import org.slf4j.LoggerFactory;
  * @deprecated as of 4.3 use the new api {@link LdapDeleteConfigurationCmd}
  */
 @Deprecated
-@APICommand(name = "ldapRemove", description = "Remove the LDAP context for this site.", responseObject = LDAPConfigResponse.class, since = "3.0.1",
+@APICommand(name = "ldapRemove", group = APICommandGroup.AuthenticationService, description = "Remove the LDAP context for this site.", responseObject = LDAPConfigResponse.class, since = "3.0.1",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class LDAPRemoveCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(LDAPRemoveCmd.class.getName());

--- a/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LdapAddConfigurationCmd.java
+++ b/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LdapAddConfigurationCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -15,7 +16,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "addLdapConfiguration", description = "Add a new Ldap Configuration", responseObject = LdapConfigurationResponse.class, since = "4.2.0",
+@APICommand(name = "addLdapConfiguration", group = APICommandGroup.AuthenticationService, description = "Add a new Ldap Configuration", responseObject = LdapConfigurationResponse.class, since = "4.2.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class LdapAddConfigurationCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(LdapAddConfigurationCmd.class.getName());

--- a/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LdapCreateAccountCmd.java
+++ b/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LdapCreateAccountCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -29,7 +30,7 @@ import org.bouncycastle.util.encoders.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "ldapCreateAccount", description = "Creates an account from an LDAP user", responseObject = AccountResponse.class, since = "4.2.0", requestHasSensitiveInfo =
+@APICommand(name = "ldapCreateAccount", group = APICommandGroup.AuthenticationService, description = "Creates an account from an LDAP user", responseObject = AccountResponse.class, since = "4.2.0", requestHasSensitiveInfo =
         false, responseHasSensitiveInfo = false)
 public class LdapCreateAccountCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(LdapCreateAccountCmd.class.getName());

--- a/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LdapDeleteConfigurationCmd.java
+++ b/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LdapDeleteConfigurationCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.Parameter;
@@ -15,7 +16,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "deleteLdapConfiguration", description = "Remove an Ldap Configuration", responseObject = LdapConfigurationResponse.class, since = "4.2.0",
+@APICommand(name = "deleteLdapConfiguration", group = APICommandGroup.AuthenticationService, description = "Remove an Ldap Configuration", responseObject = LdapConfigurationResponse.class, since = "4.2.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class LdapDeleteConfigurationCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(LdapDeleteConfigurationCmd.class.getName());

--- a/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LdapImportUsersCmd.java
+++ b/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LdapImportUsersCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseListCmd;
@@ -39,7 +40,7 @@ import org.bouncycastle.util.encoders.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "importLdapUsers", description = "Import LDAP users", responseObject = LdapUserResponse.class, since = "4.3.0",
+@APICommand(name = "importLdapUsers", group = APICommandGroup.AuthenticationService, description = "Import LDAP users", responseObject = LdapUserResponse.class, since = "4.3.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class LdapImportUsersCmd extends BaseListCmd {
 

--- a/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LdapListConfigurationCmd.java
+++ b/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LdapListConfigurationCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
 import com.cloud.api.response.LdapConfigurationResponse;
@@ -17,7 +18,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listLdapConfigurations", responseObject = LdapConfigurationResponse.class, description = "Lists all LDAP configurations", since = "4.2.0",
+@APICommand(name = "listLdapConfigurations", group = APICommandGroup.AuthenticationService, responseObject = LdapConfigurationResponse.class, description = "Lists all LDAP configurations", since = "4.2.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class LdapListConfigurationCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(LdapListConfigurationCmd.class.getName());

--- a/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LdapListUsersCmd.java
+++ b/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LdapListUsersCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
 import com.cloud.api.ServerApiException;
@@ -21,7 +22,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listLdapUsers", responseObject = LdapUserResponse.class, description = "Lists all LDAP Users", since = "4.2.0",
+@APICommand(name = "listLdapUsers", group = APICommandGroup.AuthenticationService, responseObject = LdapUserResponse.class, description = "Lists all LDAP Users", since = "4.2.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class LdapListUsersCmd extends BaseListCmd {
 

--- a/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LdapUserSearchCmd.java
+++ b/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LdapUserSearchCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.BaseListCmd;
 import com.cloud.api.Parameter;
 import com.cloud.api.response.LdapUserResponse;
@@ -17,7 +18,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "searchLdap", responseObject = LdapUserResponse.class, description = "Searches LDAP based on the username attribute", since = "4.2.0",
+@APICommand(name = "searchLdap", group = APICommandGroup.AuthenticationService, responseObject = LdapUserResponse.class, description = "Searches LDAP based on the username attribute", since = "4.2.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class LdapUserSearchCmd extends BaseListCmd {
 

--- a/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LinkDomainToLdapCmd.java
+++ b/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/LinkDomainToLdapCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -22,7 +23,7 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "linkDomainToLdap", description = "link an existing cloudstack domain to group or OU in ldap", responseObject = LinkDomainToLdapResponse.class, since = "4.6.0",
+@APICommand(name = "linkDomainToLdap", group = APICommandGroup.AuthenticationService, description = "link an existing cloudstack domain to group or OU in ldap", responseObject = LinkDomainToLdapResponse.class, since = "4.6.0",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class LinkDomainToLdapCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(LinkDomainToLdapCmd.class.getName());

--- a/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/ListDomainLdapLinkCmd.java
+++ b/cosmic-core/plugins/authentication/ldap/src/main/java/com/cloud/api/command/ListDomainLdapLinkCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.command;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
@@ -17,7 +18,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listDomainLdapLink", description = "list link of domain to group or OU in ldap", responseObject = LinkDomainToLdapResponse.class, since = "5.3.6",
+@APICommand(name = "listDomainLdapLink", group = APICommandGroup.AuthenticationService, description = "list link of domain to group or OU in ldap", responseObject = LinkDomainToLdapResponse.class, since = "5.3.6",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListDomainLdapLinkCmd extends BaseCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListDomainLdapLinkCmd.class.getName());

--- a/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/DedicateClusterCmd.java
+++ b/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/DedicateClusterCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.commands;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -22,7 +23,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "dedicateCluster", description = "Dedicate an existing cluster", responseObject = DedicateClusterResponse.class,
+@APICommand(name = "dedicateCluster", group = APICommandGroup.ClusterService, description = "Dedicate an existing cluster", responseObject = DedicateClusterResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DedicateClusterCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DedicateClusterCmd.class.getName());

--- a/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/DedicateHostCmd.java
+++ b/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/DedicateHostCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.commands;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -22,7 +23,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "dedicateHost", description = "Dedicates a host.", responseObject = DedicateHostResponse.class,
+@APICommand(name = "dedicateHost", group = APICommandGroup.HostService, description = "Dedicates a host.", responseObject = DedicateHostResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DedicateHostCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DedicateHostCmd.class.getName());

--- a/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/DedicatePodCmd.java
+++ b/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/DedicatePodCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.commands;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -22,7 +23,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "dedicatePod", description = "Dedicates a Pod.", responseObject = DedicatePodResponse.class,
+@APICommand(name = "dedicatePod", group = APICommandGroup.PodService, description = "Dedicates a Pod.", responseObject = DedicatePodResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DedicatePodCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DedicatePodCmd.class.getName());

--- a/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/DedicateZoneCmd.java
+++ b/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/DedicateZoneCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.commands;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -22,7 +23,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "dedicateZone", description = "Dedicates a zones.", responseObject = DedicateZoneResponse.class,
+@APICommand(name = "dedicateZone", group = APICommandGroup.ZoneService, description = "Dedicates a zones.", responseObject = DedicateZoneResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DedicateZoneCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(DedicateZoneCmd.class.getName());

--- a/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/ListDedicatedClustersCmd.java
+++ b/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/ListDedicatedClustersCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.commands;
 
 import com.cloud.affinity.AffinityGroupResponse;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseListCmd;
@@ -23,7 +24,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listDedicatedClusters", description = "Lists dedicated clusters.", responseObject = DedicateClusterResponse.class,
+@APICommand(name = "listDedicatedClusters", group = APICommandGroup.ClusterService, description = "Lists dedicated clusters.", responseObject = DedicateClusterResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListDedicatedClustersCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListDedicatedClustersCmd.class.getName());

--- a/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/ListDedicatedHostsCmd.java
+++ b/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/ListDedicatedHostsCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.commands;
 
 import com.cloud.affinity.AffinityGroupResponse;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseListCmd;
@@ -23,7 +24,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listDedicatedHosts", description = "Lists dedicated hosts.", responseObject = DedicateHostResponse.class,
+@APICommand(name = "listDedicatedHosts", group = APICommandGroup.HostService, description = "Lists dedicated hosts.", responseObject = DedicateHostResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListDedicatedHostsCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListDedicatedHostsCmd.class.getName());

--- a/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/ListDedicatedPodsCmd.java
+++ b/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/ListDedicatedPodsCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.commands;
 
 import com.cloud.affinity.AffinityGroupResponse;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseListCmd;
@@ -23,7 +24,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listDedicatedPods", description = "Lists dedicated pods.", responseObject = DedicatePodResponse.class,
+@APICommand(name = "listDedicatedPods", group = APICommandGroup.PodService, description = "Lists dedicated pods.", responseObject = DedicatePodResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListDedicatedPodsCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListDedicatedPodsCmd.class.getName());

--- a/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/ListDedicatedZonesCmd.java
+++ b/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/ListDedicatedZonesCmd.java
@@ -2,6 +2,7 @@ package com.cloud.api.commands;
 
 import com.cloud.affinity.AffinityGroupResponse;
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseListCmd;
@@ -23,7 +24,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listDedicatedZones", description = "List dedicated zones.", responseObject = DedicateZoneResponse.class,
+@APICommand(name = "listDedicatedZones", group = APICommandGroup.ZoneService, description = "List dedicated zones.", responseObject = DedicateZoneResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListDedicatedZonesCmd extends BaseListCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ListDedicatedZonesCmd.class.getName());

--- a/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/ReleaseDedicatedClusterCmd.java
+++ b/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/ReleaseDedicatedClusterCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.commands;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -17,7 +18,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "releaseDedicatedCluster", description = "Release the dedication for cluster", responseObject = SuccessResponse.class,
+@APICommand(name = "releaseDedicatedCluster", group = APICommandGroup.ClusterService, description = "Release the dedication for cluster", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ReleaseDedicatedClusterCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ReleaseDedicatedClusterCmd.class.getName());

--- a/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/ReleaseDedicatedHostCmd.java
+++ b/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/ReleaseDedicatedHostCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.commands;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -17,7 +18,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "releaseDedicatedHost", description = "Release the dedication for host", responseObject = SuccessResponse.class,
+@APICommand(name = "releaseDedicatedHost", group = APICommandGroup.HostService, description = "Release the dedication for host", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ReleaseDedicatedHostCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ReleaseDedicatedHostCmd.class.getName());

--- a/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/ReleaseDedicatedPodCmd.java
+++ b/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/ReleaseDedicatedPodCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.commands;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -17,7 +18,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "releaseDedicatedPod", description = "Release the dedication for the pod", responseObject = SuccessResponse.class,
+@APICommand(name = "releaseDedicatedPod", group = APICommandGroup.PodService, description = "Release the dedication for the pod", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ReleaseDedicatedPodCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ReleaseDedicatedPodCmd.class.getName());

--- a/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/ReleaseDedicatedZoneCmd.java
+++ b/cosmic-core/plugins/dedicated-resources/src/main/java/com/cloud/api/commands/ReleaseDedicatedZoneCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.commands;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -17,7 +18,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "releaseDedicatedZone", description = "Release dedication of zone", responseObject = SuccessResponse.class,
+@APICommand(name = "releaseDedicatedZone", group = APICommandGroup.ZoneService, description = "Release dedication of zone", responseObject = SuccessResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ReleaseDedicatedZoneCmd extends BaseAsyncCmd {
     public static final Logger s_logger = LoggerFactory.getLogger(ReleaseDedicatedZoneCmd.class.getName());

--- a/cosmic-core/plugins/network/nicira-nvp/src/main/java/com/cloud/api/commands/AddNiciraNvpDeviceCmd.java
+++ b/cosmic-core/plugins/network/nicira-nvp/src/main/java/com/cloud/api/commands/AddNiciraNvpDeviceCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.commands;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -21,7 +22,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 
 import javax.inject.Inject;
 
-@APICommand(name = "addNiciraNvpDevice", responseObject = NiciraNvpDeviceResponse.class, description = "Adds a Nicira NVP device",
+@APICommand(name = "addNiciraNvpDevice", group = APICommandGroup.NiciraNVPService, responseObject = NiciraNvpDeviceResponse.class, description = "Adds a Nicira NVP device",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AddNiciraNvpDeviceCmd extends BaseAsyncCmd {
     private static final String s_name = "addniciranvpdeviceresponse";

--- a/cosmic-core/plugins/network/nicira-nvp/src/main/java/com/cloud/api/commands/DeleteNiciraNvpDeviceCmd.java
+++ b/cosmic-core/plugins/network/nicira-nvp/src/main/java/com/cloud/api/commands/DeleteNiciraNvpDeviceCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.commands;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseAsyncCmd;
@@ -20,7 +21,7 @@ import com.cloud.utils.exception.InvalidParameterValueException;
 
 import javax.inject.Inject;
 
-@APICommand(name = "deleteNiciraNvpDevice", responseObject = SuccessResponse.class, description = " delete a nicira nvp device",
+@APICommand(name = "deleteNiciraNvpDevice", group = APICommandGroup.NiciraNVPService, responseObject = SuccessResponse.class, description = " delete a nicira nvp device",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class DeleteNiciraNvpDeviceCmd extends BaseAsyncCmd {
     private static final String s_name = "deleteniciranvpdeviceresponse";

--- a/cosmic-core/plugins/network/nicira-nvp/src/main/java/com/cloud/api/commands/ListNiciraNvpDeviceNetworksCmd.java
+++ b/cosmic-core/plugins/network/nicira-nvp/src/main/java/com/cloud/api/commands/ListNiciraNvpDeviceNetworksCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.commands;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseListCmd;
@@ -26,7 +27,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "listNiciraNvpDeviceNetworks", responseObject = NetworkResponse.class, description = "lists network that are using a nicira nvp device",
+@APICommand(name = "listNiciraNvpDeviceNetworks", group = APICommandGroup.NetworkService, responseObject = NetworkResponse.class, description = "lists network that are using a nicira nvp device",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListNiciraNvpDeviceNetworksCmd extends BaseListCmd {
 

--- a/cosmic-core/plugins/network/nicira-nvp/src/main/java/com/cloud/api/commands/ListNiciraNvpDevicesCmd.java
+++ b/cosmic-core/plugins/network/nicira-nvp/src/main/java/com/cloud/api/commands/ListNiciraNvpDevicesCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.commands;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseListCmd;
@@ -21,7 +22,7 @@ import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 
-@APICommand(name = "listNiciraNvpDevices", responseObject = NiciraNvpDeviceResponse.class, description = "Lists Nicira NVP devices",
+@APICommand(name = "listNiciraNvpDevices", group = APICommandGroup.NiciraNVPService, responseObject = NiciraNvpDeviceResponse.class, description = "Lists Nicira NVP devices",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class ListNiciraNvpDevicesCmd extends BaseListCmd {
     private static final String s_name = "listniciranvpdeviceresponse";

--- a/cosmic-core/server/src/main/java/com/cloud/api/auth/DefaultLoginAPIAuthenticatorCmd.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/auth/DefaultLoginAPIAuthenticatorCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.auth;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiConstants;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.ApiServerService;
@@ -23,7 +24,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "login", description = "Logs a user into the CloudStack. A successful login attempt will generate a JSESSIONID cookie value that can be passed in subsequent " +
+@APICommand(name = "login", group = APICommandGroup.AuthenticationService, description = "Logs a user into the CloudStack. A successful login attempt will generate a JSESSIONID cookie value that can be passed in subsequent " +
         "Query command calls until the \"logout\" command has been issued or the session has expired.", requestHasSensitiveInfo = true, responseObject = LoginCmdResponse.class,
         entityType = {})
 public class DefaultLoginAPIAuthenticatorCmd extends BaseCmd implements APIAuthenticator {

--- a/cosmic-core/server/src/main/java/com/cloud/api/auth/DefaultLogoutAPIAuthenticatorCmd.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/auth/DefaultLogoutAPIAuthenticatorCmd.java
@@ -1,6 +1,7 @@
 package com.cloud.api.auth;
 
 import com.cloud.api.APICommand;
+import com.cloud.api.APICommandGroup;
 import com.cloud.api.ApiErrorCode;
 import com.cloud.api.BaseCmd;
 import com.cloud.api.ServerApiException;
@@ -18,7 +19,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@APICommand(name = "logout", description = "Logs out the user", responseObject = LogoutCmdResponse.class, entityType = {})
+@APICommand(name = "logout", group = APICommandGroup.AuthenticationService, description = "Logs out the user", responseObject = LogoutCmdResponse.class, entityType = {})
 public class DefaultLogoutAPIAuthenticatorCmd extends BaseCmd implements APIAuthenticator {
 
     public static final Logger s_logger = LoggerFactory.getLogger(DefaultLoginAPIAuthenticatorCmd.class.getName());


### PR DESCRIPTION
This PR adds a service group field to all API commands, so listApis will return this group for automatic generation of API doc and API clients.

Both name and group are mandatory for all API commands.