### PR TITLE
Honor the diskBusType for DATA disks

### DIFF
--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1710,11 +1710,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 } else if (pool.getType() == StoragePoolType.CLVM || physicalDisk.getFormat() == PhysicalDiskFormat.RAW) {
                     disk.defBlockBasedDisk(physicalDisk.getPath(), devId, diskBusType);
                 } else {
-                    if (volume.getType() == Volume.Type.DATADISK) {
-                        disk.defFileBasedDisk(physicalDisk.getPath(), devId, LibvirtDiskDef.DiskBus.VIRTIO, LibvirtDiskDef.DiskFmtType.QCOW2);
-                    } else {
-                        disk.defFileBasedDisk(physicalDisk.getPath(), devId, diskBusType, LibvirtDiskDef.DiskFmtType.QCOW2);
-                    }
+                    disk.defFileBasedDisk(physicalDisk.getPath(), devId, diskBusType, LibvirtDiskDef.DiskFmtType.QCOW2);
                 }
             }
 

--- a/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/cosmic-core/plugins/hypervisor/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1520,10 +1520,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         final InputDef input = new InputDef("tablet", "usb");
         devices.addDevice(input);
 
-        LibvirtDiskDef.DiskBus diskBusType = getDiskModelFromVmDetail(vmTo);
-        if (diskBusType == null) {
-            diskBusType = getGuestDiskModel(vmTo.getPlatformEmulator());
-        }
+        // get Disk controller from VM
+        LibvirtDiskDef.DiskBus diskBusType = getGuestDiskModel(vmTo.getPlatformEmulator());
 
         // If we're using virtio scsi, then we need to add a virtual scsi controller
         if (diskBusType == LibvirtDiskDef.DiskBus.SCSI) {
@@ -1669,13 +1667,10 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 logger.debug("Disk activity check cleared");
             }
 
-            // if params contains a rootDiskController key, use its value (this is what other HVs are doing)
-            LibvirtDiskDef.DiskBus diskBusType = getDiskModelFromVmDetail(vmSpec);
+            // get Disk controller from VM
+            LibvirtDiskDef.DiskBus diskBusType = getGuestDiskModel(vmSpec.getPlatformEmulator());
+            logger.debug("disk bus type for " + vmName + " derived from getPlatformEmulator: " + vmSpec.getPlatformEmulator() + ", diskbustype is: " + diskBusType.toString());
 
-            if (diskBusType == null) {
-                diskBusType = getGuestDiskModel(vmSpec.getPlatformEmulator());
-                logger.debug("disk bus type for " + vmName + " derived from getPlatformEmulator: " + vmSpec.getPlatformEmulator() + ", diskbustype is: " + diskBusType.toString());
-            }
             final LibvirtDiskDef disk = new LibvirtDiskDef();
             if (volume.getType() == Volume.Type.ISO) {
                 if (volPath == null) {
@@ -1754,25 +1749,6 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     @Override
     public Type getType() {
         return Type.Routing;
-    }
-
-    public LibvirtDiskDef.DiskBus getDiskModelFromVmDetail(final VirtualMachineTO vmTO) {
-        Map<String, String> details = vmTO.getDetails();
-        if (details == null) {
-            return null;
-        }
-
-        final String rootDiskController = details.get(VmDetailConstants.ROOT_DISK_CONTROLLER);
-        if (StringUtils.isNotBlank(rootDiskController)) {
-            logger.debug("Passed custom disk bus " + rootDiskController);
-            for (final LibvirtDiskDef.DiskBus bus : LibvirtDiskDef.DiskBus.values()) {
-                if (bus.toString().equalsIgnoreCase(rootDiskController)) {
-                    logger.debug("Found matching enum for disk bus " + rootDiskController);
-                    return bus;
-                }
-            }
-        }
-        return null;
     }
 
     private LibvirtDiskDef.DiskBus getGuestDiskModel(final String platformEmulator) {


### PR DESCRIPTION
At VM start DATA disks would be hard-coded to VirtIO. When using SCSI this is not desired. It will now use the same controller. Also removed looking the controller up from the vm details.