### PR TITLE
Implicitly enable OptimiseFor Windows when template name contains win

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/CreateTemplateCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/template/CreateTemplateCmd.java
@@ -169,17 +169,15 @@ public class CreateTemplateCmd extends BaseAsyncCreateCmd {
     public OptimiseFor getOptimiseFor() {
         if (optimiseFor != null) {
             return OptimiseFor.valueOf(optimiseFor);
-        } else {
-            return OptimiseFor.Generic;
         }
+        return null;
     }
 
     public MaintenancePolicy getMaintenancePolicy() {
         if (maintenancePolicy != null) {
             return MaintenancePolicy.valueOf(maintenancePolicy);
-        } else {
-            return MaintenancePolicy.LiveMigrate;
         }
+        return null;
     }
 
     public String getCpuFlags() {

--- a/cosmic-core/server/src/main/java/com/cloud/template/TemplateAdapterBase.java
+++ b/cosmic-core/server/src/main/java/com/cloud/template/TemplateAdapterBase.java
@@ -407,11 +407,18 @@ public abstract class TemplateAdapterBase extends AdapterBase implements Templat
             }
         }
 
+        // When template contains Win, it should be set to OptimiseFor Windows
+        OptimiseFor correctedOptimiseFor = optimiseFor;
+        if (name != null && name.toLowerCase().contains("win") && optimiseFor != OptimiseFor.Windows) {
+            s_logger.debug("Template name '" + name + "' contains 'win' so setting OptimiseFor to Windows");
+            correctedOptimiseFor = OptimiseFor.Windows;
+        }
+
         final Long id = _tmpltDao.getNextInSequence(Long.class, "id");
         CallContext.current().setEventDetails("Id: " + id + " name: " + name);
         return new TemplateProfile(id, userId, name, displayText, bits, passwordEnabled, url, isPublic, featured, isExtractable, imgfmt, guestOSId, zoneId,
                 hypervisorType, templateOwner.getAccountName(), templateOwner.getDomainId(), templateOwner.getAccountId(), chksum, bootable, templateTag, details,
-                sshkeyEnabled, null, isDynamicallyScalable, templateType, manufacturerString, optimiseFor, maintenancePolicy, isRemoteGatewayTemplate);
+                sshkeyEnabled, null, isDynamicallyScalable, templateType, manufacturerString, correctedOptimiseFor, maintenancePolicy, isRemoteGatewayTemplate);
     }
 
     protected VMTemplateVO persistTemplate(final TemplateProfile profile, final VirtualMachineTemplate.State initialState) {


### PR DESCRIPTION
Imagine this request:
![image](https://user-images.githubusercontent.com/1630096/70043841-7b510480-15c1-11ea-9fde-7a4b4a60bcb2.png)

Results in OptimisedForWindows, without specifying it
![image](https://user-images.githubusercontent.com/1630096/70043871-8f950180-15c1-11ea-84ca-622ae014b2e6.png)

```
2019-12-03 11:38:04.344 DEBUG [c.c.t.TemplateAdapterBase] (logid: 616cb3e0) (ctx: b128885f) Template name 'Windows maar niet echt' contains 'win' so setting OptimiseFor to Windows
```
