### PR TITLE
Reapply previously working rsyslog.conf

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/etc/rsyslog.conf
+++ b/cosmic-core/systemvm/patches/centos7/etc/rsyslog.conf
@@ -1,0 +1,130 @@
+# Patched configuration file from latest rsyslog package breaks remote syslog forwarding
+# This was the previously working configuration file with all comments stripped.
+# TODO: Fix new configuration file so it works again.
+
+$ModLoad imuxsock # provides support for local system logging
+$ModLoad imklog   # provides kernel logging support (previously done by rklogd)
+$ModLoad imudp
+$UDPServerRun 3914
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+$FileOwner root
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+$IncludeConfig /etc/rsyslog.d/*.conf
+auth,authpriv.*                 /var/log/auth.log
+cron.*                          /var/log/cron.log
+daemon.*                        -/var/log/daemon.log
+kern.*                          -/var/log/kern.log
+lpr.*                           -/var/log/lpr.log
+mail.*                          -/var/log/mail.log
+mail.info                       -/var/log/mail.info
+mail.warn                       -/var/log/mail.warn
+mail.err                        /var/log/mail.err
+news.crit                       /var/log/news/news.crit
+news.err                        /var/log/news/news.err
+news.notice                     -/var/log/news/news.notice
+*.=info;*.=notice;*.=warn;\
+        auth,authpriv.none;\
+        cron.none,daemon.none;\
+        local0.none,daemon.none;\
+        mail.none,news.none             -/var/log/messages
+*.emerg                         *
+local0.*        -/var/log/haproxy.log
+
+###
+### NEW CONFIGURATION FILE - ALL COMMENTED OUT
+###
+
+# # rsyslog configuration file
+#
+# # For more information see /usr/share/doc/rsyslog-*/rsyslog_conf.html
+# # If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html
+#
+# #### MODULES ####
+#
+# # The imjournal module bellow is now used as a message source instead of imuxsock.
+# $ModLoad imuxsock # provides support for local system logging (e.g. via logger command)
+# $ModLoad imjournal # provides access to the systemd journal
+# #$ModLoad imklog # reads kernel messages (the same are read from journald)
+# #$ModLoad immark  # provides --MARK-- message capability
+#
+# # Provides UDP syslog reception
+# #$ModLoad imudp
+# #$UDPServerRun 514
+#
+# # Provides TCP syslog reception
+# #$ModLoad imtcp
+# #$InputTCPServerRun 514
+#
+#
+# #### GLOBAL DIRECTIVES ####
+#
+# # Where to place auxiliary files
+# $WorkDirectory /var/lib/rsyslog
+#
+# # Use default timestamp format
+# $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+#
+# # File syncing capability is disabled by default. This feature is usually not required,
+# # not useful and an extreme performance hit
+# #$ActionFileEnableSync on
+#
+# # Include all config files in /etc/rsyslog.d/
+# $IncludeConfig /etc/rsyslog.d/*.conf
+#
+# # Turn off message reception via local log socket;
+# # local messages are retrieved through imjournal now.
+# $OmitLocalLogging on
+#
+# # File to store the position in the journal
+# $IMJournalStateFile imjournal.state
+#
+#
+# #### RULES ####
+#
+# # Log all kernel messages to the console.
+# # Logging much else clutters up the screen.
+# #kern.*                                                 /dev/console
+#
+# # Log anything (except mail) of level info or higher.
+# # Don't log private authentication messages!
+# *.info;mail.none;authpriv.none;cron.none                /var/log/messages
+#
+# # The authpriv file has restricted access.
+# authpriv.*                                              /var/log/secure
+#
+# # Log all the mail messages in one place.
+# mail.*                                                  -/var/log/maillog
+#
+#
+# # Log cron stuff
+# cron.*                                                  /var/log/cron
+#
+# # Everybody gets emergency messages
+# *.emerg                                                 :omusrmsg:*
+#
+# # Save news errors of level crit and higher in a special file.
+# uucp,news.crit                                          /var/log/spooler
+#
+# # Save boot messages also to boot.log
+# local7.*                                                /var/log/boot.log
+#
+#
+# # ### begin forwarding rule ###
+# # The statement between the begin ... end define a SINGLE forwarding
+# # rule. They belong together, do NOT split them. If you create multiple
+# # forwarding rules, duplicate the whole block!
+# # Remote Logging (we use TCP for reliable delivery)
+# #
+# # An on-disk queue is created for this action. If the remote host is
+# # down, messages are spooled to disk and sent when it is up again.
+# #$ActionQueueFileName fwdRule1 # unique name prefix for spool files
+# #$ActionQueueMaxDiskSpace 1g   # 1gb space limit (use as much as possible)
+# #$ActionQueueSaveOnShutdown on # save messages to disk on shutdown
+# #$ActionQueueType LinkedList   # run asynchronously
+# #$ActionResumeRetryCount -1    # infinite retries if host is down
+# # remote host is: name/ip:port, e.g. 192.168.0.1:514, port optional
+# #*.* @@remote-host:514
+# # ### end of the forwarding rule ###


### PR DESCRIPTION
The newest rsyslog package has a new configuration file, that does not work with our remote syslog forwarding configuration file.

This is a quick fix, we should properly investigate the new configuration file and make that one work again.