### PR TITLE
 Check on gateway service instead of sourcenat

### DIFF
--- a/cosmic-core/cosmic-flyway/src/test/resources/db/migration/V9999_1__reference_data.sql
+++ b/cosmic-core/cosmic-flyway/src/test/resources/db/migration/V9999_1__reference_data.sql
@@ -374,4 +374,4 @@ VALUES (1, 7, 'Dhcp', 'VirtualRouter', '2017-12-12 14:16:24'), (2, 7, 'SecurityG
   (73, 15, 'NetworkACL', 'VpcVirtualRouter', '2017-12-12 14:16:24'), (74, 15, 'UserData', 'VpcVirtualRouter', '2017-12-12 14:16:24'), (75, 15, 'StaticNat', 'VpcVirtualRouter', '2017-12-12 14:16:24'),
   (76, 15, 'Dns', 'VpcVirtualRouter', '2017-12-12 14:16:24'), (85, 18, 'NetworkACL', 'VpcVirtualRouter', '2017-12-12 14:16:27'), (86, 18, 'UserData', 'VpcVirtualRouter', '2017-12-12 14:16:27'),
   (87, 18, 'Dns', 'VpcVirtualRouter', '2017-12-12 14:16:27'), (88, 19, 'Dhcp', 'VpcVirtualRouter', '2017-12-12 14:16:27'), (89, 19, 'NetworkACL', 'VpcVirtualRouter', '2017-12-12 14:16:27'),
-  (90, 19, 'UserData', 'VpcVirtualRouter', '2017-12-12 14:16:27'), (91, 19, 'Dns', 'VpcVirtualRouter', '2017-12-12 14:16:27');
+  (90, 19, 'UserData', 'VpcVirtualRouter', '2017-12-12 14:16:27'), (91, 19, 'Dns', 'VpcVirtualRouter', '2017-12-12 14:16:27'), (92, 19, 'Gateway', 'VpcVirtualRouter', '2017-12-12 14:16:27');

--- a/cosmic-core/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
@@ -298,9 +298,8 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
                         guestIp = _ipAddrMgr.acquireGuestIpAddress(network, nic.getRequestedIPv4());
                         break;
                     case DomainRouter:
-                        if (_networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.SourceNat, Provider.VirtualRouter) ||
-                                _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.SourceNat, Provider.VPCVirtualRouter)) {
-                            // Networks that support SourceNat acquire the gateway ip on their nic
+                        if ( _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.Gateway, Provider.VPCVirtualRouter)) {
+                            // Networks that support the Gateway service acquire the gateway ip on their nic
                             guestIp = network.getGateway();
                         } else {
                             // In other cases, acquire an ip address from the DHCP range (take lowest possible)


### PR DESCRIPTION
InternalVPC is an example that has no sourceNat service but still GatewayService. Therefore, we need to check on that service. This used to be like this, but regression from commit https://github.com/MissionCriticalCloud/cosmic/commit/49f78f2108c97c0b63132ebdd6e123282733212d#diff-5611d1e3c86e7817f4e99945d1a65c88