### PR TITLE
Enhance OptimiseFor Windows enable vm clock tracking

### DIFF
--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/kvm/LibvirtComputingResource.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/kvm/LibvirtComputingResource.java
@@ -1370,18 +1370,22 @@ public class LibvirtComputingResource extends AgentResourceBase implements Agent
         final ClockDef clock = new ClockDef();
         Boolean kvmClockEnabled = !isKvmClockDisabled();
         Boolean hypervClockEnabled = false;
+        Boolean trackGuest = false;
         if (vmTo.getOptimiseFor() == OptimiseFor.Windows) {
             clock.setClockOffset(ClockDef.ClockOffset.LOCALTIME);
             kvmClockEnabled = false;
             hypervClockEnabled = true;
+            trackGuest = true;
         }
-        clock.addTimer("kvmclock", null, kvmClockEnabled);
-        clock.addTimer("hypervclock", null, hypervClockEnabled);
+        clock.addTimer("kvmclock", null, kvmClockEnabled, false);
+        clock.addTimer("hypervclock", null, hypervClockEnabled, false);
 
         // Recommended default clock/timer settings - https://bugzilla.redhat.com/show_bug.cgi?id=1053847
-        clock.addTimer("rtc", "catchup");
-        clock.addTimer("pit", "delay");
-        clock.addTimer("hpet", null, false);
+        // Important note for track="guest" in Windows VMs:
+        // https://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/Virtualization_Deployment_and_Administration_Guide/sect-Virtualization-Tips_and_tricks-Libvirt_Managed_Timers.html
+        clock.addTimer("rtc", "catchup", true, trackGuest);
+        clock.addTimer("pit", "delay", true, false);
+        clock.addTimer("hpet", null, false, false);
         vm.addComponent(clock);
 
         final DevicesDef devices = new DevicesDef();

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/kvm/xml/LibvirtVmDef.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/kvm/xml/LibvirtVmDef.java
@@ -391,16 +391,18 @@ public class LibvirtVmDef {
             private String track;
             private boolean noKvmClock;
             private boolean present;
+            private boolean trackGuest;
 
             public Timer() {
             }
 
-            private Timer(final String name, final String tickPolicy, final boolean present) {
+            private Timer(final String name, final String tickPolicy, final boolean present, final boolean trackGuest) {
                 this.name = name;
                 this.tickPolicy = tickPolicy;
                 this.track = track;
                 this.noKvmClock = noKvmClock;
                 this.present = present;
+                this.trackGuest = trackGuest;
             }
 
             @Override
@@ -418,6 +420,10 @@ public class LibvirtVmDef {
                             timerBuilder.append("tickpolicy='");
                             timerBuilder.append(this.tickPolicy);
                             timerBuilder.append("' ");
+                            if (this.trackGuest) {
+                                timerBuilder.append("track='guest'");
+                                timerBuilder.append(" ");
+                            }
                         }
 
                         timerBuilder.append(">\n");
@@ -437,12 +443,12 @@ public class LibvirtVmDef {
             this.offset = offset;
         }
 
-        public void addTimer(final String timerName, final String tickPolicy, final boolean present) {
-            timers.add(new Timer(timerName, tickPolicy, present));
+        public void addTimer(final String timerName, final String tickPolicy, final boolean present, final boolean trackGuest) {
+            timers.add(new Timer(timerName, tickPolicy, present, trackGuest));
         }
 
         public void addTimer(final String timerName, final String tickPolicy) {
-            timers.add(new Timer(timerName, tickPolicy, true));
+            timers.add(new Timer(timerName, tickPolicy, true, false));
         }
 
         public enum ClockOffset {


### PR DESCRIPTION
This prevents freezes and locks on Windows VMs due to timer issues.

Linux
```
  <clock offset='utc'>
    <timer name='kvmclock' present='yes'/>
    <timer name='hypervclock' present='no'/>
    <timer name='rtc' tickpolicy='catchup'/>
    <timer name='pit' tickpolicy='delay'/>
    <timer name='hpet' present='no'/>
  </clock>
```

Windows
```
  <clock offset='localtime'>
    <timer name='kvmclock' present='no'/>
    <timer name='hypervclock' present='yes'/>
    <timer name='rtc' tickpolicy='catchup' track='guest'/>
    <timer name='pit' tickpolicy='delay'/>
    <timer name='hpet' present='no'/>
  </clock>
```
