### PR TITLE
Reload an extra time to make sure all routes are moved from old to new files

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/keepalived.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/keepalived.py
@@ -38,6 +38,9 @@ class Keepalived:
         self.write_sync_group()
         self.zap_keepalived_config_directory()
         self.reload_keepalived()
+        # Reload an extra time to make sure all routes are moved from old to new files
+        # This can be removed once all pre-Cosmic 6.2 routers are replaced
+        self.reload_keepalived()
 
     def init_config(self):
         if not os.path.exists(self.keepalived_config_path):


### PR DESCRIPTION
See `https://fossies.org/linux/keepalived/keepalived/vrrp/vrrp_iproute.c` line 1852 method `clear_diff_routes()`

Routes are being cleared when removed from file (moved to another in this case). The extra reload makes sure they are there anyway.

```
Dec 13 12:30:43 r-123-VM Keepalived_vrrp[1102]: ip route 10.11.80.0/22 ... , no longer exist
Dec 13 12:30:43 r-123-VM Keepalived_vrrp[1102]: ip route 10.11.64.0/22 ... , no longer exist
```