### PR TITLE
Option to use keepalived with unicast on a per VPC basis

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/ApiConstants.java
@@ -6,6 +6,8 @@ public class ApiConstants {
     public static final String ACCOUNT_TYPE = "accounttype";
     public static final String ACCOUNT_ID = "accountid";
     public static final String ACCOUNT_NAME = "accountname";
+    public static final String ADVERT_INTERVAL = "advertinterval";
+    public static final String ADVERT_METHOD = "advertmethod";
     public static final String ALGORITHM = "algorithm";
     public static final String ALLOCATED_ONLY = "allocatedonly";
     public static final String API_KEY = "apikey";
@@ -211,6 +213,7 @@ public class ApiConstants {
     public static final String RESPONSE = "response";
     public static final String REVERTABLE = "revertable";
     public static final String REGISTERED = "registered";
+    public static final String ROUTER_UNICAST_ID = "routerunicastid";
     public static final String QUERY_FILTER = "queryfilter";
     public static final String SCHEDULE = "schedule";
     public static final String SCOPE = "scope";

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/UpdateVPCCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/vpc/UpdateVPCCmdByAdmin.java
@@ -19,7 +19,8 @@ public class UpdateVPCCmdByAdmin extends UpdateVPCCmd {
 
     @Override
     public void execute() {
-        final Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc(), getVpcOfferingId(), getSourceNatList(), getSyslogServerList());
+        final Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc(), getVpcOfferingId(), getSourceNatList(),
+                getSyslogServerList(), getAdvertInterval(), getAdvertMethod());
         if (result != null) {
             final VpcResponse response = _responseGenerator.createVpcResponse(ResponseView.Full, result);
             response.setResponseName(getCommandName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/CreateVPCCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/CreateVPCCmd.java
@@ -21,6 +21,7 @@ import com.cloud.legacymodel.exceptions.InsufficientCapacityException;
 import com.cloud.legacymodel.exceptions.ResourceAllocationException;
 import com.cloud.legacymodel.exceptions.ResourceUnavailableException;
 import com.cloud.legacymodel.network.vpc.Vpc;
+import com.cloud.model.enumeration.AdvertMethod;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -89,6 +90,14 @@ public class CreateVPCCmd extends BaseAsyncCreateCmd {
             description = "Comma separated list of IP addresses to configure as syslog servers on the VPC to forward IP tables logging")
     private String syslogServerList;
 
+    @Parameter(name = ApiConstants.ADVERT_INTERVAL, type = CommandType.LONG,
+            description = "VRRP advertisement interval. Defaults to 1.'")
+    private Long advertInterval;
+
+    @Parameter(name = ApiConstants.ADVERT_METHOD, type = CommandType.STRING,
+            description = "VRRP advertisement method to use: unicast / multicast. Defaults to multicast'")
+    private String advertMethod;
+
     // ///////////////////////////////////////////////////
     // ///////////////// Accessors ///////////////////////
     // ///////////////////////////////////////////////////
@@ -103,8 +112,8 @@ public class CreateVPCCmd extends BaseAsyncCreateCmd {
 
     @Override
     public void create() throws ResourceAllocationException {
-        final Vpc vpc = _vpcService.createVpc(getZoneId(), getVpcOffering(), getEntityOwnerId(), getVpcName(), getDisplayText(), getCidr(), getNetworkDomain(), getDisplayVpc(), getSourceNatList(),
-                getSyslogServerList());
+        final Vpc vpc = _vpcService.createVpc(getZoneId(), getVpcOffering(), getEntityOwnerId(), getVpcName(), getDisplayText(), getCidr(), getNetworkDomain(), getDisplayVpc(),
+                getSourceNatList(), getSyslogServerList(), getAdvertInterval(), getAdvertMethod());
         if (vpc != null) {
             setEntityId(vpc.getId());
             setEntityUuid(vpc.getUuid());
@@ -216,4 +225,15 @@ public class CreateVPCCmd extends BaseAsyncCreateCmd {
     public String getEventDescription() {
         return "creating VPC. Id: " + getEntityId();
     }
-}
+
+    public Long getAdvertInterval() {
+        return advertInterval;
+    }
+
+    public AdvertMethod getAdvertMethod() {
+        if (advertMethod != null) {
+            return AdvertMethod.valueOf(advertMethod.toUpperCase());
+        } else {
+            return null;
+        }
+    }}

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/UpdateVPCCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/vpc/UpdateVPCCmd.java
@@ -17,6 +17,7 @@ import com.cloud.api.response.VpcResponse;
 import com.cloud.event.EventTypes;
 import com.cloud.legacymodel.network.vpc.Vpc;
 import com.cloud.legacymodel.user.Account;
+import com.cloud.model.enumeration.AdvertMethod;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -57,13 +58,23 @@ public class UpdateVPCCmd extends BaseAsyncCustomIdCmd {
             description = "Comma separated list of IP addresses to configure as syslog servers on the VPC to forward IP tables logging")
     private String syslogServerList;
 
+    @Parameter(name = ApiConstants.ADVERT_INTERVAL, type = CommandType.LONG,
+            description = "VRRP advertisement interval. Defaults to 1.")
+    private Long advertInterval;
+
+    @Parameter(name = ApiConstants.ADVERT_METHOD, type = CommandType.STRING,
+            description = "VRRP advertisement method to use: unicast / multicast. Defaults to multicast'")
+    private String advertMethod;
+
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
 
     @Override
     public void execute() {
-        final Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc(), getVpcOfferingId(), getSourceNatList(), getSyslogServerList());
+        final Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc(), getVpcOfferingId(), getSourceNatList(),
+                getSyslogServerList(), getAdvertInterval(), getAdvertMethod());
         if (result != null) {
             final VpcResponse response = _responseGenerator.createVpcResponse(ResponseView.Restricted, result);
             response.setResponseName(getCommandName());
@@ -149,6 +160,18 @@ public class UpdateVPCCmd extends BaseAsyncCustomIdCmd {
     public void checkUuid() {
         if (getCustomId() != null) {
             _uuidMgr.checkUuid(getCustomId(), Vpc.class);
+        }
+    }
+
+    public Long getAdvertInterval() {
+        return advertInterval;
+    }
+
+    public AdvertMethod getAdvertMethod() {
+        if (advertMethod != null) {
+            return AdvertMethod.valueOf(advertMethod.toUpperCase());
+        } else {
+            return null;
         }
     }
 }

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/DomainRouterResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/DomainRouterResponse.java
@@ -207,6 +207,10 @@ public class DomainRouterResponse extends BaseResponse implements ControlledView
     @Param(description = "What Cosmic version did the router start with")
     private String lastStartVersion;
 
+    @SerializedName(ApiConstants.ROUTER_UNICAST_ID)
+    @Param(description = "Unicast router ID")
+    private Long routerUnicastId;
+
     public DomainRouterResponse() {
         nics = new LinkedHashSet<>();
     }
@@ -451,5 +455,13 @@ public class DomainRouterResponse extends BaseResponse implements ControlledView
 
     public void setLastStartVersion(final String lastStartVersion) {
         this.lastStartVersion = lastStartVersion;
+    }
+
+    public Long getRouterUnicastId() {
+        return routerUnicastId;
+    }
+
+    public void setRouterUnicastId(final Long routerUnicastId) {
+        this.routerUnicastId = routerUnicastId;
     }
 }

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/VpcResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/VpcResponse.java
@@ -5,6 +5,7 @@ import com.cloud.api.ApiConstants;
 import com.cloud.api.BaseResponse;
 import com.cloud.api.EntityReference;
 import com.cloud.legacymodel.network.vpc.Vpc;
+import com.cloud.model.enumeration.AdvertMethod;
 import com.cloud.serializer.Param;
 
 import java.util.Date;
@@ -114,6 +115,14 @@ public class VpcResponse extends BaseResponse implements ControlledEntityRespons
     @Param(description = "Comma separated list of IP addresses to configure as syslog servers on the VPC to forward IP tables logging", since = "5.3")
     private String syslogServerList;
 
+    @SerializedName(ApiConstants.ADVERT_METHOD)
+    @Param(description = "VRRP advertisement method to use: unicast / multicast. Defaults to multicast'", since = "6.1")
+    private AdvertMethod advertMethod;
+
+    @SerializedName(ApiConstants.ADVERT_INTERVAL)
+    @Param(description = "VRRP advertisement interval. Defaults to 1.", since = "6.1")
+    private long advertInterval;
+
     public void setId(final String id) {
         this.id = id;
     }
@@ -221,5 +230,13 @@ public class VpcResponse extends BaseResponse implements ControlledEntityRespons
 
     public void setSyslogServerList(final String syslogServerList) {
         this.syslogServerList = syslogServerList;
+    }
+
+    public void setAdvertMethod(final AdvertMethod advertMethod) {
+        this.advertMethod = advertMethod;
+    }
+
+    public void setAdvertInterval(final long advertInterval) {
+        this.advertInterval = advertInterval;
     }
 }

--- a/cosmic-core/api/src/main/java/com/cloud/network/vpc/VpcService.java
+++ b/cosmic-core/api/src/main/java/com/cloud/network/vpc/VpcService.java
@@ -8,6 +8,7 @@ import com.cloud.legacymodel.exceptions.InsufficientCapacityException;
 import com.cloud.legacymodel.exceptions.NetworkRuleConflictException;
 import com.cloud.legacymodel.exceptions.ResourceAllocationException;
 import com.cloud.legacymodel.exceptions.ResourceUnavailableException;
+import com.cloud.model.enumeration.AdvertMethod;
 import com.cloud.legacymodel.network.vpc.PrivateGateway;
 import com.cloud.legacymodel.network.vpc.StaticRoute;
 import com.cloud.legacymodel.network.vpc.Vpc;
@@ -33,8 +34,8 @@ public interface VpcService {
      * @return
      * @throws ResourceAllocationException TODO
      */
-    public Vpc createVpc(long zoneId, long vpcOffId, long vpcOwnerId, String vpcName, String displayText, String cidr, String networkDomain, Boolean displayVpc, String sourceNatList, String
-            syslogServerList)
+    public Vpc createVpc(long zoneId, long vpcOffId, long vpcOwnerId, String vpcName, String displayText, String cidr, String networkDomain, Boolean displayVpc,
+                         String sourceNatList, String syslogServerList, Long advertInterval, AdvertMethod advertMethod)
             throws ResourceAllocationException;
 
     /**
@@ -58,7 +59,8 @@ public interface VpcService {
      * @param displayVpc  TODO
      * @return
      */
-    public Vpc updateVpc(long vpcId, String vpcName, String displayText, String customId, Boolean displayVpc, Long vpcOfferingId, String sourceNatList, String syslogServerList);
+    public Vpc updateVpc(long vpcId, String vpcName, String displayText, String customId, Boolean displayVpc, Long vpcOfferingId, String sourceNatList, String syslogServerList,
+                         Long advertInterval, AdvertMethod advertMethod);
 
     /**
      * Lists VPC(s) based on the parameters passed to the method call

--- a/cosmic-core/cosmic-flyway/src/main/resources/db/migration/V2_29__router_unicast_advert.sql
+++ b/cosmic-core/cosmic-flyway/src/main/resources/db/migration/V2_29__router_unicast_advert.sql
@@ -1,0 +1,112 @@
+-- Add unicast id to domain_router
+ALTER TABLE domain_router
+  ADD COLUMN `router_unicast_id` INT(1) DEFAULT NULL COMMENT 'Unicast ID of this router: 1 or 2 or NULL when multicast';
+
+-- Add vrrp fields to vpc
+ALTER TABLE vpc
+  ADD COLUMN `advert_interval` INT(1) DEFAULT 1 COMMENT 'VRRP advertisement interval. Defaults to 1.';
+ALTER TABLE vpc
+  ADD COLUMN `advert_method` VARCHAR(32) DEFAULT "MULTICAST" COMMENT 'VRRP advertisement method to use: UNICAST / MULTICAST. Defaults to MULTICAST';
+ALTER TABLE vpc
+  ADD COLUMN `unicast_subnet` VARCHAR(32) DEFAULT "100.100.0.0/24" COMMENT 'Unicast ipv4 /24 subnet to use. Defaults to 100.100.0.0/24';
+
+-- Recreate domain_router_view
+DROP VIEW IF EXISTS `domain_router_view`;
+CREATE VIEW `domain_router_view` AS
+  SELECT
+    `cloud`.`vm_instance`.`id` AS `id`,
+    `cloud`.`vm_instance`.`name` AS `name`,
+    `cloud`.`account`.`id` AS `account_id`,
+    `cloud`.`account`.`uuid` AS `account_uuid`,
+    `cloud`.`account`.`account_name` AS `account_name`,
+    `cloud`.`account`.`type` AS `account_type`,
+    `cloud`.`domain`.`id` AS `domain_id`,
+    `cloud`.`domain`.`uuid` AS `domain_uuid`,
+    `cloud`.`domain`.`name` AS `domain_name`,
+    `cloud`.`domain`.`path` AS `domain_path`,
+    `cloud`.`projects`.`id` AS `project_id`,
+    `cloud`.`projects`.`uuid` AS `project_uuid`,
+    `cloud`.`projects`.`name` AS `project_name`,
+    `cloud`.`vm_instance`.`uuid` AS `uuid`,
+    `cloud`.`vm_instance`.`created` AS `created`,
+    `cloud`.`vm_instance`.`state` AS `state`,
+    `cloud`.`vm_instance`.`removed` AS `removed`,
+    `cloud`.`vm_instance`.`pod_id` AS `pod_id`,
+    `cloud`.`vm_instance`.`instance_name` AS `instance_name`,
+    `cloud`.`vm_instance`.`last_start_datetime` AS `last_start_datetime`,
+    `cloud`.`vm_instance`.`last_start_version` AS `last_start_version`,
+    `cloud`.`host_pod_ref`.`uuid` AS `pod_uuid`,
+    `cloud`.`data_center`.`id` AS `data_center_id`,
+    `cloud`.`data_center`.`uuid` AS `data_center_uuid`,
+    `cloud`.`data_center`.`name` AS `data_center_name`,
+    `cloud`.`data_center`.`networktype` AS `data_center_type`,
+    `cloud`.`data_center`.`dns1` AS `dns1`,
+    `cloud`.`data_center`.`dns2` AS `dns2`,
+    `cloud`.`data_center`.`ip6_dns1` AS `ip6_dns1`,
+    `cloud`.`data_center`.`ip6_dns2` AS `ip6_dns2`,
+    `cloud`.`host`.`id` AS `host_id`,
+    `cloud`.`host`.`uuid` AS `host_uuid`,
+    `cloud`.`host`.`name` AS `host_name`,
+    `cloud`.`host`.`hypervisor_type` AS `hypervisor_type`,
+    `cloud`.`host`.`cluster_id` AS `cluster_id`,
+    `cloud`.`vm_template`.`id` AS `template_id`,
+    `cloud`.`vm_template`.`uuid` AS `template_uuid`,
+    `cloud`.`service_offering`.`id` AS `service_offering_id`,
+    `cloud`.`disk_offering`.`uuid` AS `service_offering_uuid`,
+    `cloud`.`disk_offering`.`name` AS `service_offering_name`,
+    `cloud`.`nics`.`id` AS `nic_id`,
+    `cloud`.`nics`.`uuid` AS `nic_uuid`,
+    `cloud`.`nics`.`network_id` AS `network_id`,
+    `cloud`.`nics`.`ip4_address` AS `ip_address`,
+    `cloud`.`nics`.`ip6_address` AS `ip6_address`,
+    `cloud`.`nics`.`ip6_gateway` AS `ip6_gateway`,
+    `cloud`.`nics`.`ip6_cidr` AS `ip6_cidr`,
+    `cloud`.`nics`.`default_nic` AS `is_default_nic`,
+    `cloud`.`nics`.`gateway` AS `gateway`,
+    `cloud`.`nics`.`netmask` AS `netmask`,
+    `cloud`.`nics`.`mac_address` AS `mac_address`,
+    `cloud`.`nics`.`broadcast_uri` AS `broadcast_uri`,
+    `cloud`.`nics`.`isolation_uri` AS `isolation_uri`,
+    `cloud`.`vpc`.`id` AS `vpc_id`,
+    `cloud`.`vpc`.`uuid` AS `vpc_uuid`,
+    `cloud`.`vpc`.`name` AS `vpc_name`,
+    `cloud`.`networks`.`uuid` AS `network_uuid`,
+    `cloud`.`networks`.`name` AS `network_name`,
+    `cloud`.`networks`.`network_domain` AS `network_domain`,
+    `cloud`.`networks`.`traffic_type` AS `traffic_type`,
+    `cloud`.`networks`.`guest_type` AS `guest_type`,
+    `cloud`.`async_job`.`id` AS `job_id`,
+    `cloud`.`async_job`.`uuid` AS `job_uuid`,
+    `cloud`.`async_job`.`job_status` AS `job_status`,
+    `cloud`.`async_job`.`account_id` AS `job_account_id`,
+    `cloud`.`domain_router`.`template_version` AS `template_version`,
+    `cloud`.`domain_router`.`scripts_version` AS `scripts_version`,
+    `cloud`.`domain_router`.`is_redundant_router` AS `is_redundant_router`,
+    `cloud`.`domain_router`.`redundant_state` AS `redundant_state`,
+    `cloud`.`domain_router`.`stop_pending` AS `stop_pending`,
+    `cloud`.`domain_router`.`role` AS `role`,
+    `cloud`.`domain_router`.`router_unicast_id` as `router_unicast_id`
+  FROM ((((((((((((((`cloud`.`domain_router`
+    JOIN `cloud`.`vm_instance` ON ((`cloud`.`vm_instance`.`id` = `cloud`.`domain_router`.`id`))) JOIN `cloud`.`account`
+      ON ((`cloud`.`vm_instance`.`account_id` = `cloud`.`account`.`id`))) JOIN `cloud`.`domain`
+      ON ((`cloud`.`vm_instance`.`domain_id` = `cloud`.`domain`.`id`))) LEFT JOIN `cloud`.`host_pod_ref`
+      ON ((`cloud`.`vm_instance`.`pod_id` = `cloud`.`host_pod_ref`.`id`))) LEFT JOIN `cloud`.`projects`
+      ON ((`cloud`.`projects`.`project_account_id` = `cloud`.`account`.`id`))) LEFT JOIN `cloud`.`data_center`
+      ON ((`cloud`.`vm_instance`.`data_center_id` = `cloud`.`data_center`.`id`))) LEFT JOIN `cloud`.`host`
+      ON ((`cloud`.`vm_instance`.`host_id` = `cloud`.`host`.`id`))) LEFT JOIN `cloud`.`vm_template`
+      ON ((`cloud`.`vm_instance`.`vm_template_id` = `cloud`.`vm_template`.`id`))) LEFT JOIN `cloud`.`service_offering`
+      ON ((`cloud`.`vm_instance`.`service_offering_id` = `cloud`.`service_offering`.`id`))) LEFT JOIN
+    `cloud`.`disk_offering` ON ((`cloud`.`vm_instance`.`service_offering_id` = `cloud`.`disk_offering`.`id`))) LEFT JOIN
+    `cloud`.`nics`
+      ON (((`cloud`.`vm_instance`.`id` = `cloud`.`nics`.`instance_id`) AND isnull(`cloud`.`nics`.`removed`)))) LEFT JOIN
+    `cloud`.`networks` ON ((`cloud`.`nics`.`network_id` = `cloud`.`networks`.`id`))) LEFT JOIN `cloud`.`vpc`
+      ON (((`cloud`.`domain_router`.`vpc_id` = `cloud`.`vpc`.`id`) AND isnull(`cloud`.`vpc`.`removed`)))) LEFT JOIN
+    `cloud`.`async_job` ON (((`cloud`.`async_job`.`instance_id` = `cloud`.`vm_instance`.`id`) AND
+                             (`cloud`.`async_job`.`instance_type` = 'DomainRouter') AND
+                             (`cloud`.`async_job`.`job_status` = 0))));
+
+-- Config
+INSERT INTO `configuration` (`category`, `instance`, `component`, `name`, `value`, `description`, `default_value`, `updated`, `scope`, `is_dynamic`)
+VALUES
+('Advanced', 'DEFAULT', 'NetworkOrchestrationService', 'router.redundant.advert.method', 'MULTICAST', 'VRRP advertisement method to use: UNICAST / MULTICAST. Defaults to MULTICAST', 1, NULL, NULL, 1),
+('Advanced', 'DEFAULT', 'NetworkOrchestrationService', 'router.redundant.unicast.subnet', '100.100.0.0/24', 'Unicast ipv4 /24 subnet to use from CGN. Defaults to 100.100.0.0/24', 1, NULL, NULL, 1)

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/network/vpc/VpcVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/network/vpc/VpcVO.java
@@ -1,6 +1,7 @@
 package com.cloud.network.vpc;
 
 import com.cloud.legacymodel.network.vpc.Vpc;
+import com.cloud.model.enumeration.AdvertMethod;
 import com.cloud.utils.db.GenericDao;
 
 import javax.persistence.Column;
@@ -54,6 +55,12 @@ public class VpcVO implements Vpc {
     String sourceNatList;
     @Column(name = "syslog_server_list")
     String syslogServerList;
+    @Column(name = "advert_interval")
+    long advertInterval;
+    @Column(name = "unicast_subnet")
+    String unicastSubnet;
+    @Column(name = "advert_method")
+    AdvertMethod advertMethod;
 
     public VpcVO() {
         uuid = UUID.randomUUID().toString();
@@ -61,7 +68,7 @@ public class VpcVO implements Vpc {
 
     public VpcVO(final long zoneId, final String name, final String displayText, final long accountId, final long domainId,
                  final long vpcOffId, final String cidr, final String networkDomain, final boolean isRedundant, final String sourceNatList,
-                 final String syslogServerList) {
+                 final String syslogServerList, final long advertInterval, final String unicastSubnet, final AdvertMethod advertMethod) {
         this.zoneId = zoneId;
         this.name = name;
         this.displayText = displayText;
@@ -75,6 +82,9 @@ public class VpcVO implements Vpc {
         redundant = isRedundant;
         this.sourceNatList = sourceNatList;
         this.syslogServerList = syslogServerList;
+        this.advertInterval = advertInterval;
+        this.unicastSubnet = unicastSubnet;
+        this.advertMethod = advertMethod;
     }
 
     @Override
@@ -208,5 +218,29 @@ public class VpcVO implements Vpc {
 
     public String getSyslogServerList() {
         return syslogServerList;
+    }
+
+    public long getAdvertInterval() {
+        return advertInterval;
+    }
+
+    public void setAdvertInterval(final long advertInterval) {
+        this.advertInterval = advertInterval;
+    }
+
+    public String getUnicastSubnet() {
+        return unicastSubnet;
+    }
+
+    public void setUnicastSubnet(final String unicastSubnet) {
+        this.unicastSubnet = unicastSubnet;
+    }
+
+    public AdvertMethod getAdvertMethod() {
+        return advertMethod;
+    }
+
+    public void setAdvertMethod(final AdvertMethod advertMethod) {
+        this.advertMethod = advertMethod;
     }
 }

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/vm/DomainRouterVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/vm/DomainRouterVO.java
@@ -49,10 +49,13 @@ public class DomainRouterVO extends VMInstanceVO implements VirtualRouter {
     @Column(name = "vpc_id")
     private Long vpcId;
 
+    @Column(name = "router_unicast_id")
+    private Long routerUnicastId;
+
     public DomainRouterVO(final long id, final long serviceOfferingId, final long elementId, final String name, final long templateId, final HypervisorType hypervisorType,
                           final long guestOSId, final long domainId, final long accountId, final long userId, final boolean isRedundantRouter, final RedundantState redundantState,
                           final boolean haEnabled, final boolean stopPending, final Long vpcId, final OptimiseFor optimiseFor, final String manufacturerString,
-                          final String cpuFlags, final Boolean macLearning, final Boolean requiresRestart, final MaintenancePolicy maintenancePolicy) {
+                          final String cpuFlags, final Boolean macLearning, final Boolean requiresRestart, final MaintenancePolicy maintenancePolicy, final Long routerUnicastId) {
         super(id, serviceOfferingId, name, name, VirtualMachineType.DomainRouter, templateId, hypervisorType, guestOSId, domainId, accountId, userId, haEnabled);
         this.elementId = elementId;
         this.isRedundantRouter = isRedundantRouter;
@@ -65,6 +68,7 @@ public class DomainRouterVO extends VMInstanceVO implements VirtualRouter {
         this.macLearning = macLearning;
         this.requiresRestart = requiresRestart;
         this.maintenancePolicy = maintenancePolicy;
+        this.routerUnicastId = routerUnicastId;
     }
 
     protected DomainRouterVO() {
@@ -167,5 +171,13 @@ public class DomainRouterVO extends VMInstanceVO implements VirtualRouter {
 
     public void setScriptsVersion(final String scriptsVersion) {
         this.scriptsVersion = scriptsVersion;
+    }
+
+    public Long getRouterUnicastId() {
+        return routerUnicastId;
+    }
+
+    public void setRouterUnicastId(final Long routerUnicastId) {
+        this.routerUnicastId = routerUnicastId;
     }
 }

--- a/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2284,6 +2284,8 @@ public class ApiResponseHelper implements ResponseGenerator {
         response.setRedundantRouter(vpc.isRedundant());
         response.setSourceNatList(vpc.getSourceNatList());
         response.setSyslogServerList(vpc.getSyslogServerList());
+        response.setAdvertInterval(vpc.getAdvertInterval());
+        response.setAdvertMethod(vpc.getAdvertMethod());
 
         final Map<Service, Set<Provider>> serviceProviderMap = ApiDBUtils.listVpcOffServices(vpc.getVpcOfferingId());
         final List<ServiceResponse> serviceResponses = getServiceResponses(serviceProviderMap);

--- a/cosmic-core/server/src/main/java/com/cloud/api/query/dao/DomainRouterJoinDaoImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/query/dao/DomainRouterJoinDaoImpl.java
@@ -64,7 +64,9 @@ public class DomainRouterJoinDaoImpl extends GenericDaoBase<DomainRouterJoinVO, 
         if (router.getLastStartVersion() != null) {
             routerResponse.setLastStartVersion(router.getLastStartVersion());
         }
-
+        if (router.getRouterUnicastId() != null) {
+            routerResponse.setRouterUnicastId(router.getRouterUnicastId());
+        }
         if (router.getTemplateVersion() != null) {
             final String routerVersion = Version.trimRouterVersion(router.getTemplateVersion());
             routerResponse.setVersion(routerVersion);

--- a/cosmic-core/server/src/main/java/com/cloud/api/query/vo/DomainRouterJoinVO.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/query/vo/DomainRouterJoinVO.java
@@ -171,6 +171,8 @@ public class DomainRouterJoinVO extends BaseViewVO implements ControlledViewEnti
     protected String lastStartDateTime;
     @Column(name = "last_start_version")
     protected String lastStartVersion;
+    @Column(name = "router_unicast_id")
+    protected Long routerUnicastId;
 
     public DomainRouterJoinVO() {
     }
@@ -722,7 +724,9 @@ public class DomainRouterJoinVO extends BaseViewVO implements ControlledViewEnti
     public String getLastStartVersion() {
         return lastStartVersion;
     }
-
+    public Long getRouterUnicastId() {
+        return routerUnicastId;
+    }
     @Override
     public Class<?> getEntityType() {
         return VirtualMachine.class;

--- a/cosmic-core/server/src/main/java/com/cloud/configuration/Config.java
+++ b/cosmic-core/server/src/main/java/com/cloud/configuration/Config.java
@@ -1601,6 +1601,24 @@ public enum Config {
             "seconds between VRRP broadcast. It would 3 times broadcast fail to trigger fail-over mechanism of redundant router",
             null),
 
+    RedundantRouterAdvertMethod(
+            "Advanced",
+            NetworkOrchestrationService.class,
+            String.class,
+            "router.redundant.advert.method",
+            "multicast",
+            "VRRP advertisement method to use: unicast / multicast. Defaults to multicast'",
+            null),
+
+    RedundantRouterUnicastSubnet(
+            "Advanced",
+            NetworkOrchestrationService.class,
+            String.class,
+            "router.redundant.unicast.subnet",
+            "100.100.0.0/24",
+            "Unicast ipv4 /24 subnet to use from CGN. Defaults to 100.100.0.0/24'",
+            null),
+
     RouterAggregationCommandEachTimeout(
             "Advanced",
             NetworkOrchestrationService.class,

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
@@ -458,6 +458,11 @@ public class NetworkHelperImpl implements NetworkHelper {
             routerOffering = _serviceOfferingDao.findById(routerDeploymentDefinition.getSecondaryServiceOfferingId());
         }
 
+        Long routerUnicastId = 1L;
+        if (isRedundant && routers != null && routers.size() == 1 && routers.get(0).getRouterUnicastId() == 1L) {
+            routerUnicastId = 2L;
+        }
+
         _serviceOfferingDao.loadDetails(routerOffering);
         final String serviceofferingHypervisor = routerOffering.getDetail("hypervisor");
         if (serviceofferingHypervisor != null && !serviceofferingHypervisor.isEmpty()) {
@@ -512,7 +517,7 @@ public class NetworkHelperImpl implements NetworkHelper {
                 router = new DomainRouterVO(id, routerOffering.getId(), routerDeploymentDefinition.getVirtualProvider().getId(), VirtualMachineName.getRouterName(id,
                         s_vmInstanceName), template.getId(), template.getHypervisorType(), template.getGuestOSId(), owner.getDomainId(), owner.getId(),
                         userId, routerDeploymentDefinition.isRedundant(), RedundantState.UNKNOWN, offerHA, false, vpcId,
-                        template.getOptimiseFor(), template.getManufacturerString(), template.getCpuFlags(), template.getMacLearning(), false, template.getMaintenancePolicy());
+                        template.getOptimiseFor(), template.getManufacturerString(), template.getCpuFlags(), template.getMacLearning(), false, template.getMaintenancePolicy(), routerUnicastId);
 
                 router.setDynamicallyScalable(template.isDynamicallyScalable());
                 router.setRole(Role.VIRTUAL_ROUTER);

--- a/cosmic-core/server/src/test/java/com/cloud/vpc/dao/MockVpcDaoImpl.java
+++ b/cosmic-core/server/src/test/java/com/cloud/vpc/dao/MockVpcDaoImpl.java
@@ -2,6 +2,7 @@ package com.cloud.vpc.dao;
 
 import com.cloud.legacymodel.network.vpc.Vpc;
 import com.cloud.legacymodel.network.vpc.Vpc.State;
+import com.cloud.model.enumeration.AdvertMethod;
 import com.cloud.network.vpc.VpcVO;
 import com.cloud.network.vpc.dao.VpcDao;
 import com.cloud.utils.db.DB;
@@ -80,9 +81,9 @@ public class MockVpcDaoImpl extends GenericDaoBase<VpcVO, Long> implements VpcDa
     public VpcVO findById(final Long id) {
         VpcVO vo = null;
         if (id.longValue() == 1) {
-            vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, "", "");
+            vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, "", "", 1L, "100.100.0.0/24", AdvertMethod.MULTICAST);
         } else if (id.longValue() == 2) {
-            vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, "", "");
+            vo = new VpcVO(1, "new vpc", "new vpc", 1, 1, 1, "0.0.0.0/0", "vpc domain", false, "", "", 1L, "100.100.0.0/24", AdvertMethod.MULTICAST);
             vo.setState(State.Inactive);
         }
 

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/config.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/config.py
@@ -35,6 +35,19 @@ class Config:
             return self.dbag_cmdline['config']['advert_int']
         return 1
 
+    def get_advert_method(self):
+        if 'advert_method' in self.dbag_cmdline['config']:
+            return self.dbag_cmdline['config']['advert_method']
+        return "multicast"
+
+    def get_unicast_subnet(self):
+        if 'unicast_subnet' in self.dbag_cmdline['config']:
+            return self.dbag_cmdline['config']['unicast_subnet']
+        return "100.100.0.0/24"
+
+    def get_unicast_id(self):
+        return self.dbag_cmdline['config']['unicast_id']
+
     def set_ingress_rules(self, key, ingress_rules):
         self.ingress_rules[key] = ingress_rules
 

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/templates/keepalived_vrrp_instance.conf
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/templates/keepalived_vrrp_instance.conf
@@ -5,6 +5,13 @@ vrrp_instance {{ name }} {
     nopreempt
     advert_int {{ advert_int }}
 
+    {% if advert_method == "UNICAST" %}
+    unicast_src_ip {{ unicast_src }}
+        unicast_peer {
+            {{ unicast_peer }}
+        }
+    {% endif %}
+
     {% if virtual_ipaddress is iterable %}
     virtual_ipaddress {
         {% for address in virtual_ipaddress %}

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/utils.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/utils.py
@@ -87,7 +87,13 @@ NETMASK="%s"
     def setup_sync_nic(self):
 
         sync_device = self.find_nic("sync")
-        sync_ip_address = self.link_local_ip.replace("169.254", "100.100")
+        print("Setting up router for %s VRRP" % self.cmdline["advert_method"])
+        if self.cmdline["advert_method"] == "UNICAST":
+            sync_ip_address = self.cmdline["unicast_subnet"].replace("0/24", self.cmdline["unicast_id"])
+        else:
+            sync_ip_address = self.link_local_ip.replace("169.254", "100.100")
+
+        print("Sync ip is %s" % sync_ip_address)
 
         if not sync_device:
             return False

--- a/cosmic-model/src/main/java/com/cloud/legacymodel/network/vpc/Vpc.java
+++ b/cosmic-model/src/main/java/com/cloud/legacymodel/network/vpc/Vpc.java
@@ -3,6 +3,7 @@ package com.cloud.legacymodel.network.vpc;
 import com.cloud.legacymodel.Identity;
 import com.cloud.legacymodel.InternalIdentity;
 import com.cloud.legacymodel.acl.ControlledEntity;
+import com.cloud.model.enumeration.AdvertMethod;
 
 public interface Vpc extends ControlledEntity, Identity, InternalIdentity {
 
@@ -50,6 +51,21 @@ public interface Vpc extends ControlledEntity, Identity, InternalIdentity {
      * @return VPC syslog server list
      */
     String getSyslogServerList();
+
+    /**
+     * @return VRRP advert_interval
+     */
+    long getAdvertInterval();
+
+    /**
+     * @return VRRP unicast subnet
+     */
+    String getUnicastSubnet();
+
+    /**
+     * @return VRRP advert method
+     */
+    AdvertMethod getAdvertMethod();
 
     /**
      * @return true if restart is required for the VPC; false otherwise

--- a/cosmic-model/src/main/java/com/cloud/model/enumeration/AdvertMethod.java
+++ b/cosmic-model/src/main/java/com/cloud/model/enumeration/AdvertMethod.java
@@ -1,0 +1,6 @@
+package com.cloud.model.enumeration;
+
+public enum AdvertMethod {
+    MULTICAST,
+    UNICAST
+}


### PR DESCRIPTION
This PR adds the following features:
- make `advert_interval` configurable per VPC
- choose between `vrrp` `multicast` (default) or `vrrp ` `unicast`

Switching between the types or changing `advert_interval` needs a `Restart+Cleanup` to take effect. This will not be seamless due to incompatible configurations. The hiccup should however be small, under 60 seconds.

New config is pushed to the routers:
```
[root@r-15-vm ~]# cat /etc/cosmic/router/cmdline.json
{
    "config": {
        "advert_int": "10",
        "advert_method": "unicast",
        "controlip": "169.254.2.180",
        "controlmac": "0e:00:a9:fe:02:b4",
        "controlmask": "255.255.0.0",
        "disable_rp_filter": "true",
        "dns1": "8.8.8.8",
        "domain": "cs2cloud",
        "name": "r-15-VM",
        "redundant_router": "true",
        "redundant_state": "MASTER",
        "router_id": "6",
        "router_password": "13220771506355102625775035799920100309361512856445189727817038968793235061440945672822979465776690439192792976992798289724123227177813654728782793802659542",
        "syncmac": "02:00:64:10:00:01",
        "template": "domP",
        "type": "vpcrouter",
        "unicast_id": "1",
        "unicast_subnet": "100.100.0.0/24",
        "vpccidr": "10.0.0.0/16"
    },
    "id": "cmdline"
}
```

The `keepaliived` is configured accordingly. Example for `unicast`:

```
```vrrp_instance public_eth2 {
    state BACKUP
    interface eth1
    virtual_router_id 2
    nopreempt
    advert_int 1

    unicast_src_ip 100.100.0.1
        unicast_peer {
            100.100.0.2
        }

    virtual_ipaddress {
    }
    virtual_ipaddress_excluded {
        100.64.0.9/24 dev eth2
    }```

```vrrp_instance public_eth2 {
    state BACKUP
    interface eth1
    virtual_router_id 2
    nopreempt
    advert_int 1

    unicast_src_ip 100.100.0.2
        unicast_peer {
            100.100.0.1
        }

    virtual_ipaddress {
    }
    virtual_ipaddress_excluded {
        100.64.0.9/24 dev eth2
    }
```

Unicast failover demo:
![image](https://user-images.githubusercontent.com/1630096/48969727-0557ac00-f003-11e8-81f7-0b241e09ac0d.png)

The communication is now happening over unicast (no more multicast packets):

```
[root@r-32-vm ~]# tcpdump -ni eth1 vrrp
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on eth1, link-type EN10MB (Ethernet), capture size 262144 bytes
10:58:30.538067 IP 100.100.0.1 > 100.100.0.2: VRRPv2, Advertisement, vrid 2, prio 100, authtype none, intvl 1s, length 16
10:58:30.546263 IP 100.100.0.1 > 100.100.0.2: VRRPv2, Advertisement, vrid 3, prio 100, authtype none, intvl 1s, length 16
10:58:30.557602 IP 100.100.0.1 > 100.100.0.2: VRRPv2, Advertisement, vrid 254, prio 100, authtype none, intvl 1s, length 16
10:58:31.545774 IP 100.100.0.1 > 100.100.0.2: VRRPv2, Advertisement, vrid 2, prio 100, authtype none, intvl 1s, length 16
10:58:31.556761 IP 100.100.0.1 > 100.100.0.2: VRRPv2, Advertisement, vrid 3, prio 100, authtype none, intvl 1s, length 16
10:58:31.567788 IP 100.100.0.1 > 100.100.0.2: VRRPv2, Advertisement, vrid 254, prio 100, authtype none, intvl 1s, length 16
10:58:32.551894 IP 100.100.0.1 > 100.100.0.2: VRRPv2, Advertisement, vrid 2, prio 100, authtype none, intvl 1s, length 16
10:58:32.563829 IP 100.100.0.1 > 100.100.0.2: VRRPv2, Advertisement, vrid 3, prio 100, authtype none, intvl 1s, length 16
10:58:32.575186 IP 100.100.0.1 > 100.100.0.2: VRRPv2, Advertisement, vrid 254, prio 100, authtype none, intvl 1s, length 16
```
