### PR TITLE
[WIP] Set static routes per tier

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/keepalived.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/keepalived.py
@@ -4,6 +4,7 @@ import socket
 import subprocess
 
 from jinja2 import Environment, FileSystemLoader
+from netaddr import IPNetwork, IPAddress
 
 import utils
 
@@ -33,7 +34,6 @@ class Keepalived:
         self.init_config()
         self.write_global_defs()
         self.parse_vrrp_interface_instances()
-        self.parse_vrrp_routes_instance()
         self.write_sync_group()
         self.zap_keepalived_config_directory()
         self.reload_keepalived()
@@ -89,45 +89,40 @@ class Keepalived:
                 virtual_router_id=interface_id,
                 advert_int=self.config.get_advert_int(),
                 virtual_ipaddress=[],
-                virtual_ipaddress_excluded=ipv4addresses
+                virtual_ipaddress_excluded=ipv4addresses,
+                network=interface
             )
-
-    def parse_vrrp_routes_instance(self):
-        sync_interface_name = self.config.get_sync_interface_name()
-
-        virtualroutes = []
-
-        # Set the default route here until we handle it from the management server
-        if 'source_nat' in self.config.dbag_network_overview['services'] and \
-                self.config.dbag_network_overview['services']['source_nat']:
-            virtualroutes.append(
-                'default via %s' % self.config.dbag_network_overview['services']['source_nat'][0]['gateway']
-            )
-
-        for route in self.config.dbag_network_overview['routes']:
-            virtualroutes.append('%s via %s metric %s' % (route['cidr'], route['next_hop'], route['metric']))
-
-        self.write_vrrp_instance(
-            name='routes',
-            state='BACKUP',
-            interface=sync_interface_name,
-            virtual_router_id=self.routes_vrrp_id,
-            advert_int=self.config.get_advert_int(),
-            virtual_ipaddress=[],
-            virtual_routes=virtualroutes
-        )
 
     def write_vrrp_instance(
             self,
             name,
             state,
             interface,
+            network,
             virtual_router_id,
             advert_int,
             virtual_ipaddress=None,
-            virtual_ipaddress_excluded=None,
-            virtual_routes=None
+            virtual_ipaddress_excluded=None
     ):
+
+        virtual_routes = []
+        # Generate virtual routes
+        if len(network) > 0 and 'type' in network['metadata'] and network['metadata']['type'] in ("guesttier", "private", "public"):
+            for route in self.config.dbag_network_overview['routes']:
+                if IPAddress(route['next_hop']) in IPNetwork(network['ipv4_addresses'][0]['cidr']):
+                    logging.debug("Adding route to %s for %s because part of cidr %s" % (route['next_hop'], interface, network['ipv4_addresses'][0]['cidr']))
+                    virtual_routes.append('%s via %s metric %s' % (route['cidr'], route['next_hop'], route['metric']))
+                else:
+                    logging.debug("Skipping route %s for %s because not part of cidr %s" % (route['next_hop'], interface, network['ipv4_addresses'][0]['cidr']))
+            # Set the default route here until we handle it from the management server
+            if network['metadata']['type'] == 'public' and 'source_nat' in self.config.dbag_network_overview['services'] and \
+                    self.config.dbag_network_overview['services']['source_nat']:
+                virtual_routes.append(
+                    'default via %s' % self.config.dbag_network_overview['services']['source_nat'][0]['gateway']
+                )
+        else:
+            logging.debug("Skipping because network is empty. Network: %s" % network)
+
         content = self.jinja_env.get_template('keepalived_vrrp_instance.conf').render(
             name=name,
             state=state,


### PR DESCRIPTION
```
[root@r-5-vm conf.d]# cat *
global_defs {
    router_id r-5-vm
}vrrp_sync_group cosmic {
    notify_master "/opt/cosmic/router/scripts/primary-backup.sh primary"
    notify_backup "/opt/cosmic/router/scripts/primary-backup.sh backup"
    notify_fault "/opt/cosmic/router/scripts/primary-backup.sh fault"

    group {
        public_eth2
        private_eth3
        guesttier_eth4
    }
}vrrp_instance guesttier_eth4 {
    state BACKUP
    interface eth1
    virtual_router_id 4
    nopreempt
    advert_int 1

    virtual_ipaddress {
    }
    virtual_ipaddress_excluded {
        10.0.0.1/24 dev eth4
    }
    virtual_routes {
    }
}vrrp_instance private_eth3 {
    state BACKUP
    interface eth1
    virtual_router_id 3
    nopreempt
    advert_int 1

    virtual_ipaddress {
    }
    virtual_ipaddress_excluded {
        10.10.0.9/24 dev eth3
    }
    virtual_routes {
        172.17.0.0/23 via 10.10.0.100 metric 100
        172.16.0.0/24 via 10.10.0.101 metric 100
    }
}vrrp_instance public_eth2 {
    state BACKUP
    interface eth1
    virtual_router_id 2
    nopreempt
    advert_int 1

    virtual_ipaddress {
    }
    virtual_ipaddress_excluded {
        100.64.0.5/24 dev eth2
    }
    virtual_routes {
        212.204.99.32/32 via 100.64.0.2 metric 100
        default via 100.64.0.1
    }
}
```

```
[root@r-5-vm conf.d]# ip r
default via 100.64.0.1 dev eth2
10.0.0.0/24 dev eth4 proto kernel scope link src 10.0.0.1
10.10.0.0/24 dev eth3 proto kernel scope link src 10.10.0.9
100.64.0.0/24 dev eth2 proto kernel scope link src 100.64.0.5
100.100.0.0/16 dev eth1 proto kernel scope link src 100.100.1.174
169.254.0.0/16 dev eth0 proto kernel scope link src 169.254.1.174
172.16.0.0/24 via 10.10.0.101 dev eth3 metric 100
172.17.0.0/23 via 10.10.0.100 dev eth3 metric 100
212.204.99.32 via 100.64.0.2 dev eth2 metric 100
```

![image](https://user-images.githubusercontent.com/1630096/48724592-f0a59d80-ec29-11e8-8a1d-bfc235594ba2.png)

