### PR TITLE
Set terminate policy to destroy for routers

### DIFF
--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceProperties.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceProperties.java
@@ -571,7 +571,7 @@ public class LibvirtComputingResourceProperties implements PropertiesPojo {
         public static final int DEFAULT_VM_MIGRATE_SPEED = -1;
 
         public static final String DEFAULT_TERMPOLICY_CRASH_ROUTER = "restart";
-        public static final String DEFAULT_TERMPOLICY_POWEROFF_ROUTER = "restart";
+        public static final String DEFAULT_TERMPOLICY_POWEROFF_ROUTER = "destroy";
         public static final String DEFAULT_TERMPOLICY_REBOOT_ROUTER = "restart";
 
         public static final String DEFAULT_TERMPOLICY_CRASH_VM = "destroy";


### PR DESCRIPTION
This should speedup stop/destroy of routers (and so also the build time of PRs)