### PR TITLE
Fix incorrect userdata decoding

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -4036,9 +4036,11 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         _accountMgr.checkAccess(owner, AccessType.UseEntry, false, template);
 
         // Decode userData
-        String decodedUserData;
+        String decodedUserData = null;
         try {
-            decodedUserData = java.net.URLDecoder.decode(userData, "UTF-8");
+            if (userData != null) {
+                decodedUserData = java.net.URLDecoder.decode(userData, "UTF-8");
+            }
         } catch (final UnsupportedEncodingException e) {
             throw new InvalidParameterValueException("Unsupported encoding");
         }


### PR DESCRIPTION
Userdata send to Cosmic is not correctly decoded. Base64 padding is converted to `%3d` which is not base64 compliant. This PR does URI decoding of the userdata before passing it to the base64 decoder.
![image](https://user-images.githubusercontent.com/1177804/42929248-cef8f8ea-8b39-11e8-85ca-83c5ee0bc811.png)
