### PR TITLE
Honor systemvm template version for SecStorage and ConsoleProxy VMs

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
@@ -964,9 +964,10 @@ public class ConsoleProxyManagerImpl extends SystemVmManagerBase implements Cons
             return null;
         }
 
-        VMTemplateVO template = null;
         final HypervisorType availableHypervisor = _resourceMgr.getAvailableHypervisor(dataCenterId);
-        template = _templateDao.findSystemVMReadyTemplate(dataCenterId, availableHypervisor);
+        final String templateName = retrieveTemplateName(dataCenterId);
+        final VMTemplateVO template = _templateDao.findRoutingTemplate(availableHypervisor, templateName);
+
         if (template == null) {
             throw new CloudRuntimeException("Not able to find the System templates or not downloaded in zone " + dataCenterId);
         }

--- a/cosmic-core/server/src/main/java/com/cloud/storage/secondary/SecondaryStorageManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/storage/secondary/SecondaryStorageManagerImpl.java
@@ -1105,9 +1105,10 @@ public class SecondaryStorageManagerImpl extends SystemVmManagerBase implements 
             return new HashMap<>();
         }
 
-        final VMTemplateVO template;
         final HypervisorType availableHypervisor = _resourceMgr.getAvailableHypervisor(dataCenterId);
-        template = _templateDao.findSystemVMReadyTemplate(dataCenterId, availableHypervisor);
+        final String templateName = retrieveTemplateName(dataCenterId);
+        final VMTemplateVO template = _templateDao.findRoutingTemplate(availableHypervisor, templateName);
+
         if (template == null) {
             throw new CloudRuntimeException("Not able to find the System templates or not downloaded in zone " + dataCenterId);
         }

--- a/cosmic-core/server/src/main/java/com/cloud/systemvm/SystemVmManagerBase.java
+++ b/cosmic-core/server/src/main/java/com/cloud/systemvm/SystemVmManagerBase.java
@@ -7,6 +7,7 @@ import com.cloud.context.CallContext;
 import com.cloud.db.model.Zone;
 import com.cloud.dc.DataCenterVO;
 import com.cloud.dc.dao.DataCenterDao;
+import com.cloud.framework.config.ConfigKey;
 import com.cloud.host.dao.HostDao;
 import com.cloud.info.RunningHostCountInfo;
 import com.cloud.info.RunningHostInfoAgregator;
@@ -17,6 +18,7 @@ import com.cloud.network.Networks.TrafficType;
 import com.cloud.network.dao.IPAddressVO;
 import com.cloud.network.dao.NetworkDao;
 import com.cloud.network.dao.NetworkVO;
+import com.cloud.network.router.VirtualNetworkApplianceManager;
 import com.cloud.network.rules.RulesManager;
 import com.cloud.utils.DateUtil;
 import com.cloud.utils.component.ManagerBase;
@@ -157,4 +159,10 @@ public abstract class SystemVmManagerBase extends ManagerBase implements SystemV
                 return;
         }
     }
+
+    protected String retrieveTemplateName(final long datacenterId) {
+        final ConfigKey<String> hypervisorConfigKey = VirtualNetworkApplianceManager.RouterTemplateKvm;
+        return hypervisorConfigKey.valueIn(datacenterId);
+    }
+
 }


### PR DESCRIPTION
Use the same template form routers and systemvms. Just registering and pointing the setting to it, will make it work. No more DB hacks needed.

Before:
```
[root@s-1-vm ~]# cat /etc/cosmic-release
Cosmic Release 17.11.30 Thu Nov 30 15:33:52 GMT 2017
```

After:
```
[root@s-5-vm ~]# cat /etc/cosmic-release
Cosmic Release 18.2.15 Thu Feb 15 13:00:39 GMT 2018
```