### PR TITLE
Assign router to dedicated resource when available

### DIFF
--- a/cosmic-core/cosmic-flyway/src/main/resources/db/migration/V2_35__add_allow_router_deployments.sql
+++ b/cosmic-core/cosmic-flyway/src/main/resources/db/migration/V2_35__add_allow_router_deployments.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `affinity_group` ADD `allow_router_deployments` BIGINT(1)  NOT NULL  DEFAULT "0" AFTER `acl_type`;

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/affinity/AffinityGroupVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/affinity/AffinityGroupVO.java
@@ -34,6 +34,8 @@ public class AffinityGroupVO implements AffinityGroup {
     private long accountId;
     @Column(name = "uuid")
     private String uuid;
+    @Column(name = "allow_router_deployments")
+    private long allowRouterDeployments;
 
     public AffinityGroupVO() {
         uuid = UUID.randomUUID().toString();
@@ -103,5 +105,9 @@ public class AffinityGroupVO implements AffinityGroup {
     @Override
     public Class<?> getEntityType() {
         return AffinityGroup.class;
+    }
+
+    public long getAllowRouterDeployments() {
+        return allowRouterDeployments;
     }
 }

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/affinity/dao/AffinityGroupDao.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/affinity/dao/AffinityGroupDao.java
@@ -20,5 +20,9 @@ public interface AffinityGroupDao extends GenericDao<AffinityGroupVO, Long> {
 
     AffinityGroupVO findByAccountAndType(Long accountId, String string);
 
+    AffinityGroupVO findByAccountAndTypeAndRouterFlag(Long accountId, String string, Long routerFlag);
+
+    AffinityGroupVO findDomainLevelGroupByTypeAndRouterFlag(Long accountId, String string, Long routerFlag);
+
     AffinityGroupVO findDomainLevelGroupByType(Long domainId, String string);
 }

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/affinity/dao/AffinityGroupDaoImpl.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/affinity/dao/AffinityGroupDaoImpl.java
@@ -53,6 +53,7 @@ public class AffinityGroupDaoImpl extends GenericDaoBase<AffinityGroupVO, Long> 
 
         AccountIdTypeSearch = createSearchBuilder();
         AccountIdTypeSearch.and("accountId", AccountIdTypeSearch.entity().getAccountId(), SearchCriteria.Op.EQ);
+        AccountIdTypeSearch.and("allowRouterDeployments", AccountIdTypeSearch.entity().getAllowRouterDeployments(), SearchCriteria.Op.EQ);
         AccountIdTypeSearch.and("type", AccountIdTypeSearch.entity().getType(), SearchCriteria.Op.EQ);
 
         final SearchBuilder<AffinityGroupDomainMapVO> domainTypeSearch = _groupDomainDao.createSearchBuilder();
@@ -60,6 +61,7 @@ public class AffinityGroupDaoImpl extends GenericDaoBase<AffinityGroupVO, Long> 
         DomainLevelTypeSearch = createSearchBuilder();
         DomainLevelTypeSearch.and("type", DomainLevelTypeSearch.entity().getType(), SearchCriteria.Op.EQ);
         DomainLevelTypeSearch.and("aclType", DomainLevelTypeSearch.entity().getAclType(), SearchCriteria.Op.EQ);
+        DomainLevelTypeSearch.and("allowRouterDeployments", DomainLevelTypeSearch.entity().getAllowRouterDeployments(), SearchCriteria.Op.EQ);
         DomainLevelTypeSearch.join("domainTypeSearch", domainTypeSearch, domainTypeSearch.entity().getAffinityGroupId(), DomainLevelTypeSearch.entity().getId(),
                 JoinType.INNER);
         DomainLevelTypeSearch.done();
@@ -127,7 +129,7 @@ public class AffinityGroupDaoImpl extends GenericDaoBase<AffinityGroupVO, Long> 
         final SearchCriteria<AffinityGroupVO> sc = AccountIdTypeSearch.create();
         sc.setParameters("accountId", accountId);
         sc.setParameters("type", type);
-
+        sc.setParameters("allowRouterDeployments", 0L);
         return findOneBy(sc);
     }
 
@@ -136,6 +138,26 @@ public class AffinityGroupDaoImpl extends GenericDaoBase<AffinityGroupVO, Long> 
         final SearchCriteria<AffinityGroupVO> sc = DomainLevelTypeSearch.create();
         sc.setParameters("aclType", ControlledEntity.ACLType.Domain);
         sc.setParameters("type", type);
+        sc.setParameters("allowRouterDeployments", 0L);
+        sc.setJoinParameters("domainTypeSearch", "domainId", domainId);
+        return findOneBy(sc);
+    }
+
+    @Override
+    public AffinityGroupVO findByAccountAndTypeAndRouterFlag(final Long accountId, final String type, final Long routerFlag) {
+        final SearchCriteria<AffinityGroupVO> sc = AccountIdTypeSearch.create();
+        sc.setParameters("accountId", accountId);
+        sc.setParameters("type", type);
+        sc.setParameters("allowRouterDeployments", routerFlag);
+        return findOneBy(sc);
+    }
+
+    @Override
+    public AffinityGroupVO findDomainLevelGroupByTypeAndRouterFlag(final Long domainId, final String type, final Long routerFlag) {
+        final SearchCriteria<AffinityGroupVO> sc = DomainLevelTypeSearch.create();
+        sc.setParameters("aclType", ControlledEntity.ACLType.Domain);
+        sc.setParameters("type", type);
+        sc.setParameters("allowRouterDeployments", routerFlag);
         sc.setJoinParameters("domainTypeSearch", "domainId", domainId);
         return findOneBy(sc);
     }


### PR DESCRIPTION
Enable this feature by setting `allow_router_deployments` in `affinity_group` to `1`.