### PR TITLE
Fix duplicated serialized names

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/response/AsyncJobResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/AsyncJobResponse.java
@@ -13,6 +13,9 @@ import com.google.gson.annotations.SerializedName;
 
 @EntityReference(value = JobInfo.class)
 public class AsyncJobResponse extends BaseResponse {
+    @SerializedName(ApiConstants.JOB_STATUS)
+    @Param(description = "The current status of the latest async job acting on this object, should be 0 for PENDING")
+    private Integer jobStatus;
 
     @SerializedName("accountid")
     @Param(description = "the account that executed the async command")
@@ -64,6 +67,11 @@ public class AsyncJobResponse extends BaseResponse {
 
     public void setCmd(final String cmd) {
         this.cmd = cmd;
+    }
+
+    @Override
+    public void setJobStatus(final Integer jobStatus) {
+        this.jobStatus = jobStatus;
     }
 
     public void setJobProcStatus(final Integer jobProcStatus) {

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/SystemVmResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/SystemVmResponse.java
@@ -12,6 +12,14 @@ import com.google.gson.annotations.SerializedName;
 
 @EntityReference(value = VirtualMachine.class)
 public class SystemVmResponse extends BaseResponse {
+    @SerializedName(ApiConstants.JOB_ID)
+    @Param(description = "the job ID associated with the system VM. This is only displayed if the router listed is part of a currently running asynchronous job.")
+    private String jobId;
+
+    @SerializedName(ApiConstants.JOB_STATUS)
+    @Param(description = "the job status associated with the system VM.  This is only displayed if the router listed is part of a currently running asynchronous job.")
+    private Integer jobStatus;
+
     @SerializedName("id")
     @Param(description = "the ID of the system VM")
     private String id;
@@ -327,5 +335,25 @@ public class SystemVmResponse extends BaseResponse {
 
     public void setLinkLocalNetmask(final String linkLocalNetmask) {
         this.linkLocalNetmask = linkLocalNetmask;
+    }
+
+    @Override
+    public String getJobId() {
+        return jobId;
+    }
+
+    @Override
+    public void setJobId(final String jobId) {
+        this.jobId = jobId;
+    }
+
+    @Override
+    public Integer getJobStatus() {
+        return jobStatus;
+    }
+
+    @Override
+    public void setJobStatus(final Integer jobStatus) {
+        this.jobStatus = jobStatus;
     }
 }

--- a/cosmic-core/server/src/main/java/com/cloud/api/ApiGsonHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/ApiGsonHelper.java
@@ -11,6 +11,7 @@ public class ApiGsonHelper {
         s_gBuilder = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
         s_gBuilder.setVersion(1.3);
         s_gBuilder.registerTypeAdapter(ResponseObject.class, new ResponseObjectTypeAdapter());
+        s_gBuilder.setExclusionStrategies(new SuperclassExclusionStrategy());
         s_gBuilder.registerTypeAdapter(Map.class, new StringMapTypeAdapter());
     }
 

--- a/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseGsonHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseGsonHelper.java
@@ -21,12 +21,14 @@ public class ApiResponseGsonHelper {
         s_gBuilder.setVersion(1.3);
         s_gBuilder.registerTypeAdapter(ResponseObject.class, new ResponseObjectTypeAdapter());
         s_gBuilder.registerTypeAdapter(String.class, new EncodedStringTypeAdapter());
+        s_gBuilder.setExclusionStrategies(new SuperclassExclusionStrategy());
         s_gBuilder.setExclusionStrategies(new ApiResponseExclusionStrategy());
 
         s_gLogBuilder = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
         s_gLogBuilder.setVersion(1.3);
         s_gLogBuilder.registerTypeAdapter(ResponseObject.class, new ResponseObjectTypeAdapter());
         s_gLogBuilder.registerTypeAdapter(String.class, new EncodedStringTypeAdapter());
+        s_gLogBuilder.setExclusionStrategies(new SuperclassExclusionStrategy());
         s_gLogBuilder.setExclusionStrategies(new LogExclusionStrategy());
     }
 

--- a/cosmic-core/server/src/main/java/com/cloud/api/SuperclassExclusionStrategy.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/SuperclassExclusionStrategy.java
@@ -1,0 +1,43 @@
+package com.cloud.api;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+
+/***
+ * This Class excludes serialized names which are overwritten in the inherited class.
+ * GSON 1.7.2 replaced all the serialized names which are the same but from 2.4 it
+ * generates an exception. This class will skip the names in the base classes.
+ */
+public class SuperclassExclusionStrategy implements ExclusionStrategy {
+    private final HashMap<Class, Class> inheritanceMap = new HashMap<>();
+
+    public boolean shouldSkipClass(Class<?> arg0) {
+        return false;
+    }
+
+    public boolean shouldSkipField(FieldAttributes fieldAttributes) {
+        String fieldName = fieldAttributes.getName();
+        Class<?> theClass = fieldAttributes.getDeclaringClass();
+        Class<?> superclass = theClass.getSuperclass();
+
+        if (this.inheritanceMap.containsKey(theClass)) {
+            if (getField(this.inheritanceMap.get(theClass), fieldName) != null) {
+                return true;
+            }
+        }
+
+        this.inheritanceMap.put(superclass, theClass);
+        return false;
+    }
+
+    private Field getField(Class<?> theClass, String fieldName) {
+        try {
+            return theClass.getDeclaredField(fieldName);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
*GSON 1.7.2* did an overwrite on duplicate `@SerializedName`. This behaviour was changed in version *2.4* which doesn't allow duplicate names anymore. This PR doesn't overwrite duplicate names, but skips them. Superseedes PR #776 