### PR TITLE
Add the ability to include custom logback configurations

### DIFF
--- a/cosmic-client/src/main/resources/logback.xml
+++ b/cosmic-client/src/main/resources/logback.xml
@@ -50,6 +50,9 @@
         </encoder>
     </appender>
 
+    <include resource="logback-custom.xml"/>
+    <!-- Include your custom logback configuration in /etc/cosmic/management/logback-custom.xml -->
+
     <logger name="com.cloud.utils.db.GenericDaoBase" level="WARN" />
     <logger name="com.cloud.spring" level="WARN" />
 


### PR DESCRIPTION
Add the ability to create a logback-custom.xml configuration in /etc/cosmic/management using includes to append/add this to the default logback configuration in Cosmic. An example of adding a Gelf appender for Graylog:

```
<included>

<appender name="gelf" class="biz.paluch.logging.gelf.logback.GelfLogbackAppender">
        <host>udp:192.168.22.1</host>
        <port>12201</port>
        <version>1.1</version>
        <facility>cosmic-mgmt</facility>
        <extractStackTrace>true</extractStackTrace>
        <filterStackTrace>true</filterStackTrace>
        <mdcProfiling>true</mdcProfiling>
        <timestampPattern>yyyy-MM-dd HH:mm:ss,SSSS</timestampPattern>
        <maximumMessageSize>8192</maximumMessageSize>

        <!-- This are fields using MDC -->
        <includeFullMdc>true</includeFullMdc>
        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
            <level>DEBUG</level>
        </filter>
    </appender>

    <root level="debug">
        <appender-ref ref="gelf" />
    </root>

</included>
```