### PR TITLE
TemplateSync should not remove ready and downloaded templates on its own

### DIFF
--- a/cosmic-core/engine/storage/image/src/main/java/com/cloud/storage/image/TemplateServiceImpl.java
+++ b/cosmic-core/engine/storage/image/src/main/java/com/cloud/storage/image/TemplateServiceImpl.java
@@ -407,6 +407,8 @@ public class TemplateServiceImpl implements TemplateService {
                                         && tmpltStore.getState() == State.Ready
                                         && tmpltStore.getInstallPath() == null) {
                                     s_logger.info("Keep fake entry in template store table for migration of previous NFS to object store");
+                                } else if (tmpltStore.getState() == State.Ready && tmpltStore.getDownloadState() == VMTemplateStorageResourceAssoc.Status.DOWNLOADED) {
+                                    s_logger.info("Keep template " + uniqueName + " entry as state is Ready and downloaded. No need to download again.");
                                 } else {
                                     s_logger.info("Removing leftover template " + uniqueName + " entry from template store table");
                                     // remove those leftover entries


### PR DESCRIPTION
An issue on the template sync killed all templates:

```
2018-03-13 12:26:30.403 ERROR [c.c.s.d.DownloadListener] (logid: f486fc42) (ctx: 52fff33e) Caught exception while doing template/volume sync
com.cloud.utils.exception.CloudRuntimeException: Failed to send command, due to Agent:34600, com.cloud.exception.OperationTimedoutException: Commands 6768910239937855495 to Host 34600 timed out after 3600
        at com.cloud.storage.RemoteHostEndPoint.sendMessage(RemoteHostEndPoint.java:179)
        at com.cloud.storage.volume.VolumeServiceImpl.listVolume(VolumeServiceImpl.java:1514)
        at com.cloud.storage.volume.VolumeServiceImpl.handleVolumeSync(VolumeServiceImpl.java:1335)
        at com.cloud.storage.download.DownloadListener.processConnect(DownloadListener.java:261)
        at com.cloud.agent.manager.AgentManagerImpl.notifyMonitorsOfConnection(AgentManagerImpl.java:873)
        at com.cloud.agent.manager.AgentManagerImpl.handleConnectedAgent(AgentManagerImpl.java:736)
        at com.cloud.agent.manager.AgentManagerImpl.access$000(AgentManagerImpl.java:103)
        at com.cloud.agent.manager.AgentManagerImpl$HandleAgentConnectTask.runInContext(AgentManagerImpl.java:1312)
        at com.cloud.managed.context.ManagedContextRunnable$1.run(ManagedContextRunnable.java:39)
        at com.cloud.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:38)
        at com.cloud.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:84)
        at com.cloud.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:35)
        at com.cloud.managed.context.ManagedContextRunnable.run(ManagedContextRunnable.java:36)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
```

and then lots of these:

```
2018-03-13 12:26:30.491 INFO  [c.c.s.i.TemplateServiceImpl] (logid: 2d6608d8) (ctx: 29b58caa) Template Sync did not find 352-2-380e8a15-fd3b-30fc-a3fd-487cb1478c16 on image store 7, may request download based on available hypervisor types
```
