### PR TITLE
Add static route to mgt network for secondary storage device

### DIFF
--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/secondarystorage/NfsSecondaryStorageResource.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/secondarystorage/NfsSecondaryStorageResource.java
@@ -165,6 +165,7 @@ public class NfsSecondaryStorageResource extends AgentResourceBase implements Se
     private String _ssvmPSK = null;
     private String _localNic;
     private String _localMask;
+    private String _setSecStorageRoute;
 
     public int getTimeout() {
         return this._timeout;
@@ -1363,6 +1364,7 @@ public class NfsSecondaryStorageResource extends AgentResourceBase implements Se
             this._localgw = (String) params.get("localgw");
             this._localNic = (String) params.get("mgtnic");
             this._localMask = (String) params.get("mgtmask");
+            this._setSecStorageRoute = (String) params.get("setsecstorageroute");
 
             startAdditionalServices();
             this._params.put("install.numthreads", "50");
@@ -1649,11 +1651,18 @@ public class NfsSecondaryStorageResource extends AgentResourceBase implements Se
             return;
         }
 
-        try {
-            attemptRoute(uri);
-        } catch (final Exception e) {
-            s_logger.debug("Failed to resolve hostname from " + uri);
+        // Check if we need to set a route for the sec storage ip to the mgt network
+        s_logger.debug("Value of _setSecStorageRoute is: " + this._setSecStorageRoute);
+
+        if ("true".equalsIgnoreCase(this._setSecStorageRoute)) {
+            s_logger.debug("Setting route for Secondary Storage ip towards management is enabled");
+            try {
+                attemptRoute(uri);
+            } catch (final Exception e) {
+                s_logger.debug("Failed to resolve hostname from " + uri);
+            }
         }
+
         attemptMount(localRootPath, remoteDevice, uri);
 
         // XXX: Adding the check for creation of snapshots dir here. Might have

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/secondarystorage/NfsSecondaryStorageResource.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/secondarystorage/NfsSecondaryStorageResource.java
@@ -1683,10 +1683,10 @@ public class NfsSecondaryStorageResource extends AgentResourceBase implements Se
             return;
         }
 
-        final Script command = new Script(!this._inSystemVM, "/usr/sbin/route", this._timeout, s_logger);
-        command.add("add");
-        command.add("-host", ipAddress);
-        command.add("gw", this._localgw);
+        final Script command = new Script(!this._inSystemVM, "/usr/sbin/ip", this._timeout, s_logger);
+        command.add("route");
+        command.add("add", ipAddress + "/32");
+        command.add("via", this._localgw);
 
         result = command.execute();
 

--- a/cosmic-agent/src/main/java/com/cloud/agent/service/AgentConfiguration.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/service/AgentConfiguration.java
@@ -65,6 +65,7 @@ public class AgentConfiguration {
     private String sslcopy;
     private String template;
     private String type;
+    private String setsecstorageroute;
 
     public String getGuid() {
         return guid;
@@ -461,6 +462,14 @@ public class AgentConfiguration {
 
     public String getType() {
         return type;
+    }
+
+    public String getSetsecstorageroute() {
+        return setsecstorageroute;
+    }
+
+    public void setSetsecstorageroute(final String setsecstorageroute) {
+        this.setsecstorageroute = setsecstorageroute;
     }
 
     public void setType(final String type) {

--- a/cosmic-agent/src/main/java/com/cloud/agent/service/AgentShell.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/service/AgentShell.java
@@ -108,6 +108,7 @@ public class AgentShell {
         addNotNull(this.allProperties, "type", this.agentConfiguration.getType());
         addNotNull(this.allProperties, "workers", this.agentConfiguration.getWorkers());
         addNotNull(this.allProperties, "zone", this.agentConfiguration.getZone());
+        addNotNull(this.allProperties, "setsecstorageroute", this.agentConfiguration.getSetsecstorageroute());
     }
 
     /**

--- a/cosmic-core/server/src/main/java/com/cloud/storage/secondary/SecondaryStorageManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/storage/secondary/SecondaryStorageManagerImpl.java
@@ -400,6 +400,13 @@ public class SecondaryStorageManagerImpl extends SystemVmManagerBase implements 
             setRfc1918Routes = false;
         }
 
+        // Secondary Storage Route
+        Boolean setSecStorageRoute = false;
+        final String setSecStorageRouteStr = this._configDao.getValue("secstorage.set.route.to.management.network");
+        if (setSecStorageRouteStr != null && setSecStorageRouteStr.equalsIgnoreCase("true")) {
+            setSecStorageRoute = true;
+        }
+
         // External firewall
         this._allowedExternalCidrs = this._configDao.getValue("secstorage.allowed.external.cidrs");
         if (this._allowedExternalCidrs != null) {
@@ -450,6 +457,8 @@ public class SecondaryStorageManagerImpl extends SystemVmManagerBase implements 
 
         /* Set RFC1918 routes to MGT nic */
         buf.append(" setrfc1918routes=").append(setRfc1918Routes.toString().toLowerCase());
+
+        buf.append(" setsecstorageroute=").append(setSecStorageRoute.toString().toLowerCase());
 
         final DataCenterVO dc = this._dcDao.findById(profile.getVirtualMachine().getDataCenterId());
         buf.append(" internaldns1=").append(dc.getInternalDns1());


### PR DESCRIPTION
Add route to secondary storage (in system vm) to the management nic so that it will not go to public network.

Routes are only created when the secondary storage and mgt nic are not in the same network.

```
2020-02-24 14:05:07.716 DEBUG (logid: df48266f) 1594 --- [agentRequest-Handler-1] c.c.a.r.s.NfsSecondaryStorageResource    : Got hostname 192.168.22.1
2020-02-24 14:05:07.717 DEBUG (logid: df48266f) 1594 --- [agentRequest-Handler-1] c.c.a.r.s.NfsSecondaryStorageResource    : Attempting to route 192.168.22.1 to 192.168.22.1
2020-02-24 14:05:07.717 ERROR (logid: df48266f) 1594 --- [agentRequest-Handler-1] c.c.a.r.s.NfsSecondaryStorageResource    : No need to route 192.168.22.1 to 192.168.22.1

2020-02-24 14:05:08.897 DEBUG (logid: df48266f) 1594 --- [agentRequest-Handler-2] c.c.a.r.s.NfsSecondaryStorageResource    : Got hostname 192.168.31.35
2020-02-24 14:05:08.897 DEBUG (logid: df48266f) 1594 --- [agentRequest-Handler-2] c.c.a.r.s.NfsSecondaryStorageResource    : Attempting to route 192.168.31.35 to 192.168.22.1
2020-02-24 14:05:08.898 DEBUG (logid: df48266f) 1594 --- [agentRequest-Handler-2] c.c.a.r.s.NfsSecondaryStorageResource    : Executing: /usr/sbin/route add -host 192.168.31.35 gw 192.168.22.1
```

```
[root@s-9-vm ~]# ip r
default via 100.64.0.1 dev eth0
10.0.0.0/8 via 192.168.22.1 dev eth2
100.64.0.0/24 dev eth0 proto kernel scope link src 100.64.0.2
169.254.0.0/16 dev eth1 proto kernel scope link src 169.254.3.193
172.16.0.0/12 via 192.168.22.1 dev eth2
192.168.0.0/16 via 192.168.22.1 dev eth2
192.168.22.0/24 dev eth2 proto kernel scope link src 192.168.22.139
192.168.31.35 via 192.168.22.1 dev eth2
```

Control with `secstorage.set.route.to.management.network` setting, defaults to False.