### PR TITLE
Only allow UUIDs instead of Long IDs

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/BaseCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/BaseCmd.java
@@ -12,6 +12,7 @@ import com.cloud.framework.config.dao.ConfigurationDao;
 import com.cloud.legacymodel.Displayable;
 import com.cloud.legacymodel.exceptions.ConcurrentOperationException;
 import com.cloud.legacymodel.exceptions.InsufficientCapacityException;
+import com.cloud.legacymodel.exceptions.InvalidParameterValueException;
 import com.cloud.legacymodel.exceptions.NetworkRuleConflictException;
 import com.cloud.legacymodel.exceptions.ResourceAllocationException;
 import com.cloud.legacymodel.exceptions.ResourceUnavailableException;
@@ -351,8 +352,7 @@ public abstract class BaseCmd {
         // entityId can be internal db id or UUID so accordingly call findbyId or findByUUID
 
         if (entityId instanceof Long) {
-            // Its internal db id - use findById
-            return _entityMgr.findById(entityType, (Long) entityId);
+            throw new InvalidParameterValueException("We do not support integer resource IDs any more. Please use UUID instead.");
         } else if (entityId instanceof String) {
             try {
                 // In case its an async job the internal db id would be a string because of json deserialization

--- a/cosmic-core/server/src/main/java/com/cloud/event/ActionEventUtils.java
+++ b/cosmic-core/server/src/main/java/com/cloud/event/ActionEventUtils.java
@@ -8,6 +8,7 @@ import com.cloud.framework.config.dao.ConfigurationDao;
 import com.cloud.framework.events.EventBus;
 import com.cloud.framework.events.EventBusException;
 import com.cloud.legacymodel.Identity;
+import com.cloud.legacymodel.exceptions.InvalidParameterValueException;
 import com.cloud.legacymodel.user.Account;
 import com.cloud.legacymodel.user.User;
 import com.cloud.projects.Project;
@@ -171,9 +172,7 @@ public class ActionEventUtils {
         // entityId can be internal db id or UUID so accordingly call findbyId or return uuid directly
 
         if (entityId instanceof Long) {
-            // Its internal db id - use findById
-            final Object objVO = s_entityMgr.findById(entityType, (Long) entityId);
-            return ((Identity) objVO).getUuid();
+            throw new InvalidParameterValueException("We do not support integer resource IDs any more. Please use UUID instead.");
         } else if (entityId instanceof String) {
             try {
                 // In case its an async job the internal db id would be a string because of json deserialization


### PR DESCRIPTION
Resource IDs that are Longs are from the CloudStack 3.0 days. We don't need support for that any more. In fact, it's more secure to only rely on UUIDs.