### PR TITLE
Handle race condition in the monitoring of the migration process on KVM

### DIFF
--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
@@ -109,13 +109,21 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
 
                 // pause vm if we meet the vm.migrate.pauseafter threshold and not already paused
                 final int migratePauseAfter = libvirtComputingResource.getMigratePauseAfter();
-                if (migratePauseAfter > 0 && sleeptime > migratePauseAfter && dm.getInfo().state == DomainState.VIR_DOMAIN_RUNNING) {
-                    s_logger.info("Pausing VM " + vmName + " due to property vm.migrate.pauseafter setting to " + migratePauseAfter + "ms to complete migration");
+                if (migratePauseAfter > 0 && sleeptime > migratePauseAfter) {
+                    DomainState state = null;
                     try {
-                        dm.suspend();
+                        state = dm.getInfo().state;
                     } catch (final LibvirtException e) {
-                        // pause could be racy if it attempts to pause right when vm is finished, simply warn
-                        s_logger.info("Failed to pause vm " + vmName + " : " + e.getMessage());
+                        s_logger.info("Couldn't get VM domain state after " + sleeptime + "ms: " + e.getMessage());
+                    }
+                    if (state != null && state == DomainState.VIR_DOMAIN_RUNNING) {
+                        try {
+                            s_logger.info("Pausing VM " + vmName + " due to property vm.migrate.pauseafter setting to " + migratePauseAfter + "ms to complete migration");
+                            dm.suspend();
+                        } catch (final LibvirtException e) {
+                            // pause could be racy if it attempts to pause right when vm is finished, simply warn
+                            s_logger.info("Failed to pause vm " + vmName + " : " + e.getMessage());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This is issue is reported under these conditions:
- VM migration has physically finished
- Migration thread executor is still not marked as terminated

```
There is a race condition in the monitoring of the migration process on KVM. 
If the monitor wakes up in the tight window after the migration succeeds,
but before the migration thread terminates, the monitor will get a LibvirtException 
“Domain not found: no domain with matching uuid” when checking on the migration status. 
This in turn causes CloudStack to sync the VM state to stop, in which it issues a defensive 
StopCommand to ensure it is correctly synced.

Fix: Prevent LibvirtException: "Domain not found" caused by the call to dm.getInfo()
```

```
From the migration monitoring process, as VM has been migrated, that domain cannot 
be found (we should get the destination domain from the migration thread later) and the
LibvirtException is thrown: LibvirtException “Domain not found: no domain with matching uuid”.
So basically the idea is just logging the issue but not suspending the VM as the migration has
already been performed, but the migration thread is not marked as finished. Once the migrarion
thread is marked as finished, the migration monitoring process (while loop) ends and the migration
command wrapper would continue its execution.
Regarding your last question, we won't need to suspend the VM in this case as the migration has
already been performed. VM suspension will take place whenever the migration is in progress and
those conditions are met.
```
Thanks @nvazquez !
