### PR TITLE
Do not use ZeroConf on the ssvm and cpvm

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/utils.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/utils.py
@@ -29,6 +29,7 @@ class Utils:
                 ifcfg = """
 DEVICE="eth%s"
 IPV6INIT="no"
+NOZEROCONF="yes"
 BOOTPROTO="none"
 ONBOOT="yes"
 HWADDR="%s"


### PR DESCRIPTION
This removes these routes from ssvm and cpvm:

```
169.254.0.0/16 dev eth0 scope link metric 1002
169.254.0.0/16 dev eth1 scope link metric 1003
169.254.0.0/16 dev eth2 scope link metric 1004
```