### PR TITLE
Remove SSL

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/templates/vhost-metadata.conf
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/templates/vhost-metadata.conf
@@ -1,6 +1,5 @@
 server {
     listen       {{ ipaddress }}:80;
-    listen       {{ ipaddress }}:443 ssl;
     server_name  _;
     root         /var/www/html;
 


### PR DESCRIPTION
SSL is not used and nginx won't start if there are no certificates presents.