### PR TITLE
Only ignore non-user subnets from connection tracking

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/config.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/config.py
@@ -100,11 +100,13 @@ class Config:
             if interface['metadata']['type'] == 'public':
                 return utils.get_interface_name_from_mac_address(interface['mac_address'])
 
-    def get_all_ipv4_addresses_on_router(self):
+    def get_to_be_ignored_ipv4_addresses_on_router(self):
         ipv4_addresses = []
 
         for interface in self.dbag_network_overview['interfaces']:
             for ip in interface['ipv4_addresses']:
-                ipv4_addresses.append(ip['cidr'].split('/')[0])
+                if interface['metadata']['type'] in ('other', 'sync'):
+                    ipv4_addresses.append(ip['cidr'].split('/')[0])
+        ipv4_addresses.append(self.get_unicast_subnet())
 
         return ipv4_addresses

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/conntrackd.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/conntrackd.py
@@ -26,7 +26,7 @@ class Conntrackd:
     def write_config_file(self):
         address_ignore = []
 
-        for ipv4 in self.config.get_all_ipv4_addresses_on_router():
+        for ipv4 in self.config.get_to_be_ignored_ipv4_addresses_on_router():
             address_ignore.append('IPv4_address %s' % ipv4)
 
         if self.config.get_advert_method() == "UNICAST":


### PR DESCRIPTION
Before:
```
        Address Ignore {
            IPv4_address 169.254.0.89
            IPv4_address 85.x.x.x
            IPv4_address 85.x.x.y
            IPv4_address 10.10.16.1
            IPv4_address 10.10.16.65
            IPv4_address 10.10.16.193
            IPv4_address 10.10.16.129
        }
```

After:
```
        Address Ignore {
            IPv4_address 169.254.0.89
            IPv4_address 100.100.0.0/24
        }
```

Thanks @ddegoede :)