### PR TITLE
New state PowerOnUnexpected for VMs that we know should not be Running

### DIFF
--- a/cosmic-core/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/cosmic-core/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -1110,6 +1110,8 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                 handlePowerOnReportWithNoPendingJobsOnVM(vm);
             } else if (vm.getPowerState() == PowerState.PowerPaused) {
                 handlePowerPausedReportWithNoPendingJobsOnVM(vm);
+            } else if (vm.getPowerState() == PowerState.PowerOnUnexpected) {
+                s_logger.info("VM " + vm.getInstanceName() + " is in PowerOn state while this was unexpected!");
             } else {
                 handlePowerOffReportWithNoPendingJobsOnVM(vm);
             }
@@ -1509,7 +1511,9 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                     case PowerPaused:
                         handlePowerPausedReportWithNoPendingJobsOnVM(vm);
                         break;
-
+                    case PowerOnUnexpected:
+                        s_logger.info("VM " + vm.getInstanceName() + " is in PowerOn state while this was unexpected!!");
+                        break;
                     case PowerOff:
                     case PowerReportMissing:
                         handlePowerOffReportWithNoPendingJobsOnVM(vm);

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDao.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDao.java
@@ -67,6 +67,8 @@ public interface VMInstanceDao extends GenericDao<VMInstanceVO, Long>, StateDao<
 
     VMInstanceVO findVMByInstanceName(String name);
 
+    VMInstanceVO findVMByInstanceNameIncludingRemoved(String name);
+
     VMInstanceVO findVMByHostName(String hostName);
 
     void updateProxyId(long id, Long proxyId, Date time);

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
@@ -322,6 +322,13 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
     }
 
     @Override
+    public VMInstanceVO findVMByInstanceNameIncludingRemoved(final String name) {
+        final SearchCriteria<VMInstanceVO> sc = _instanceNameSearch.create();
+        sc.setParameters("instanceName", name);
+        return findOneIncludingRemovedBy(sc);
+    }
+
+    @Override
     public VMInstanceVO findVMByHostName(final String hostName) {
         final SearchCriteria<VMInstanceVO> sc = _hostNameSearch.create();
         sc.setParameters("hostName", hostName);
@@ -609,7 +616,7 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
             @Override
             public Boolean doInTransaction(final TransactionStatus status) {
                 boolean needToUpdate = false;
-                final VMInstanceVO instance = findById(instanceId);
+                final VMInstanceVO instance = findByIdIncludingRemoved(instanceId);
                 if (instance != null) {
                     final Long savedPowerHostId = instance.getPowerHostId();
                     if (instance.getPowerState() != powerState || savedPowerHostId == null

--- a/cosmic-model/src/main/java/com/cloud/legacymodel/vm/VirtualMachine.java
+++ b/cosmic-model/src/main/java/com/cloud/legacymodel/vm/VirtualMachine.java
@@ -130,6 +130,7 @@ public interface VirtualMachine extends RunningOn, ControlledEntity, Identity, I
     enum PowerState {
         PowerUnknown,
         PowerOn,
+        PowerOnUnexpected,
         PowerOff,
         PowerPaused,
         PowerReportMissing


### PR DESCRIPTION
Better logging for VMs power states.

This VM is active in the DB and reported Running. This is as we expect:
```
2018-11-02 20:15:08.542 DEBUG [c.c.v.VirtualMachinePowerStateSyncImpl] VM found running as expected: v-2-VM, host: kvm1.cloud.lan
```

This VM we know (it is in the DB) however, it is removed so should NOT be Running. We can add code to handle it automatically later:
```
2018-11-02 20:15:08.542 DEBUG [c.c.v.VirtualMachinePowerStateSyncImpl] VM found running while it should be gone: r-3-VM, host: kvm1.cloud.lan
```
In the DB, this VM gets state `PowerOnUnexpected`:
![image](https://user-images.githubusercontent.com/1630096/47936157-1c601e00-dedd-11e8-89b1-6be4ae1f6776.png)

This is a VM we do not know about (not in the DB), most likely a manual test VM. We just ignore it completely and simply log it:
```
2018-11-02 20:15:08.543 DEBUG [c.c.v.VirtualMachinePowerStateSyncImpl] VM found running that is unknown to us: s-1-2-VM, host: kvm1.cloud.lan. Ignoring.
```

