### PR TITLE
Enable sftp in systemvm sshd config

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/utils.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/utils.py
@@ -122,6 +122,8 @@ ChallengeResponseAuthentication no
 
 PrintMotd yes
 
+Subsystem sftp /usr/libexec/openssh/sftp-server
+
 AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
 AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
 AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE


### PR DESCRIPTION
This makes ansible happy, doesn't really hurt to enable this.

This was enabled on the earlier debian systemvm