### PR TITLE
Update pom.xml

### DIFF
--- a/cosmic-core/systemvm/pom.xml
+++ b/cosmic-core/systemvm/pom.xml
@@ -49,13 +49,15 @@
                                         <include name="**/*" />
                                         <exclude name="**/.classpath" />
                                         <exclude name="**/log**" />
-                                        <exclude name="**/logrotate.d" />
+                                        <exclude name="**/logrotate.d/**" />
                                         <exclude name="**/.project" />
+                                        <exclude name="**/systemd/**" />
                                         <exclude name="**/wscript_build" />
                                     </tarfileset>
                                     <tarfileset dir="${basedir}/target/build-patch/" filemode="644">
                                         <include name="**/log**" />
                                         <include name="**/logrotate.d/**" />
+                                        <include name="**/systemd/**" />
                                     </tarfileset>
                                 </tar>
 


### PR DESCRIPTION
- remove executable bit from systemd unit files
- include logrotate config only once

```
Feb  1 08:03:53 r-65541-betanl1 systemd[1]: Configuration file /usr/lib/systemd/system/cosmic-agent.service is marked executable. Please remove executable permission bits. Proceeding anyway.
Feb  1 08:03:53 r-65541-betanl1 systemd[1]: Configuration file /usr/lib/systemd/system/cosmic-password-server@.service is marked executable. Please remove executable permission bits. Proceeding anyway.
```

```
tar tzvf /mnt/cdrom/cloud-scripts.tgz  | grep logrotate.d
-rwxr-xr-x 0/0             349 2018-01-30 13:06 etc/logrotate.d/cloud
-rwxr-xr-x 0/0             270 2018-01-30 13:06 etc/logrotate.d/conntrackd
-rwxr-xr-x 0/0             280 2018-01-30 13:06 etc/logrotate.d/dnsmasq
-rwxr-xr-x 0/0             203 2018-01-30 13:06 etc/logrotate.d/haproxy
-rwxr-xr-x 0/0             103 2018-01-30 13:06 etc/logrotate.d/ppp
-rwxr-xr-x 0/0             555 2018-01-30 13:06 etc/logrotate.d/rsyslog
drwxr-xr-x 0/0               0 2018-01-30 13:06 etc/logrotate.d/
-rw-r--r-- 0/0             349 2018-01-30 13:06 etc/logrotate.d/cloud
-rw-r--r-- 0/0             270 2018-01-30 13:06 etc/logrotate.d/conntrackd
-rw-r--r-- 0/0             280 2018-01-30 13:06 etc/logrotate.d/dnsmasq
-rw-r--r-- 0/0             203 2018-01-30 13:06 etc/logrotate.d/haproxy
-rw-r--r-- 0/0             103 2018-01-30 13:06 etc/logrotate.d/ppp
-rw-r--r-- 0/0             555 2018-01-30 13:06 etc/logrotate.d/rsyslog
```