### PR TITLE
Feature/scsi multi queue

### DIFF
--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/kvm/LibvirtComputingResource.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/kvm/LibvirtComputingResource.java
@@ -1481,7 +1481,7 @@ public class LibvirtComputingResource extends AgentResourceBase implements Agent
 
         // Always add a virtio scsi controller
         vmTo.getName();
-        final ScsiDef sd = new ScsiDef((short) 0, 0, 0, 9, 0);
+        final ScsiDef sd = new ScsiDef((short) 0, 0, 0, 9, 0, vcpus);
         devices.addDevice(sd);
         logger.debug("Adding SCSI definition for " + vmTo.getName() + ":\n" + sd.toString());
 

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/kvm/xml/LibvirtVmDef.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/kvm/xml/LibvirtVmDef.java
@@ -965,13 +965,15 @@ public class LibvirtVmDef {
         private int bus = 0;
         private int slot = 9;
         private int function = 0;
+        private int queues = 0;
 
-        public ScsiDef(final short index, final int domain, final int bus, final int slot, final int function) {
+        public ScsiDef(final short index, final int domain, final int bus, final int slot, final int function, final int queues) {
             this.index = index;
             this.domain = domain;
             this.bus = bus;
             this.slot = slot;
             this.function = function;
+            this.queues = queues;
         }
 
         public ScsiDef() {
@@ -985,6 +987,9 @@ public class LibvirtVmDef {
             scsiBuilder.append(String.format("<controller type='scsi' index='%d' model='virtio-scsi'>\n", this.index));
             scsiBuilder.append(String.format("<address type='pci' domain='0x%04X' bus='0x%02X' slot='0x%02X' function='0x%01X'/>\n",
                     this.domain, this.bus, this.slot, this.function));
+            if (this.queues > 0) {
+                scsiBuilder.append(String.format("<driver queues='%d'/>\n", this.queues));
+            }
             scsiBuilder.append("</controller>\n");
             return scsiBuilder.toString();
         }

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/kvm/xml/LibvirtVmDef.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/kvm/xml/LibvirtVmDef.java
@@ -987,6 +987,12 @@ public class LibvirtVmDef {
             scsiBuilder.append(String.format("<controller type='scsi' index='%d' model='virtio-scsi'>\n", this.index));
             scsiBuilder.append(String.format("<address type='pci' domain='0x%04X' bus='0x%02X' slot='0x%02X' function='0x%01X'/>\n",
                     this.domain, this.bus, this.slot, this.function));
+
+            // Limit to max 8 queues
+            if (this.queues > 8) {
+                this.queues = 8;
+            }
+
             if (this.queues > 0) {
                 scsiBuilder.append(String.format("<driver queues='%d'/>\n", this.queues));
             }

--- a/cosmic-agent/src/test/java/com/cloud/agent/resource/kvm/LibvirtVMDefTest.java
+++ b/cosmic-agent/src/test/java/com/cloud/agent/resource/kvm/LibvirtVMDefTest.java
@@ -138,10 +138,11 @@ public class LibvirtVMDefTest extends TestCase {
     }
 
     public void testScsiDef() {
-        final ScsiDef def = new ScsiDef();
+        final ScsiDef def = new ScsiDef((short)0, 0, 0, 9, 0, 4);
         final String str = def.toString();
         final String expected = "<controller type='scsi' index='0' model='virtio-scsi'>\n" +
                 "<address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>\n" +
+                "<driver queues='4'/>\n" +
                 "</controller>\n";
         assertEquals(str, expected);
     }


### PR DESCRIPTION
This adds queues to the SCSI controller. By default the number of vCPUs == the number of queue's. The max is 8.

Example:
```
    <controller type='scsi' index='0' model='virtio-scsi'>
      <driver queues='1'/>
      <alias name='scsi0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
    </controller>
```

and

```
    <controller type='scsi' index='0' model='virtio-scsi'>
      <driver queues='2'/>
      <alias name='scsi0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
    </controller>
```
