### PR TITLE
Fixed a bug in the urllib2 call for password save

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/CsPasswordService.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/CsPasswordService.py
@@ -11,10 +11,9 @@ class CsPasswordServiceVMConfig:
 
     def __init__(self, dbag):
         self.dbag = dbag
-        self.process()
 
     def process(self):
-        self.__update(self.dbag['ip_address'], self.dbag['password'])
+        return self.__update(self.dbag['ip_address'], self.dbag['password'])
 
     def __update(self, vm_ip, password):
         token = ""
@@ -46,12 +45,14 @@ class CsPasswordServiceVMConfig:
                         params = {'ip': vm_ip, 'password': password, 'token': token}
                         req = urllib2.Request(url, urllib.urlencode(params), headers=headers)
                         try:
-                            res = urllib2.urlopen(req).read()
-                            if res.code == 200:
-                                logging.debug("Update password server result ==> %s" % res)
-                                return res
+                            res = urllib2.urlopen(req)
+                            if res.getcode() == 200:
+                                logging.debug("Update password server result ==> %s" % res.read())
+                                return 0
                         except Exception as e:
                             logging.debug("Error while querying password server ==> %s" % e.message)
+                            return 1
+
 
                     test_tries += 1
                     logging.debug("Testing password server process round %s/%s" % (test_tries, max_tries))
@@ -59,3 +60,7 @@ class CsPasswordServiceVMConfig:
 
                 logging.debug("Update password server skipped because we didn't find a passwd server process for "
                               "%s (makes sense on backup routers)" % ip)
+                return 1
+
+        # on a non-master router no passwords to set, so we finish with success
+        return 0

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/update_config.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/update_config.py
@@ -56,7 +56,10 @@ def process_vmpasswd():
     logging.info("process_vmpassword")
     qf = process(False)
     logging.info("Sending password to password server")
-    CsPasswordServiceVMConfig(qf.getData())
+    returncode = CsPasswordServiceVMConfig(qf.getData()).process()
+    # TODO: use the returncode as exit code, but for now we just log the exit code
+    logging.info("The vmpassword processing ended with exit code %d" % returncode)
+    #sys.exit(returncode)
 
 
 filename = min(glob.iglob(jsonCmdConfigPath + '*'), key=os.path.getctime)


### PR DESCRIPTION
The csPasswordService  contained a bug that did not understand the response code from the password server on the routerVM, and the password server was tested with a template that did not support passwords, now the password is set correctly and is also acked by the VM, which did not happen previously as the password was "saved_password" which cloud-init ignores.

Because of the invalid code the retry (5x) was always done, even though the password was saved, the response was not correctly interpreted and thus the password was always saved multiple times as can be seen in the output of older test runs:

```
Standard Output
DEBUG      2019-02-08 14:38:22,055 - test - Ping result from the Router on IP '169.254.3.186' is -> '1'
DEBUG      2019-02-08 14:38:22,055 - test - Executing vm ping 1/15
DEBUG      2019-02-08 14:38:38,190 - test - Ping result from the Router on IP '169.254.3.186' is -> '1'
DEBUG      2019-02-08 14:38:38,191 - test - Executing vm ping 2/15
DEBUG      2019-02-08 14:38:44,271 - test - VM 10.0.0.38 is pingable, give it 10s to request the password
DEBUG      2019-02-08 14:38:54,281 - test - Checking router 169.254.3.186 for passwd_server_ip.py process, state MASTER
DEBUG      2019-02-08 14:38:55,845 - test - Result from the Router on IP '169.254.3.186' is -> Number of processess found: '1'
DEBUG      2019-02-08 14:38:55,845 - test - Checking router 169.254.3.186 for dnsmasq process, state MASTER
DEBUG      2019-02-08 14:38:57,229 - test - Result from the Router on IP '169.254.3.186' is -> Number of processess found: '1'
DEBUG      2019-02-08 14:38:57,229 - test - Checking password of VM-70be430a-a4e5-4049-bbec-266cc20e90b8 in router 169.254.3.186, state MASTER
DEBUG      2019-02-08 14:38:57,267 - test - The router with link local address 169.254.3.186 reports state UNKNOWN
DEBUG      2019-02-08 14:38:58,331 - test - Got this response: [
u'Feb  8 13:38:01 r-16-vm passwd_server_ip.py: serve_password[10.0.0.1]: password saved for VM IP 10.0.0.38', 
u'Feb  8 13:38:03 r-16-vm passwd_server_ip.py: serve_password[10.0.0.1]: password saved for VM IP 10.0.0.38', 
u'Feb  8 13:38:05 r-16-vm passwd_server_ip.py: serve_password[10.0.0.1]: password saved for VM IP 10.0.0.38', 
u'Feb  8 13:38:07 r-16-vm passwd_server_ip.py: serve_password[10.0.0.1]: password saved for VM IP 10.0.0.38', 
u'Feb  8 13:38:09 r-16-vm passwd_server_ip.py: serve_password[10.0.0.1]: password saved for VM IP 10.0.0.38', 
u'Feb  8 13:38:30 r-16-vm passwd_server_ip.py: serve_password[10.0.0.1]: password sent to 10.0.0.38'] 
DEBUG      2019-02-08 14:38:58,332 - test - Test succeeded!
DEBUG      2019-02-08 14:38:58,332 - test - Restarting VPC 933b1b36-6bd1-4807-b036-cf65494c374c with cleanup
DEBUG      2019-02-08 14:40:33,708 - test - Getting the router info again after the cleanup (router names / ip addresses changed)
DEBUG      2019-02-08 14:40:33,726 - test - Check whether routers are happy
DEBUG      2019-02-08 14:40:33,726 - test - Starting test round 0/5
DEBUG      2019-02-08 14:40:33,726 - test - Creating VM in network=NETWORK-10.0.0.1
DEBUG      2019-02-08 14:40:58,917 - test - Created VM with ID: a3a55fe1-c924-4687-9d4b-026bfa055c01
DEBUG      2019-02-08 14:40:58,917 - test - Check whether VM 10.0.0.234 is up
DEBUG      2019-02-08 14:41:03,185 - test - Ping result from the Router on IP '169.254.1.105' is -> '1'
DEBUG      2019-02-08 14:41:03,185 - test - Executing vm ping 1/15
DEBUG      2019-02-08 14:41:09,308 - test - VM 10.0.0.234 is pingable, give it 10s to request the password
DEBUG      2019-02-08 14:41:19,311 - test - Checking router 169.254.1.105 for passwd_server_ip.py process, state MASTER
DEBUG      2019-02-08 14:41:20,992 - test - Result from the Router on IP '169.254.1.105' is -> Number of processess found: '1'
DEBUG      2019-02-08 14:41:20,993 - test - Checking router 169.254.1.105 for dnsmasq process, state MASTER
DEBUG      2019-02-08 14:41:22,374 - test - Result from the Router on IP '169.254.1.105' is -> Number of processess found: '1'
DEBUG      2019-02-08 14:41:22,375 - test - Checking password of VM-a3a55fe1-c924-4687-9d4b-026bfa055c01 in router 169.254.1.105, state MASTER
DEBUG      2019-02-08 14:41:22,409 - test - The router with link local address 169.254.1.105 reports state UNKNOWN
DEBUG      2019-02-08 14:41:23,512 - test - Got this response: [
u'Feb  8 13:40:38 r-18-vm passwd_server_ip.py: serve_password[10.0.0.1]: password saved for VM IP 10.0.0.234', 
u'Feb  8 13:40:40 r-18-vm passwd_server_ip.py: serve_password[10.0.0.1]: password saved for VM IP 10.0.0.234', 
u'Feb  8 13:40:42 r-18-vm passwd_server_ip.py: serve_password[10.0.0.1]: password saved for VM IP 10.0.0.234', 
u'Feb  8 13:40:44 r-18-vm passwd_server_ip.py: serve_password[10.0.0.1]: password saved for VM IP 10.0.0.234', 
u'Feb  8 13:40:46 r-18-vm passwd_server_ip.py: serve_password[10.0.0.1]: password saved for VM IP 10.0.0.234', 
u'Feb  8 13:41:07 r-18-vm passwd_server_ip.py: serve_password[10.0.0.1]: password sent to 10.0.0.234'] 
DEBUG      2019-02-08 14:41:23,512 - test - Test succeeded!
DEBUG      2019-02-08 14:41:23,512 - test - Cleaning up all resources:
DEBUG      2019-02-08 14:41:23,512 - test -  -> Account 62e16adb-97bb-4cf0-9724-291c9423bd1a
```

Now it is clean:

```
Standard Output
DEBUG      2019-02-11 16:10:19,264 - test - Ping result from the Router on IP '169.254.3.4' is -> '1'
DEBUG      2019-02-11 16:10:19,264 - test - Executing vm ping 1/15
DEBUG      2019-02-11 16:10:35,341 - test - Ping result from the Router on IP '169.254.3.4' is -> '1'
DEBUG      2019-02-11 16:10:35,341 - test - Executing vm ping 2/15
DEBUG      2019-02-11 16:10:41,467 - test - VM 10.0.0.97 is pingable, give it 10s to request the password
DEBUG      2019-02-11 16:10:51,478 - test - Checking router 169.254.3.4 for passwd_server_ip.py process, state MASTER
DEBUG      2019-02-11 16:10:52,699 - test - Result from the Router on IP '169.254.3.4' is -> Number of processess found: '1'
DEBUG      2019-02-11 16:10:52,699 - test - Checking router 169.254.3.4 for dnsmasq process, state MASTER
DEBUG      2019-02-11 16:10:54,435 - test - Result from the Router on IP '169.254.3.4' is -> Number of processess found: '1'
DEBUG      2019-02-11 16:10:54,435 - test - Checking password of VM-c564b8ae-fb15-4905-a3db-6f081bfcd183 in router 169.254.3.4, state MASTER
DEBUG      2019-02-11 16:10:54,473 - test - The router with link local address 169.254.3.4 reports state UNKNOWN
DEBUG      2019-02-11 16:10:55,594 - test - Got this response: [
u'Feb 11 15:10:09 r-16-vm passwd_server_ip.py: serve_password[10.0.0.1]: password saved for VM IP 10.0.0.97', 
u'Feb 11 15:10:25 r-16-vm passwd_server_ip.py: serve_password[10.0.0.1]: password sent to 10.0.0.97', 
u'Feb 11 15:10:25 r-16-vm passwd_server_ip.py: serve_password[10.0.0.1]: saved_password ack received from 10.0.0.97'] 
DEBUG      2019-02-11 16:10:55,594 - test - Test succeeded!
DEBUG      2019-02-11 16:10:55,594 - test - Restarting VPC 30e5b865-2dc3-4fd8-9fb8-4b82eec5b9cd with cleanup
DEBUG      2019-02-11 16:12:35,986 - test - Getting the router info again after the cleanup (router names / ip addresses changed)
DEBUG      2019-02-11 16:12:36,003 - test - Check whether routers are happy
DEBUG      2019-02-11 16:12:36,003 - test - Starting test round 0/5
DEBUG      2019-02-11 16:12:36,003 - test - Creating VM in network=NETWORK-10.0.0.1
DEBUG      2019-02-11 16:12:46,134 - test - Created VM with ID: ce13421f-9446-4659-b3a3-dc751ae8c8eb
DEBUG      2019-02-11 16:12:46,134 - test - Check whether VM 10.0.0.153 is up
DEBUG      2019-02-11 16:12:50,252 - test - Ping result from the Router on IP '169.254.0.118' is -> '1'
DEBUG      2019-02-11 16:12:50,253 - test - Executing vm ping 1/15
DEBUG      2019-02-11 16:13:06,326 - test - Ping result from the Router on IP '169.254.0.118' is -> '1'
DEBUG      2019-02-11 16:13:06,326 - test - Executing vm ping 2/15
DEBUG      2019-02-11 16:13:12,373 - test - VM 10.0.0.153 is pingable, give it 10s to request the password
DEBUG      2019-02-11 16:13:22,373 - test - Checking router 169.254.0.118 for passwd_server_ip.py process, state MASTER
DEBUG      2019-02-11 16:13:24,048 - test - Result from the Router on IP '169.254.0.118' is -> Number of processess found: '1'
DEBUG      2019-02-11 16:13:24,048 - test - Checking router 169.254.0.118 for dnsmasq process, state MASTER
DEBUG      2019-02-11 16:13:25,170 - test - Result from the Router on IP '169.254.0.118' is -> Number of processess found: '1'
DEBUG      2019-02-11 16:13:25,170 - test - Checking password of VM-ce13421f-9446-4659-b3a3-dc751ae8c8eb in router 169.254.0.118, state MASTER
DEBUG      2019-02-11 16:13:25,205 - test - The router with link local address 169.254.0.118 reports state UNKNOWN
DEBUG      2019-02-11 16:13:26,255 - test - Got this response: [
u'Feb 11 15:12:40 r-18-vm passwd_server_ip.py: serve_password[10.0.0.1]: password saved for VM IP 10.0.0.153', 
u'Feb 11 15:12:55 r-18-vm passwd_server_ip.py: serve_password[10.0.0.1]: password sent to 10.0.0.153', 
u'Feb 11 15:12:55 r-18-vm passwd_server_ip.py: serve_password[10.0.0.1]: saved_password ack received from 10.0.0.153'] 
DEBUG      2019-02-11 16:13:26,255 - test - Test succeeded!
DEBUG      2019-02-11 16:13:26,256 - test - Updating template 9cc3eac7-6d7b-11e7-8f09-5254001daa61 setting passwordenabled to False
DEBUG      2019-02-11 16:13:26,270 - test - Cleaning up all resources:
DEBUG      2019-02-11 16:13:26,270 - test -  -> Account bf6d2ae0-7594-43d6-8a8c-c53a31343204
```