### PR TITLE
Allow tcp-proxy for HAProxy configs

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/CreateLoadBalancerRuleCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/loadbalancer/CreateLoadBalancerRuleCmd.java
@@ -280,7 +280,7 @@ public class CreateLoadBalancerRuleCmd extends BaseAsyncCreateCmd /*implements L
             throw new InvalidParameterValueException(
                     "Parameter cidrList is deprecated; if you need to open firewall rule for the specific CIDR, please refer to createFirewallRule command");
         }
-        if (lbProtocol != null && !lbProtocol.toLowerCase().equals("tcp")) {
+        if (lbProtocol != null && !lbProtocol.toLowerCase().startsWith("tcp")) {
             throw new InvalidParameterValueException(
                     "Only TCP protocol is supported because HAProxy can only do TCP.");
         }


### PR DESCRIPTION
This fixes #534

```
listen 100_64_0_4-5555 100.64.0.4:5555
        balance roundrobin
        timeout client 60000
        timeout server 60000
        server 100_64_0_4-5555_0 10.0.0.212:5555 check send-proxy
        server 100_64_0_4-5555_1 10.0.0.41:5555 check send-proxy
```