### PR TITLE
Fix endless start loop when rebooting systemvm

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/generic_startup_hook.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/generic_startup_hook.py
@@ -94,7 +94,7 @@ def full_start(application):
 
 
 def reboot_start(application):
-    application.create_cmdline_json_from_properties()
+    application.write_cmdline_json()
 
     application.start_app()
 


### PR DESCRIPTION
This requires systemvm `19.9.19` or newer.
