### PR TITLE
Always check the public ip acl on input

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/firewall.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/firewall.py
@@ -156,7 +156,7 @@ class Firewall:
 
         # create ingress chain filter (load balancing)
         self.fw.append(["filter", "", "-N ACL_PUBLIC_IP_%s" % device])
-        self.fw.append(["filter", "", "-A INPUT -m state --state NEW -i %s -j ACL_PUBLIC_IP_%s" % (device, device)])
+        self.fw.append(["filter", "", "-A INPUT -m state --state NEW -j ACL_PUBLIC_IP_%s" % device])
 
         # create egress chain
         self.fw.append(["mangle", "front", "-N ACL_OUTBOUND_%s" % device])


### PR DESCRIPTION
Currently the PUBLIC IP ACL is only checked if the incoming interface is the public interface, this change removed that check. Thus the PUBLIC IP ACL is always checked and the load balancer is reachable from the internal tiers, if the PUBLIC IP ACL is allowing this traffic.