### PR TITLE
When stopping or deleting VPN always proceed

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
@@ -444,11 +444,6 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
                 result = result & element.stopSite2SiteVpn(conn);
             }
 
-            if (!result) {
-                conn.setState(State.Error);
-                _vpnConnectionDao.persist(conn);
-                throw new ResourceUnavailableException("Failed to apply site-to-site VPN", Site2SiteVpnConnection.class, id);
-            }
         } finally {
             _vpnConnectionDao.releaseFromLockTable(conn.getId());
         }


### PR DESCRIPTION
This allows deleting a VPN connection that is Disconnected or in Error state. Before, it had to execute a successful stop first, which is not possible in Error state. This tries, and then deletes the connection. The desired state config should take care of the rest.