### PR TITLE
No longer log all the firewall rules as this fills the disk

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/CsNetfilter.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/CsNetfilter.py
@@ -141,7 +141,10 @@ class CsNetfilters(object):
             if isinstance(fw[1], int):
                 new_rule.set_count(fw[1])
 
-            logging.info("Add: rule=%s table=%s", fw[2], new_rule.get_table())
+            # This makes the logs very verbose, you probably don't want this
+            # Uncomment when debugging
+            # logging.info("Add: rule=%s table=%s", fw[2], new_rule.get_table())
+
             # front means insert instead of append
             cpy = fw[2]
             if fw[1] == "front":


### PR DESCRIPTION
86% of log messages is this line...

```
[root@r-596313-nlX router]# cat router.log | wc -l
8718336
[root@r-596313-nlX router]# cat router.log | grep "CsNetfilter.py" | wc -l
7487834
```