### PR TITLE
[WIP] Fix/response serialization

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/response/AsyncJobResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/AsyncJobResponse.java
@@ -13,6 +13,8 @@ import com.google.gson.annotations.SerializedName;
 
 @EntityReference(value = JobInfo.class)
 public class AsyncJobResponse extends BaseResponse {
+    @Param(description = "The current status of the latest async job acting on this object, should be 0 for PENDING", SerializedName = ApiConstants.JOB_STATUS)
+    private Integer dummy_jobStatus;
 
     @SerializedName("accountid")
     @Param(description = "the account that executed the async command")

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/SystemVmResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/SystemVmResponse.java
@@ -12,6 +12,12 @@ import com.google.gson.annotations.SerializedName;
 
 @EntityReference(value = VirtualMachine.class)
 public class SystemVmResponse extends BaseResponse {
+    @Param(description = "The UUID of the latest async job acting on this object", SerializedName = ApiConstants.JOB_ID)
+    private String dummy_jobId;
+
+    @Param(description = "The current status of the latest async job acting on this object, should be 0 for PENDING", SerializedName = ApiConstants.JOB_STATUS)
+    private Integer dummy_jobStatus;
+
     @SerializedName("id")
     @Param(description = "the ID of the system VM")
     private String id;

--- a/cosmic-core/api/src/main/java/com/cloud/serializer/Param.java
+++ b/cosmic-core/api/src/main/java/com/cloud/serializer/Param.java
@@ -23,4 +23,6 @@ public @interface Param {
     RoleType[] authorized() default {};
 
     boolean isSensitive() default false;
+
+    String SerializedName() default "";
 }

--- a/cosmic-core/server/src/main/java/com/cloud/discovery/ApiDiscoveryServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/discovery/ApiDiscoveryServiceImpl.java
@@ -93,7 +93,9 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
             final Field[] responseFields = apiCmdAnnotation.responseObject().getDeclaredFields();
             for (final Field responseField : responseFields) {
                 final ApiResponseResponse responseResponse = getFieldResponseMap(responseField);
-                response.addApiResponse(responseResponse);
+                if (response.getName() != null) {
+                    response.addApiResponse(responseResponse);
+                }
             }
 
             response.setObjectName("api");
@@ -130,8 +132,8 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
         final ApiResponseResponse responseResponse = new ApiResponseResponse();
         final SerializedName serializedName = responseField.getAnnotation(SerializedName.class);
         final Param param = responseField.getAnnotation(Param.class);
-        if (serializedName != null && param != null) {
-            responseResponse.setName(serializedName.value());
+        if (serializedName != null && param != null || param != null && !param.SerializedName().isEmpty()) {
+            responseResponse.setName(serializedName != null ? serializedName.value() : param.SerializedName());
             responseResponse.setDescription(param.description());
             responseResponse.setType(responseField.getType().getSimpleName().toLowerCase());
             //If response is not of primitive type - we have a nested entity

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>cloud.cosmic</groupId>
@@ -55,7 +56,7 @@
         <integration.tests.report>${coverage.reports.dir}/jacoco-it-merged.exec</integration.tests.report>
 
         <!-- Pinned older version than Spring 4 dependency management -->
-        <cs.gson.version>2.8.2</cs.gson.version>
+        <cs.gson.version>2.8.5</cs.gson.version>
 
         <!-- Dependency management properties -->
         <cs.amqp-client.version>5.5.0</cs.amqp-client.version>


### PR DESCRIPTION
After GSON was bumped from 1.7.2 to 2.4.2 responses where incorrect as GSON can't serialize duplicated names (which was the case in 1.7.2 by overwriting the exisiting keys). Removed serialization from the `BaseResponse` class and made the reponse classes responsible for it.