### PR TITLE
Allow routers to reboot without destroying instance on hv

### DIFF
--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1484,9 +1484,11 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         vm.addComponent(features);
 
         final TermPolicy term = new TermPolicy();
-        term.setCrashPolicy("destroy");
-        term.setPowerOffPolicy("destroy");
-        term.setRebootPolicy("destroy");
+        if (VirtualMachine.Type.DomainRouter.equals(vmTo.getType())) {
+            term.setCrashPolicy("restart");
+            term.setPowerOffPolicy("restart");
+            term.setRebootPolicy("restart");
+        }
         vm.addComponent(term);
 
         final ClockDef clock = new ClockDef();


### PR DESCRIPTION
Normal VM:
```
[root@kvm1 ~]# virsh dumpxml i-2-11-VM | grep on_
  <on_poweroff>destroy</on_poweroff>
  <on_reboot>destroy</on_reboot>
  <on_crash>destroy</on_crash>
```

Router:
```
[root@kvm2 ~]# virsh dumpxml r-10-VM | grep on_
  <on_poweroff>restart</on_poweroff>
  <on_reboot>restart</on_reboot>
  <on_crash>restart</on_crash>
```