### PR TITLE
Setup routes for RFC1918 ip space to the local mgt gateway

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/setup_cpvm.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/setup_cpvm.py
@@ -20,6 +20,7 @@ class ConsoleProxyVM:
         logging.info("Setting up configuration for %s" % self.cmdline["type"])
         self.setup_agent_config()
         setup_iptable_rules()
+        Utils(self.cmdline).set_rfc1918_routes()
 
         os.system("systemctl start cosmic-agent")
 

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/setup_ssvm.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/setup_ssvm.py
@@ -28,6 +28,7 @@ class SecondaryStorageVM:
         setup_html()
         setup_iptable_rules()
         self.setup_nginx()
+        Utils(self.cmdline).set_rfc1918_routes()
 
         os.system("systemctl start cosmic-agent")
 

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/utils.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/utils.py
@@ -202,7 +202,7 @@ Cosmic sytemvm powered by %s
             f.write(motd)
 
     def setup_default_gw(self):
-        if "gateway" in  self.cmdline:
+        if "gateway" in self.cmdline:
             with open("/etc/sysconfig/network", "w") as f:
                 f.write("GATEWAY=%s" % self.cmdline["gateway"])
 
@@ -220,3 +220,8 @@ Cosmic sytemvm powered by %s
 
     def restart_watchdog(self):
         os.system("systemctl restart watchdog")
+
+    def set_rfc1918_routes(self):
+        os.system("ip route add 10.0.0.0/8 via %s" % self.cmdline["localgw"])
+        os.system("ip route add 172.16.0.0/12 via %s" % self.cmdline["localgw"])
+        os.system("ip route add 192.168.0.0/16 via %s" % self.cmdline["localgw"])


### PR DESCRIPTION
```
[root@v-8-vm network-scripts]# ip r
default via 100.64.0.1 dev eth2
8.8.4.4 via 192.168.22.1 dev eth1
10.0.0.0/8 via 192.168.22.1 dev eth1
100.64.0.0/24 dev eth2 proto kernel scope link src 100.64.0.2
169.254.0.0/16 dev eth0 proto kernel scope link src 169.254.0.182
172.16.0.0/12 via 192.168.22.1 dev eth1
192.168.0.0/16 via 192.168.22.1 dev eth1
192.168.22.0/24 dev eth1 proto kernel scope link src 192.168.22.131
```