### PR TITLE
Bring back maintenance feature

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/resource/ResourceManagerImpl.java
@@ -2257,12 +2257,6 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
             throw new InvalidParameterValueException("Unable to find host with ID: " + hostId + ". Please specify a valid host ID.");
         }
 
-        final List<VMInstanceVO> vmsRunningOnHost = this._vmDao.listByHostId(hostId);
-
-        if (!vmsRunningOnHost.isEmpty()) {
-            throw new InvalidParameterValueException("There are active VMs on this host. Please migrate all VMs on this host to another host before starting maintenance.");
-        }
-
         if (this._hostDao.countBy(host.getClusterId(), ResourceState.PrepareForMaintenance, ResourceState.ErrorInMaintenance) > 0) {
             throw new InvalidParameterValueException("There are other servers in PrepareForMaintenance OR ErrorInMaintenance STATUS in cluster " + host.getClusterId());
         }


### PR DESCRIPTION
This does require some attention on KVM:
`workers` global setting is used for HA and also for the number of live migrations that are attempted at the same time. This should be set to a low value, to say 1 or 2. We need to test if HA is still fast enough.
