### PR TITLE
Revert "Add safe guard around unicast methods"

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/conntrackd.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/conntrackd.py
@@ -29,11 +29,7 @@ class Conntrackd:
         for ipv4 in self.config.get_all_ipv4_addresses_on_router():
             address_ignore.append('IPv4_address %s' % ipv4)
 
-        if self.config.get_advert_method() == "UNICAST":
-            unicast_src, unicast_peer = utils.get_unicast_ips(self.config)
-        else:
-            unicast_src = None
-            unicast_peer = None
+        unicast_src, unicast_peer = utils.get_unicast_ips(self.config)
 
         content = self.jinja_env.get_template('conntrackd.conf').render(
             ipv6_multicast_address=self.conntrackd_ipv6_multicast_address,

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/keepalived.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/keepalived.py
@@ -83,11 +83,7 @@ class Keepalived:
             for i in interface['ipv4_addresses']:
                 ipv4addresses.append('%s dev %s' % (i['cidr'], interface_name))
 
-            if self.config.get_advert_method() == "UNICAST":
-                unicast_src, unicast_peer = utils.get_unicast_ips(self.config)
-            else:
-                unicast_src = None
-                unicast_peer = None
+            unicast_src, unicast_peer = utils.get_unicast_ips(self.config)
 
             self.write_vrrp_instance(
                 name=name,
@@ -117,11 +113,8 @@ class Keepalived:
                 'default via %s' % self.config.dbag_network_overview['services']['source_nat'][0]['gateway']
             )
 
-        if self.config.get_advert_method() == "UNICAST":
-            unicast_src, unicast_peer = utils.get_unicast_ips(self.config)
-        else:
-            unicast_src = None
-            unicast_peer = None
+        unicast_src, unicast_peer = utils.get_unicast_ips(self.config)
+
         self.write_vrrp_instance(
             name='routes',
             state='BACKUP',


### PR DESCRIPTION
Reverts MissionCriticalCloud/cosmic#803 and the unwanted auto-merge of MissionCriticalCloud/cosmic#802

Two PRs had the same commit ID. I wrote the commit and the first PR, then the 2nd PR was also opened by someone else and that was later merged by me. However, the original PR now also showed I merged it (which is confusing, as I merged #803 not #802). You can see this because #802 does not have a revert button and #803 has. I will prepare a revert-PR just in case we need it.