### PR TITLE
[WIP] Fix iptables output rules

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/firewall.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/firewall.py
@@ -59,6 +59,7 @@ class Firewall:
         self.fw.append(["filter", "", "-P FORWARD DROP"])
 
         self.fw.append(["filter", "", "-A FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT"])
+        self.fw.append(["filter", "", "-A OUTPUT -m state --state RELATED,ESTABLISHED -j ACCEPT"])
 
         self.fw.append(["mangle", "front", "-A POSTROUTING -p udp -m udp --dport 68 -j CHECKSUM --checksum-fill"])
 
@@ -85,6 +86,9 @@ class Firewall:
         self.fw.append(["filter", "", "-A INPUT -i %s -m state --state RELATED,ESTABLISHED -j ACCEPT" % device])
         self.fw.append(["filter", "", "-A FORWARD -m state --state NEW -o %s -j ACL_INBOUND_%s" % (device, device)])
         self.fw.append(["filter", "", "-A OUTPUT -m state --state NEW -o %s -j ACL_INBOUND_%s" % (device, device)])
+        self.fw.append(["filter", "", "-A OUTPUT -m state --state NEW -o %s -m limit --limit 2/second -j LOG "
+                                      "--log-prefix \"iptables denied: [output] \" --log-level 4" % device])
+        self.fw.append(["filter", "", "-A OUTPUT -m state --state NEW -o %s -j DROP" % device])
 
         self.fw.append(["filter", "front", "-A ACL_INBOUND_%s -d 224.0.0.18/32 -j ACCEPT" % device])
         self.fw.append(["filter", "front", "-A ACL_INBOUND_%s -d 224.0.0.22/32 -j ACCEPT" % device])

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/databag/cs_iptables_save.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/databag/cs_iptables_save.py
@@ -184,7 +184,11 @@ class Tables(UserDict):
                             print(elem, file=f)
                         # not really the correct place for this, but for now it is the only working place.
                         if (key == "filter") and (elem is not None) and elem.startswith("INPUT", 3):
-                            print("-A INPUT -m limit --limit 2/second -j LOG --log-prefix \"iptables denied: [input]\" --log-level 4", file=f)
+                            print("-A INPUT -m limit --limit 2/second -j LOG --log-prefix "
+                                  "\"iptables denied: [input] \" --log-level 4", file=f)
+                        if (key == "filter") and (elem is not None) and elem.startswith("FORWARD", 3):
+                            print("-A FORWARD -m limit --limit 2/second -j LOG --log-prefix "
+                                  "\"iptables denied: [ingress] \" --log-level 4", file=f)
                     print("COMMIT", file=f)
 
     def put_into_tables(self, line):


### PR DESCRIPTION
the current OUTPUT jump to ACL_INBOUND_* chain is useless, because there is no default DROP in OUTPUT. 

This is fixed in this PR by adding a jump to DROP if the same conditions are met as for the prior jump to the ACL_INBOUND_* chain. 