### PR TITLE
Set internal routes for DNS and MGT

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/generic_startup_hook.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/generic_startup_hook.py
@@ -38,7 +38,7 @@ class App:
         self.cmdline = {}
 
         with open(AGENT_PROPERTIES, "r") as f:
-            config = yaml.load(f)
+            config = yaml.load(stream=f, Loader=yaml.FullLoader)
             self.cmdline = config['cosmic']
 
     def write_cmdline_json(self):

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/setup_cpvm.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/setup_cpvm.py
@@ -60,6 +60,8 @@ class ConsoleProxyVM:
         if self.cmdline['setrfc1918routes'] == 'true':
             logging.info("Setting rfc1918 routes")
             Utils(self.cmdline).set_rfc1918_routes()
+        logging.info("Setting local routes")
+        Utils(self.cmdline).set_local_routes()
 
         os.system("systemctl start cosmic-agent")
 

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/setup_ssvm.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/setup_ssvm.py
@@ -61,6 +61,8 @@ class SecondaryStorageVM:
         if self.cmdline['setrfc1918routes'] == 'true':
             logging.info("Setting rfc1918 routes")
             Utils(self.cmdline).set_rfc1918_routes()
+        logging.info("Setting local routes")
+        Utils(self.cmdline).set_local_routes()
 
         os.system("systemctl start cosmic-agent")
 

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/utils.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/utils.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 import os
 import subprocess
-
+import ipaddress
 import yaml
 
 
@@ -264,3 +264,16 @@ Cosmic sytemvm powered by %s
         os.system("ip route add 10.0.0.0/8 via %s" % self.cmdline["localgw"])
         os.system("ip route add 172.16.0.0/12 via %s" % self.cmdline["localgw"])
         os.system("ip route add 192.168.0.0/16 via %s" % self.cmdline["localgw"])
+
+    def set_local_routes(self):
+        # Internal DNS
+        if "internaldns1" in self.cmdline and ipaddress.ip_address(self.cmdline["internaldns1"]).is_private:
+            print("Set route for internal DNS1 to localgw")
+            os.system("ip route add %s via %s" % (self.cmdline["internaldns1"], self.cmdline["localgw"]))
+        if "internaldns2" in self.cmdline and ipaddress.ip_address(self.cmdline["internaldns2"]).is_private:
+            print("Set route for internal DNS2 to localgw")
+            os.system("ip route add %s via %s" % (self.cmdline["internaldns2"], self.cmdline["localgw"]))
+        # Management Servers
+        for mgt in self.cmdline.get('hosts', []):
+            print("Set route for management server %s to localgw" % mgt)
+            os.system("ip route add %s via %s" % (mgt, self.cmdline["localgw"]))


### PR DESCRIPTION
```default via 100.69.1.1 dev eth0
100.69.1.0/24 dev eth0 proto kernel scope link src 100.69.1.6
169.254.0.0/16 dev eth1 proto kernel scope link src 169.254.1.192
172.16.193.0/27 dev eth2 proto kernel scope link src 172.16.193.21
[root@v-192-vm ~]#

[root@v-192-vm startup]# python3.6 /opt/cosmic/startup/generic_startup_hook.py
/opt/cosmic/startup/generic_startup_hook.py:41: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  config = yaml.load(f)
Processing control
Finding device for mac_address 0e:00:a9:fe:01:c0
Found interface eth1
169.254.1.192
Processing public
Finding device for mac_address 06:a7:20:00:00:3c
Found interface eth0
Processing mgt
Finding device for mac_address 06:c6:02:00:00:69
Found interface eth2
RTNETLINK answers: File exists
Job for keepalived.service failed because a configured resource limit was exceeded. See "systemctl status keepalived.service" and "journalctl -xe" for details.
Changed root password
2019-05-22 09:24:58,012  generic_startup_hook.py start_app:79 Starting app consoleproxy
2019-05-22 09:24:58,013  setup_cpvm.py start:57 Setting up configuration for consoleproxy
2019-05-22 09:24:58,019  setup_cpvm.py start:63 Setting local routes
Set route for internal DNS1 to localgw
Set route for internal DNS2 to localgw
Set route for management server 10.200.10.46 to localgw
Set route for management server 10.200.10.45 to localgw
Set route for management server 10.200.10.44 to localgw

[root@v-192-vm startup]# ip r
default via 100.69.1.1 dev eth0
10.200.10.31 via 172.16.193.1 dev eth2
10.200.10.32 via 172.16.193.1 dev eth2
10.200.10.44 via 172.16.193.1 dev eth2
10.200.10.45 via 172.16.193.1 dev eth2
10.200.10.46 via 172.16.193.1 dev eth2
100.69.1.0/24 dev eth0 proto kernel scope link src 100.69.1.6
169.254.0.0/16 dev eth1 proto kernel scope link src 169.254.1.192
169.254.0.0/16 dev eth0 scope link metric 1002
169.254.0.0/16 dev eth1 scope link metric 1003
169.254.0.0/16 dev eth2 scope link metric 1004
172.16.193.0/27 dev eth2 proto kernel scope link src 172.16.193.21
```