### PR TITLE
Removed deprecated settings to make l2tp working

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/templates/l2tp.conf
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/templates/l2tp.conf
@@ -5,7 +5,6 @@ conn L2TP-PSK
     keyexchange=ikev1
     forceencaps=yes
     leftfirewall=yes
-    leftnexthop=%defaultroute
     type=transport
     leftprotoport=17/1701
     right=%any
@@ -13,3 +12,5 @@ conn L2TP-PSK
     auto=add
     rightsubnetwithin=0.0.0.0/0
     authby=psk
+    ikelifetime=8h
+    keylife=1h

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/templates/options.xl2tpd.conf
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/templates/options.xl2tpd.conf
@@ -4,11 +4,10 @@ ipcp-accept-remote
 noccp
 idle 1800
 auth
-crtscts
 mtu 1410
 mru 1410
 nodefaultroute
 debug
-lock
 connect-delay 5000
+require-mschap-v2
 ms-dns {{ local_ip }}


### PR DESCRIPTION
After upgrading systemvm's to CentOS7 remote access VPN broke. This PR will remove deprecated settings from strongswan and xl2tpd config files.