### PR TITLE
Update to latest flywaydb and set table for backward compatibility

### DIFF
--- a/cosmic-core/cosmic-flyway/src/main/java/com/cloud/flyway/FlywayDB.java
+++ b/cosmic-core/cosmic-flyway/src/main/java/com/cloud/flyway/FlywayDB.java
@@ -1,15 +1,14 @@
 package com.cloud.flyway;
 
 import com.cloud.legacymodel.exceptions.CloudRuntimeException;
-
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-import javax.sql.DataSource;
-
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.FlywayException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
 
 public class FlywayDB {
 
@@ -31,6 +30,7 @@ public class FlywayDB {
 
         final Flyway flyway = new Flyway();
         flyway.setDataSource(dataSource);
+        flyway.setTable("schema_version");
         flyway.setEncoding("UTF-8");
 
         try {

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>cloud.cosmic</groupId>
@@ -36,7 +37,7 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>2.0.1.RELEASE</version>
-        <relativePath /> <!-- lookup parent from repository -->
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
     <properties>
@@ -76,7 +77,7 @@
         <cs.dependency-check-maven.version>3.1.2</cs.dependency-check-maven.version>
         <cs.ehcache-core.version>2.6.9</cs.ehcache-core.version>
         <cs.ejb-api.version>3.0</cs.ejb-api.version>
-        <cs.flyway.version>4.2.0</cs.flyway.version>
+        <cs.flyway.version>5.2.0</cs.flyway.version>
         <cs.gmaven-runtime-1.7.version>1.3</cs.gmaven-runtime-1.7.version>
         <cs.groovy-all.version>2.0.5</cs.groovy-all.version>
         <cs.guava-testlib.version>23.0</cs.guava-testlib.version>
@@ -672,7 +673,7 @@
                         <id>enforce</id>
                         <configuration>
                             <rules>
-                                <DependencyConvergence />
+                                <DependencyConvergence/>
                             </rules>
                         </configuration>
                         <goals>


### PR DESCRIPTION
Update to the latest flyway version. Set table to `schema_version` as with version 6.0 of flyway this will change.