### PR TITLE
Implement CacheMode API parameter

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
@@ -21,6 +21,7 @@ public class ApiConstants {
     public static final String BYTES_WRITE_RATE = "byteswriterate";
     public static final String CATEGORY = "category";
     public static final String CAN_REVERT = "canrevert";
+    public static final String CACHE_MODE = "cachemode";
     public static final String CERTIFICATE = "certificate";
     public static final String CERTIFICATE_CHAIN = "certchain";
     public static final String CERTIFICATE_FINGERPRINT = "fingerprint";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/offering/CreateDiskOfferingCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/offering/CreateDiskOfferingCmd.java
@@ -74,6 +74,9 @@ public class CreateDiskOfferingCmd extends BaseCmd {
     @Parameter(name = ApiConstants.MAX_IOPS, type = CommandType.LONG, required = false, description = "max iops of the disk offering")
     private Long maxIops;
 
+    @Parameter(name = ApiConstants.CACHE_MODE, type = CommandType.STRING, required = false, description = "cache mode to use")
+    private String cacheMode;
+
     @Parameter(name = ApiConstants.HYPERVISOR_SNAPSHOT_RESERVE,
             type = CommandType.INTEGER,
             required = false,
@@ -150,6 +153,14 @@ public class CreateDiskOfferingCmd extends BaseCmd {
 
     public Integer getHypervisorSnapshotReserve() {
         return hypervisorSnapshotReserve;
+    }
+
+    public DiskOffering.DiskCacheMode getCacheMode() {
+        if (cacheMode != null) {
+            return DiskOffering.DiskCacheMode.valueOf(cacheMode.toUpperCase());
+        } else {
+            return null;
+        }
     }
 
     /////////////////////////////////////////////////////

--- a/cosmic-core/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -96,6 +96,7 @@ import com.cloud.legacymodel.user.User;
 import com.cloud.legacymodel.utils.Pair;
 import com.cloud.model.enumeration.AllocationState;
 import com.cloud.model.enumeration.BroadcastDomainType;
+import com.cloud.model.enumeration.DiskControllerType;
 import com.cloud.model.enumeration.GuestType;
 import com.cloud.model.enumeration.HypervisorType;
 import com.cloud.model.enumeration.NetworkType;
@@ -1187,11 +1188,12 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         final Long iopsReadRate = cmd.getIopsReadRate();
         final Long iopsWriteRate = cmd.getIopsWriteRate();
         final Integer hypervisorSnapshotReserve = cmd.getHypervisorSnapshotReserve();
+        final DiskOffering.DiskCacheMode cacheMode = cmd.getCacheMode();
 
         final Long userId = CallContext.current().getCallingUserId();
         return createDiskOffering(userId, domainId, name, description, provisioningType, numGibibytes, tags, isCustomized,
                 localStorageRequired, isDisplayOfferingEnabled, isCustomizedIops, minIops,
-                maxIops, bytesReadRate, bytesWriteRate, iopsReadRate, iopsWriteRate, hypervisorSnapshotReserve);
+                maxIops, bytesReadRate, bytesWriteRate, iopsReadRate, iopsWriteRate, hypervisorSnapshotReserve, cacheMode);
     }
 
     @Override
@@ -4705,7 +4707,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                                                 final Long numGibibytes, String tags, boolean isCustomized, final boolean localStorageRequired,
                                                 final boolean isDisplayOfferingEnabled, final Boolean isCustomizedIops, Long minIops, Long maxIops,
                                                 Long bytesReadRate, Long bytesWriteRate, Long iopsReadRate, Long iopsWriteRate,
-                                                final Integer hypervisorSnapshotReserve) {
+                                                final Integer hypervisorSnapshotReserve, final DiskOffering.DiskCacheMode cacheMode) {
         long diskSize = 0;// special case for custom disk offerings
         if (numGibibytes != null && numGibibytes <= 0) {
             throw new InvalidParameterValueException("Please specify a disk size of at least 1 Gb.");
@@ -4791,6 +4793,9 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         }
         if (iopsWriteRate != null && iopsWriteRate > 0) {
             newDiskOffering.setIopsWriteRate(iopsWriteRate);
+        }
+        if (cacheMode != null) {
+            newDiskOffering.setCacheMode(cacheMode);
         }
 
         if (hypervisorSnapshotReserve != null && hypervisorSnapshotReserve < 0) {


### PR DESCRIPTION
When creating a disk offering the UI specifies the cacheMode, but it wasn't picked up by the API.

![image](https://user-images.githubusercontent.com/1630096/40227275-51f96f4a-5a8e-11e8-95a8-974c8f5a6ae1.png)
