### PR TITLE
Update the state of redundancy of routers when they finish starting and stopping

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -1425,8 +1425,11 @@ public class VirtualNetworkApplianceManagerImpl extends ManagerBase implements V
             _routerDao.persist(router, guestNetworks);
         }
 
-        updateRoutersRedundantState(router);
-
+        final List<DomainRouterVO> routers = _routerDao.listByVpcId(router.getVpcId());
+        for (final DomainRouterVO domainRouterVO : routers) {
+            s_logger.info("Updating the redundant state of router " + router);
+            updateRoutersRedundantState(domainRouterVO);
+        }
         return result;
     }
 

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -562,7 +562,7 @@ public class VirtualNetworkApplianceManagerImpl extends ManagerBase implements V
         boolean updated;
         updated = false;
         final RedundantState prevState = router.getRedundantState();
-        if (router.getState() != VirtualMachine.State.Running) {
+        if (router.getState() != VirtualMachine.State.Starting && router.getState() != VirtualMachine.State.Running) {
             router.setRedundantState(RedundantState.UNKNOWN);
             updated = true;
         } else {
@@ -1424,6 +1424,8 @@ public class VirtualNetworkApplianceManagerImpl extends ManagerBase implements V
             router.setScriptsVersion(versionAnswer.getScriptsVersion());
             _routerDao.persist(router, guestNetworks);
         }
+
+        updateRoutersRedundantState(router);
 
         return result;
     }


### PR DESCRIPTION
When a router is started or stopped, all routers belonging to that VPC will update their status so it's up2date after these events. Also works with reboot.