### PR TITLE
Apply public IP ACLs when defining load-balancing/port-forwarding rules

### DIFF
--- a/cosmic-core/engine/orchestration/src/main/java/com/cloud/engine/orchestration/NetworkOrchestrator.java
+++ b/cosmic-core/engine/orchestration/src/main/java/com/cloud/engine/orchestration/NetworkOrchestrator.java
@@ -2435,7 +2435,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
             List<IPAddressVO> ips = null;
             final Account owner = _entityMgr.findById(Account.class, network.getAccountId());
             if (network.getVpcId() != null) {
-                ips = _ipAddressDao.listByAssociatedVpc(network.getVpcId(), true);
+                ips = _ipAddressDao.listByVpc(network.getVpcId(), true);
                 if (ips.isEmpty()) {
                     final Vpc vpc = _vpcMgr.getActiveVpc(network.getVpcId());
                     s_logger.debug("Creating a source nat ip for vpc " + vpc);

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/network/dao/IPAddressDao.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/network/dao/IPAddressDao.java
@@ -50,7 +50,9 @@ public interface IPAddressDao extends GenericDao<IPAddressVO, Long> {
 
     List<IPAddressVO> listByVpcAndSourceNetwork(long vpcId, long networkId);
 
-    List<IPAddressVO> listByAssociatedVpc(long vpcId, Boolean isSourceNat);
+    List<IPAddressVO> listByVpc(long vpcId, Boolean isSourceNat);
+
+    List<IPAddressVO> listByVpcWithAssociatedNetwork(long vpcId);
 
     long countFreePublicIPs();
 

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -425,8 +425,8 @@ public class CommandSetupHelper {
         cmds.addCommand(cmd);
     }
 
-    public void createPublicIpACLsCommands(final DomainRouterVO router, final Commands cmds, final long networkId) {
-        final List<IPAddressVO> publicIps = _ipAddressDao.listByVpcAndSourceNetwork(router.getVpcId(), networkId);
+    public void createPublicIpACLsCommands(final DomainRouterVO router, final Commands cmds) {
+        final List<IPAddressVO> publicIps = _ipAddressDao.listByVpcWithAssociatedNetwork(router.getVpcId());
         publicIps.forEach(ipAddressVO -> {
             final Long aclId = ipAddressVO.getIpACLId();
             if (aclId != null) {

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -551,7 +551,7 @@ public class CommandSetupHelper {
                     if (TrafficType.Public.equals(trafficType)) {
                         ipv4Addresses.addAll(_ipAddressDao.listByAssociatedVpc(router.getVpcId(), false)
                                                           .stream()
-                                                          .filter(ipAddressVO -> !ipsToExclude.contains(ipAddressVO.getAddress()))
+                                                          .filter(ipAddressVO -> !ipsToExclude.contains(ipAddressVO.getAddress()) && ipAddressVO.getAssociatedWithNetworkId() != null)
                                                           .map(ipAddressVO -> {
                                                               final Ip ip = ipAddressVO.getAddress();
                                                               final VlanVO vlanVO = _vlanDao.findById(ipAddressVO.getVlanId());

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -549,7 +549,7 @@ public class CommandSetupHelper {
                 if (network != null) {
                     final TrafficType trafficType = network.getTrafficType();
                     if (TrafficType.Public.equals(trafficType)) {
-                        ipv4Addresses.addAll(_ipAddressDao.listByAssociatedVpc(router.getVpcId(), false)
+                        ipv4Addresses.addAll(_ipAddressDao.listByVpc(router.getVpcId(), false)
                                                           .stream()
                                                           .filter(ipAddressVO -> !ipsToExclude.contains(ipAddressVO.getAddress()) && ipAddressVO.getAssociatedWithNetworkId() != null)
                                                           .map(ipAddressVO -> {
@@ -561,7 +561,7 @@ public class CommandSetupHelper {
                                                           })
                                                           .collect(Collectors.toList()));
 
-                        serviceSourceNatsTO.addAll(_ipAddressDao.listByAssociatedVpc(router.getVpcId(), true)
+                        serviceSourceNatsTO.addAll(_ipAddressDao.listByVpc(router.getVpcId(), true)
                                                                 .stream()
                                                                 .map(IPAddressVO::getAddress)
                                                                 .filter(ip -> !ipsToExclude.contains(ip))

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/VpcNetworkHelperImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/VpcNetworkHelperImpl.java
@@ -97,7 +97,7 @@ public class VpcNetworkHelperImpl extends NetworkHelperImpl {
         }
 
         //4) allocate nic for additional public network(s)
-        final List<IPAddressVO> ips = _ipAddressDao.listByAssociatedVpc(vpcId, false);
+        final List<IPAddressVO> ips = _ipAddressDao.listByVpc(vpcId, false);
         final List<NicProfile> publicNics = new ArrayList<>();
         Network publicNetwork = null;
         for (final IPAddressVO ip : ips) {

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
@@ -311,14 +311,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                         _userStatsDao.persist(stats);
                     }
 
-                    final List<IPAddressVO> publicIps = _ipAddressDao.listByVpcAndSourceNetwork(domainRouterVO.getVpcId(), publicNtwk.getId());
-                    publicIps.forEach(ipAddressVO -> {
-                        final Long aclId = ipAddressVO.getIpACLId();
-                        if (aclId != null) {
-                            final List<NetworkACLItemVO> rules = _networkACLItemDao.listByACL(ipAddressVO.getIpACLId());
-                            _commandSetupHelper.createPublicIpACLsCommands(rules, domainRouterVO, cmds, ipAddressVO);
-                        }
-                    });
+                    _commandSetupHelper.createPublicIpACLsCommands(domainRouterVO, cmds, publicNtwk.getId());
                 }
 
                 // create ip assoc for source nat

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
@@ -311,7 +311,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                         _userStatsDao.persist(stats);
                     }
 
-                    _commandSetupHelper.createPublicIpACLsCommands(domainRouterVO, cmds, publicNtwk.getId());
+                    _commandSetupHelper.createPublicIpACLsCommands(domainRouterVO, cmds);
                 }
 
                 // create ip assoc for source nat

--- a/cosmic-core/server/src/main/java/com/cloud/network/topology/BasicNetworkVisitor.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/topology/BasicNetworkVisitor.java
@@ -72,13 +72,12 @@ public class BasicNetworkVisitor extends NetworkTopologyVisitor {
 
     @Override
     public boolean visit(final StaticNatRules nat) throws ResourceUnavailableException {
-        final Network network = nat.getNetwork();
         final DomainRouterVO router = (DomainRouterVO) nat.getRouter();
         final List<? extends StaticNat> rules = nat.getRules();
 
         final Commands cmds = new Commands(Command.OnError.Continue);
         _commandSetupHelper.createApplyStaticNatCommands(rules, router, cmds);
-        _commandSetupHelper.createPublicIpACLsCommands(router, cmds, network.getPhysicalNetworkId());
+        _commandSetupHelper.createPublicIpACLsCommands(router, cmds);
 
         return _networkGeneralHelper.sendCommandsToRouter(router, cmds);
     }
@@ -91,7 +90,7 @@ public class BasicNetworkVisitor extends NetworkTopologyVisitor {
 
         final Commands cmds = new Commands(Command.OnError.Continue);
         _commandSetupHelper.createApplyLoadBalancingRulesCommands(rules, router, cmds, network.getId());
-        _commandSetupHelper.createPublicIpACLsCommands(router, cmds, network.getPhysicalNetworkId());
+        _commandSetupHelper.createPublicIpACLsCommands(router, cmds);
 
         return _networkGeneralHelper.sendCommandsToRouter(router, cmds);
     }
@@ -106,7 +105,7 @@ public class BasicNetworkVisitor extends NetworkTopologyVisitor {
         final Purpose purpose = firewall.getPurpose();
 
         final Commands cmds = new Commands(Command.OnError.Continue);
-        _commandSetupHelper.createPublicIpACLsCommands(router, cmds, network.getPhysicalNetworkId());
+        _commandSetupHelper.createPublicIpACLsCommands(router, cmds);
         if (purpose == Purpose.LoadBalancing) {
 
             _commandSetupHelper.createApplyLoadBalancingRulesCommands(loadbalancingRules, router, cmds, network.getId());

--- a/cosmic-core/server/src/main/java/com/cloud/network/topology/BasicNetworkVisitor.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/topology/BasicNetworkVisitor.java
@@ -72,11 +72,13 @@ public class BasicNetworkVisitor extends NetworkTopologyVisitor {
 
     @Override
     public boolean visit(final StaticNatRules nat) throws ResourceUnavailableException {
-        final VirtualRouter router = nat.getRouter();
+        final Network network = nat.getNetwork();
+        final DomainRouterVO router = (DomainRouterVO) nat.getRouter();
         final List<? extends StaticNat> rules = nat.getRules();
 
         final Commands cmds = new Commands(Command.OnError.Continue);
         _commandSetupHelper.createApplyStaticNatCommands(rules, router, cmds);
+        _commandSetupHelper.createPublicIpACLsCommands(router, cmds, network.getPhysicalNetworkId());
 
         return _networkGeneralHelper.sendCommandsToRouter(router, cmds);
     }
@@ -89,6 +91,7 @@ public class BasicNetworkVisitor extends NetworkTopologyVisitor {
 
         final Commands cmds = new Commands(Command.OnError.Continue);
         _commandSetupHelper.createApplyLoadBalancingRulesCommands(rules, router, cmds, network.getId());
+        _commandSetupHelper.createPublicIpACLsCommands(router, cmds, network.getPhysicalNetworkId());
 
         return _networkGeneralHelper.sendCommandsToRouter(router, cmds);
     }
@@ -96,13 +99,14 @@ public class BasicNetworkVisitor extends NetworkTopologyVisitor {
     @Override
     public boolean visit(final FirewallRules firewall) throws ResourceUnavailableException {
         final Network network = firewall.getNetwork();
-        final VirtualRouter router = firewall.getRouter();
+        final DomainRouterVO router = (DomainRouterVO) firewall.getRouter();
         final List<? extends FirewallRule> rules = firewall.getRules();
         final List<LoadBalancingRule> loadbalancingRules = firewall.getLoadbalancingRules();
 
         final Purpose purpose = firewall.getPurpose();
 
         final Commands cmds = new Commands(Command.OnError.Continue);
+        _commandSetupHelper.createPublicIpACLsCommands(router, cmds, network.getPhysicalNetworkId());
         if (purpose == Purpose.LoadBalancing) {
 
             _commandSetupHelper.createApplyLoadBalancingRulesCommands(loadbalancingRules, router, cmds, network.getId());

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -977,7 +977,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             // disassociate the public IPs if not required anymore
             if (!hasSourceNatService(vpc)) {
                 boolean success = true;
-                final List<IPAddressVO> ipsToRelease = _ipAddressDao.listByAssociatedVpc(vpcId, null);
+                final List<IPAddressVO> ipsToRelease = _ipAddressDao.listByVpc(vpcId, null);
                 s_logger.debug("Releasing ips for vpc id=" + vpcId + " as a part of vpc cleanup");
                 for (final IPAddressVO ipToRelease : ipsToRelease) {
                     success = success && _ipAddrMgr.disassociatePublicIpAddress(ipToRelease.getId(), CallContext.current().getCallingUserId(), caller);
@@ -2341,7 +2341,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         _s2sVpnMgr.cleanupVpnGatewayByVpc(vpcId);
 
         // 2) release all ip addresses
-        final List<IPAddressVO> ipsToRelease = _ipAddressDao.listByAssociatedVpc(vpcId, null);
+        final List<IPAddressVO> ipsToRelease = _ipAddressDao.listByVpc(vpcId, null);
         s_logger.debug("Releasing ips for vpc id=" + vpcId + " as a part of vpc cleanup");
         for (final IPAddressVO ipToRelease : ipsToRelease) {
             success = success && _ipAddrMgr.disassociatePublicIpAddress(ipToRelease.getId(), callerUserId, caller);

--- a/cosmic-core/server/src/main/java/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
@@ -115,7 +115,7 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
             throw new InvalidParameterValueException("The VPN gateway of VPC " + vpcId + " already exists!");
         }
         //Use source NAT ip for VPC
-        final List<IPAddressVO> ips = _ipAddressDao.listByAssociatedVpc(vpcId, true);
+        final List<IPAddressVO> ips = _ipAddressDao.listByVpc(vpcId, true);
         if (ips.size() != 1) {
             throw new CloudRuntimeException("Vpc " + vpcId + " does not have a Public IP address with SourceNat, so no VPN is possible.");
         }


### PR DESCRIPTION
Making sure the public IP ACL definition is sent to the router, before applying load-balancing and/or port-forwarding rules.

**Load balancing:**
```
-rw-r--r--. 1 root root 210 Mar 27 10:13 public_ip_acl.json.0e531cc0-b615-484d-a2fa-6e7ea9184aa4.gz
-rw-r--r--. 1 root root 594 Mar 27 10:13 load_balancer.json.2473b314-f0b3-4403-97fd-30afa1b57745.gz
```

**Port forwarding:**
```
-rw-r--r--. 1 root root 211 Mar 27 11:16 public_ip_acl.json.4ac040bb-b008-4098-a831-4298044fb0b1.gz
-rw-r--r--. 1 root root 220 Mar 27 11:16 forwarding_rules.json.fe2a4c3e-a3c4-4424-9011-4a54fc6cb93a.gz
```