### PR TITLE
Add local domain to dnsmasq config to allow local dns resolving

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/dhcp_service.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/dhcp_service.py
@@ -44,6 +44,7 @@ class DhcpService:
 
         filename = 'dnsmasq_global.conf'
         content = self.jinja_env.get_template('dnsmasq_global.conf').render(
+            domain_name=self.config.dbag_cmdline['config']['domain'],
             interfaces=interfaces
         )
 

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/templates/dnsmasq_global.conf
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/templates/dnsmasq_global.conf
@@ -16,3 +16,5 @@ except-interface=lo
 except-interface={{ interface }}
 {% endfor %}
 bind-dynamic
+local=/{{ domain_name }}/
+domain={{ domain_name }}


### PR DESCRIPTION
This was impossible before this fix:
In the example the VPC has a domain name of `magweg.vpc`
```
[root@Macchinina ~]# nslookup vm1
Server:    10.0.0.1
Address 1: 10.0.0.1

Name:      vm1
Address 1: 10.0.0.90 vm1.magweg.vpc
[root@Macchinina ~]# nslookup vm1.magweg.vpc
Server:    10.0.0.1
Address 1: 10.0.0.1

Name:      vm1.magweg.vpc
Address 1: 10.0.0.90 vm1.magweg.vpc
```