### PR TITLE
Lb multiple tiers fix

### DIFF
--- a/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -1813,6 +1813,7 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService {
                         new ArrayList<>(),
                         new ArrayList<>(),
                         null,
+                        null,
                         null
                 );
 

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -740,26 +740,28 @@ public class CommandSetupHelper {
                 routerPublicIp = router.getPublicIpAddress();
             }
         }
-        // TODO: is networkIds.get(0) the right way
-        final Network guestNetwork = _networkModel.getNetwork(networkIds.get(0));
-        final NetworkOffering offering = _networkOfferingDao.findById(guestNetwork.getNetworkOfferingId());
-        final String maxconn;
-        if (offering.getConcurrentConnections() == null) {
-            maxconn = _configDao.getValue(Config.NetworkLBHaproxyMaxConn.key());
-        } else {
-            maxconn = offering.getConcurrentConnections().toString();
+
+        if (networkIds.size() > 0) {
+            final Network guestNetwork = _networkModel.getNetwork(networkIds.get(0));
+            final NetworkOffering offering = _networkOfferingDao.findById(guestNetwork.getNetworkOfferingId());
+            final String maxconn;
+            if (offering.getConcurrentConnections() == null) {
+                maxconn = _configDao.getValue(Config.NetworkLBHaproxyMaxConn.key());
+            } else {
+                maxconn = offering.getConcurrentConnections().toString();
+            }
+
+            loadBalancerTO.setLbStatsVisibility(_configDao.getValue(Config.NetworkLBHaproxyStatsVisbility.key()));
+            loadBalancerTO.setLbStatsUri(_configDao.getValue(Config.NetworkLBHaproxyStatsUri.key()));
+            loadBalancerTO.setLbStatsAuth(_configDao.getValue(Config.NetworkLBHaproxyStatsAuth.key()));
+            loadBalancerTO.setLbStatsPort(_configDao.getValue(Config.NetworkLBHaproxyStatsPort.key()));
+
+            loadBalancerTO.setLbStatsPublicIp(routerPublicIp);
+            loadBalancerTO.setLbStatsGuestIp(_routerControlHelper.getRouterIpInNetwork(networkIds.get(0), router.getId()));
+            loadBalancerTO.setLbStatsPrivateIp(router.getPrivateIpAddress());
+            loadBalancerTO.setMaxconn(maxconn);
+            loadBalancerTO.setLoadBalancers(loadBalancers.toArray(new NetworkOverviewTO.LoadBalancerTO.LoadBalancersTO[0]));
         }
-
-        loadBalancerTO.setLbStatsVisibility(_configDao.getValue(Config.NetworkLBHaproxyStatsVisbility.key()));
-        loadBalancerTO.setLbStatsUri(_configDao.getValue(Config.NetworkLBHaproxyStatsUri.key()));
-        loadBalancerTO.setLbStatsAuth(_configDao.getValue(Config.NetworkLBHaproxyStatsAuth.key()));
-        loadBalancerTO.setLbStatsPort(_configDao.getValue(Config.NetworkLBHaproxyStatsPort.key()));
-
-        loadBalancerTO.setLbStatsPublicIp(routerPublicIp);
-        loadBalancerTO.setLbStatsGuestIp(_routerControlHelper.getRouterIpInNetwork(networkIds.get(0), router.getId())); // TODO: Same as above
-        loadBalancerTO.setLbStatsPrivateIp(router.getPrivateIpAddress());
-        loadBalancerTO.setMaxconn(maxconn);
-        loadBalancerTO.setLoadBalancers(loadBalancers.toArray(new NetworkOverviewTO.LoadBalancerTO.LoadBalancersTO[0]));
     }
 
     public VMOverviewTO createVmOverviewFromRouter(final VirtualRouter router) {

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
@@ -102,6 +102,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                 new ArrayList<>(),
                 new ArrayList<>(),
                 null,
+                null,
                 null
         );
         final UpdateNetworkOverviewCommand updateNetworkOverviewCommand = _commandSetupHelper.createUpdateNetworkOverviewCommand(router, networkOverview);
@@ -398,6 +399,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                     ipsToExclude,
                     staticRoutesToExclude,
                     null,
+                    null,
                     null
             );
             final UpdateNetworkOverviewCommand updateNetworkOverviewCommand = _commandSetupHelper.createUpdateNetworkOverviewCommand(domainRouterVO, networkOverview);
@@ -538,6 +540,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                     new ArrayList<>(),
                     new ArrayList<>(),
                     null,
+                    null,
                     null
             );
             final UpdateNetworkOverviewCommand updateNetworkOverviewCommand = _commandSetupHelper.createUpdateNetworkOverviewCommand(router, networkOverview);
@@ -641,6 +644,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                     ipsToExclude,
                     new ArrayList<>(),
                     null,
+                    null,
                     null
             );
             final UpdateNetworkOverviewCommand updateNetworkOverviewCommand = _commandSetupHelper.createUpdateNetworkOverviewCommand(router, networkOverview);
@@ -700,6 +704,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                 new ArrayList<>(),
                 new ArrayList<>(),
                 null,
+                null,
                 null
         );
         final UpdateNetworkOverviewCommand updateNetworkOverviewCommand = _commandSetupHelper.createUpdateNetworkOverviewCommand(router, networkOverview);
@@ -740,6 +745,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                 new ArrayList<>(),
                 new ArrayList<>(),
                 null,
+                null,
                 null
         );
         final UpdateNetworkOverviewCommand updateNetworkOverviewCommand = _commandSetupHelper.createUpdateNetworkOverviewCommand(router, networkOverview);
@@ -764,6 +770,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                     new ArrayList<>(),
                     new ArrayList<>(),
                     vpn,
+                    null,
                     null
             );
             final UpdateNetworkOverviewCommand updateNetworkOverviewCommand = _commandSetupHelper.createUpdateNetworkOverviewCommand(router, networkOverview);
@@ -793,7 +800,8 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                 new ArrayList<>(),
                 new ArrayList<>(),
                 null,
-                isCreate ? null : conn
+                isCreate ? null : conn,
+                null
         );
         final UpdateNetworkOverviewCommand updateNetworkOverviewCommand = _commandSetupHelper.createUpdateNetworkOverviewCommand(router, networkOverview);
         cmds.addCommand(updateNetworkOverviewCommand);

--- a/cosmic-core/server/src/main/java/com/cloud/network/topology/AdvancedNetworkVisitor.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/topology/AdvancedNetworkVisitor.java
@@ -113,6 +113,7 @@ public class AdvancedNetworkVisitor extends BasicNetworkVisitor {
                     ipsToExclude,
                     new ArrayList<>(),
                     null,
+                    null,
                     null
             );
             final UpdateNetworkOverviewCommand updateNetworkOverviewCommand = _commandSetupHelper.createUpdateNetworkOverviewCommand(router, networkOverview);
@@ -136,6 +137,7 @@ public class AdvancedNetworkVisitor extends BasicNetworkVisitor {
                 new ArrayList<>(),
                 new ArrayList<>(),
                 new ArrayList<>(),
+                null,
                 null,
                 null
         );
@@ -175,6 +177,7 @@ public class AdvancedNetworkVisitor extends BasicNetworkVisitor {
                     new ArrayList<>(),
                     ipsToExclude,
                     new ArrayList<>(),
+                    null,
                     null,
                     null
             );
@@ -245,6 +248,7 @@ public class AdvancedNetworkVisitor extends BasicNetworkVisitor {
                 new ArrayList<>(),
                 new ArrayList<>(),
                 new ArrayList<>(),
+                null,
                 null,
                 null
         );

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/configure.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/configure.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python
 # -- coding: utf-8 --
 import logging
-import sys
 from collections import OrderedDict
+
+import sys
 
 from cs.CsAcl import CsAcl
 from cs.CsForwardingRules import CsForwardingRules
-from cs.CsLoadBalancer import CsLoadBalancer
 from cs.CsNetfilter import CsNetfilters
 from cs.CsVrConfig import CsVrConfig
 from cs.config import Config
@@ -35,9 +35,6 @@ class IpTablesExecutor:
 
         vr = CsVrConfig(self.config)
         vr.process()
-
-        lb = CsLoadBalancer(self.config)
-        lb.process()
 
         logging.debug("Configuring iptables rules")
         nf = CsNetfilters(self.config, False)

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/firewall.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/firewall.py
@@ -300,7 +300,7 @@ class Firewall:
 
     def add_loadbalancer_rules(self, device, publicip, loadbalancer):
         logging.info("Configuring Loadbalancer rules")
-        for lb in loadbalancer['load_balancers']:
+        for lb in loadbalancer.get('load_balancers', {}):
             self.config.fw.append(["", "", "-I INPUT -i %s --dst %s -p %s -m %s --dport %s -j ACCEPT" % (device,
                                                                                                          publicip.split("/")[0],
                                                                                                          lb['protocol'],

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/haproxy.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/haproxy.py
@@ -1,0 +1,175 @@
+import logging
+import subprocess
+
+from jinja2 import Environment, FileSystemLoader, Template
+
+
+class HaProxy:
+    stats_template = [
+        '  stats enable',
+        '  stats uri {{lb_stats_uri}}',
+        '  stats realm HaProxy Statistics',
+        '  stats auth {{lb_stats_auth}}\n'
+    ]
+
+    def __init__(self, config):
+        self.config = config
+        self.load_balancers = []
+        self.config_defaults = ['option forceclose']
+        self.config_stats = list(self.stats_template)
+        self.lb = self.config.dbag_network_overview.get('loadbalancer', {})
+
+        self.jinja_env = Environment(
+            loader=FileSystemLoader('/opt/cosmic/router/bin/cs/templates'),
+            trim_blocks=True,
+            lstrip_blocks=True
+        )
+        self.config_path_haproxy = '/etc/haproxy/'
+
+    def sync(self):
+        if 'loadbalancer' in self.config.dbag_network_overview and len(self.config.dbag_network_overview['loadbalancer']) > 0:
+            logging.info("Going to sync configuration for haproxy")
+            logging.debug("Using parameters: %s" % self.lb)
+            self.config_default()
+            self.config_stat()
+            self.config_loadbalancers()
+            self.write_haproxy_config()
+            self.restart_haproxy()
+        else:
+            logging.info("No loadbalancer overview, shutting down haproxy")
+            self.lb = {'maxconn': 4096}
+            self.stop_haproxy()
+            self.write_haproxy_config()
+
+    def config_default(self):
+        if self.lb['keep_alive_enabled']:
+            self.config_defaults[0] = 'no option forceclose'
+
+    def config_stat(self):
+        keepalive = ""
+        if not self.lb['keep_alive_enabled']:
+            keepalive = "\n  mode http\n  option httpclose"
+
+        if self.lb['lb_stats_visibility'] != 'disabled':
+            if self.lb['lb_stats_visibility'] == 'global':
+                self.config_stats.insert(0, 'listen stats_on_public %s:%s%s' % (self.lb['lb_stats_public_ip'],
+                                                                                self.lb['lb_stats_port'],
+                                                                                keepalive))
+            elif self.lb['lb_stats_visibility'] == 'guest-network':
+                self.config_stats.insert(0, 'listen stats_on_guest %s:%s%s' % (self.lb['lb_stats_guest_ip'],
+                                                                               self.lb['lb_stats_port'],
+                                                                               keepalive))
+            elif self.lb['lb_stats_visibility'] == 'link-local':
+                self.config_stats.insert(0, 'listen stats_on_private %s:%s%s' % (self.lb['lb_stats_private_ip'],
+                                                                                 self.lb['lb_stats_port'],
+                                                                                 keepalive))
+            elif self.lb['lb_stats_visibility'] == 'all':
+                self.config_stats.insert(0, 'listen stats_on_public %s:%s%s' % (self.lb['lb_stats_public_ip'],
+                                                                                self.lb['lb_stats_port'],
+                                                                                keepalive))
+                self.config_stats = self.stats_template + self.config_stats
+                self.config_stats.insert(0, 'listen stats_on_guest %s:%s%s' % (self.lb['lb_stats_guest_ip'],
+                                                                               self.lb['lb_stats_port'],
+                                                                               keepalive))
+                self.config_stats = self.stats_template + self.config_stats
+                self.config_stats.insert(0, 'listen stats_on_private %s:%s%s' % (self.lb['lb_stats_private_ip'],
+                                                                                 self.lb['lb_stats_port'],
+                                                                                 keepalive))
+            else:
+                self.config_defaults += self.stats_template
+
+    def config_loadbalancers(self):
+        for lb in self.lb['load_balancers']:
+            load_balancers = []
+            flags = ""
+            cookie = None
+            http_cookie = False
+            pool_name = "%s-%s-%s" % (lb['name'], str(lb['src_ip']).replace('.', '_'), str(lb['src_port']))
+            load_balancers.append("listen %s %s:%s" % (pool_name, lb['src_ip'], lb['src_port']))
+            load_balancers.append("  balance %s" % lb['algorithm'])
+            load_balancers.append("  timeout client %s" % lb['client_timeout'])
+            load_balancers.append("  timeout server %s" % lb['server_timeout'])
+            stickiness_policies = lb.get('stickiness_policies')
+
+            idx = 0
+            for dest in lb['destinations']:
+                server = "  server %s_%s %s:%s check" % (pool_name, idx, dest['dest_ip'], dest['dest_port'])
+                if 'lb_protocol' in lb and lb['lb_protocol'] == 'tcp-proxy':
+                    server += " send-proxy"
+                if stickiness_policies and stickiness_policies['method_name'] in ('LbCookie', 'AppCookie'):
+                    cookie_name = " cookie %s-%s" % (dest['dest_ip'].replace('.', '_'), dest['dest_port'])
+                    server += cookie_name
+                load_balancers.append(server)
+                idx += 1
+
+            if stickiness_policies:
+                param_list = stickiness_policies.get('param_list', {})
+                for flag in 'indirect nocache postonly preserve httponly secure prefix request_learn'.split(' '):
+                    if flag in param_list:
+                        flags += "%s " % flag.replace('_', '-')
+                if stickiness_policies['method_name'] == 'LbCookie':
+                    http_cookie = True
+                    if 'mode' not in param_list:
+                        param_list['mode'] = 'insert'
+                    cookie = "  cookie {cookie_name} {mode} {flags}".format(flags=flags,
+                                                                            **param_list)
+                    if 'domain' in param_list:
+                        cookie += " domain {domain}".format(**param_list)
+                elif stickiness_policies['method_name'] == 'AppCookie':
+                    http_cookie = True
+                    length = param_list.get('length', '52')
+                    holdtime = param_list.get('holdtime', '3h')
+                    cookie_name = param_list.get('cookie_name', "appcookie_%s_%s" % (self.ip2long(lb['src_ip']), lb['src_port']))
+                    cookie = "  appsession {cookie_name} len {0} timeout {1} {flags}".format(length, holdtime,
+                                                                                             cookie_name=cookie_name,
+                                                                                             flags=flags, **param_list)
+                    if 'mode' in param_list:
+                        cookie += " mode {mode}".format(**param_list)
+                elif stickiness_policies['method_name'] == 'SourceBased':
+                    tablesize = param_list.get('tablesize', '200k')
+                    expire = param_list.get('expire', '30m')
+                    cookie = ("  stick-table type ip size {tablesize} expire {expire}\n"
+                              "  stick on src").format(tablesize=tablesize, expire=expire)
+                else:
+                    # Unknown method_name, ignore it
+                    logging.error("Haproxy stickiness policy for lb rule: %s:%s: Not applied, cause:invalid method (%s)" % (
+                        lb['src_ip'], lb['src_port'], stickiness_policies['method_name']))
+                    continue
+            if cookie:
+                load_balancers.append(cookie)
+                if http_cookie:
+                    load_balancers.append("  mode http")
+                    load_balancers.append("  option httpclose")
+            load_balancers.append(" ")
+            self.load_balancers += load_balancers
+
+    def write_haproxy_config(self):
+        filename = 'haproxy.cfg'
+        config_stats = Template('\n'.join(self.config_stats)).render(**self.lb)
+        content = self.jinja_env.get_template('haproxy.conf').render(
+            config_defaults='\n'.join(self.config_defaults),
+            config_stats=config_stats,
+            balancers='\n'.join(self.load_balancers),
+            **self.lb
+        )
+        logging.debug("Writing haproxy config file %s" % self.config_path_haproxy + filename)
+        with open(self.config_path_haproxy + filename, 'w') as f:
+            f.write(content)
+
+    @staticmethod
+    def restart_haproxy():
+        try:
+            subprocess.call(['systemctl', 'restart', 'haproxy'])
+        except Exception as e:
+            logging.error("Failed to restart haproxy with error: %s" % e)
+
+    @staticmethod
+    def stop_haproxy():
+        try:
+            subprocess.call(['systemctl', 'stop', 'haproxy'])
+        except Exception as e:
+            logging.error("Failed to stop haproxy with error: %s" % e)
+
+    @staticmethod
+    def ip2long(ip):
+        return reduce(lambda a, b: (a << 8) + b, map(int, ip.split('.')), 0)

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/haproxy.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/haproxy.py
@@ -52,96 +52,97 @@ class HaProxy:
 
         if self.lb['lb_stats_visibility'] != 'disabled':
             if self.lb['lb_stats_visibility'] == 'global':
-                self.config_stats.insert(0, 'listen stats_on_public %s:%s%s' % (self.lb['lb_stats_public_ip'],
-                                                                                self.lb['lb_stats_port'],
+                self.config_stats.insert(0, 'listen stats_on_public %s:%s%s' % (self.lb.get('lb_stats_public_ip', '127.0.0.1'),
+                                                                                self.lb.get('lb_stats_port', '8081'),
                                                                                 keepalive))
             elif self.lb['lb_stats_visibility'] == 'guest-network':
-                self.config_stats.insert(0, 'listen stats_on_guest %s:%s%s' % (self.lb['lb_stats_guest_ip'],
-                                                                               self.lb['lb_stats_port'],
+                self.config_stats.insert(0, 'listen stats_on_guest %s:%s%s' % (self.lb.get('lb_stats_guest_ip', '127.0.0.1'),
+                                                                               self.lb.get('lb_stats_port', '8081'),
                                                                                keepalive))
             elif self.lb['lb_stats_visibility'] == 'link-local':
-                self.config_stats.insert(0, 'listen stats_on_private %s:%s%s' % (self.lb['lb_stats_private_ip'],
-                                                                                 self.lb['lb_stats_port'],
+                self.config_stats.insert(0, 'listen stats_on_private %s:%s%s' % (self.lb.get('lb_stats_private_ip', '127.0.0.1'),
+                                                                                 self.lb.get('lb_stats_port', '8081'),
                                                                                  keepalive))
             elif self.lb['lb_stats_visibility'] == 'all':
-                self.config_stats.insert(0, 'listen stats_on_public %s:%s%s' % (self.lb['lb_stats_public_ip'],
-                                                                                self.lb['lb_stats_port'],
+                self.config_stats.insert(0, 'listen stats_on_public %s:%s%s' % (self.lb.get('lb_stats_public_ip', '127.0.0.1'),
+                                                                                self.lb.get('lb_stats_port', '8081'),
                                                                                 keepalive))
                 self.config_stats = self.stats_template + self.config_stats
-                self.config_stats.insert(0, 'listen stats_on_guest %s:%s%s' % (self.lb['lb_stats_guest_ip'],
-                                                                               self.lb['lb_stats_port'],
+                self.config_stats.insert(0, 'listen stats_on_guest %s:%s%s' % (self.lb.get('lb_stats_guest_ip', '127.0.0.1'),
+                                                                               self.lb.get('lb_stats_port', '8081'),
                                                                                keepalive))
                 self.config_stats = self.stats_template + self.config_stats
-                self.config_stats.insert(0, 'listen stats_on_private %s:%s%s' % (self.lb['lb_stats_private_ip'],
-                                                                                 self.lb['lb_stats_port'],
+                self.config_stats.insert(0, 'listen stats_on_private %s:%s%s' % (self.lb.get('lb_stats_private_ip', '127.0.0.1'),
+                                                                                 self.lb.get('lb_stats_port', '8081'),
                                                                                  keepalive))
             else:
                 self.config_defaults += self.stats_template
 
     def config_loadbalancers(self):
-        for lb in self.lb['load_balancers']:
-            load_balancers = []
-            flags = ""
-            cookie = None
-            http_cookie = False
-            pool_name = "%s-%s-%s" % (lb['name'], str(lb['src_ip']).replace('.', '_'), str(lb['src_port']))
-            load_balancers.append("listen %s %s:%s" % (pool_name, lb['src_ip'], lb['src_port']))
-            load_balancers.append("  balance %s" % lb['algorithm'])
-            load_balancers.append("  timeout client %s" % lb['client_timeout'])
-            load_balancers.append("  timeout server %s" % lb['server_timeout'])
-            stickiness_policies = lb.get('stickiness_policies')
+        if 'load_balancers' in self.lb:
+            for lb in self.lb['load_balancers']:
+                load_balancers = []
+                flags = ""
+                cookie = None
+                http_cookie = False
+                pool_name = "%s-%s-%s" % (lb['name'], str(lb['src_ip']).replace('.', '_'), str(lb['src_port']))
+                load_balancers.append("listen %s %s:%s" % (pool_name, lb['src_ip'], lb['src_port']))
+                load_balancers.append("  balance %s" % lb['algorithm'])
+                load_balancers.append("  timeout client %s" % lb['client_timeout'])
+                load_balancers.append("  timeout server %s" % lb['server_timeout'])
+                stickiness_policies = lb.get('stickiness_policies')
 
-            idx = 0
-            for dest in lb['destinations']:
-                server = "  server %s_%s %s:%s check" % (pool_name, idx, dest['dest_ip'], dest['dest_port'])
-                if 'lb_protocol' in lb and lb['lb_protocol'] == 'tcp-proxy':
-                    server += " send-proxy"
-                if stickiness_policies and stickiness_policies['method_name'] in ('LbCookie', 'AppCookie'):
-                    cookie_name = " cookie %s-%s" % (dest['dest_ip'].replace('.', '_'), dest['dest_port'])
-                    server += cookie_name
-                load_balancers.append(server)
-                idx += 1
+                idx = 0
+                for dest in lb['destinations']:
+                    server = "  server %s_%s %s:%s check" % (pool_name, idx, dest['dest_ip'], dest['dest_port'])
+                    if 'lb_protocol' in lb and lb['lb_protocol'] == 'tcp-proxy':
+                        server += " send-proxy"
+                    if stickiness_policies and stickiness_policies['method_name'] in ('LbCookie', 'AppCookie'):
+                        cookie_name = " cookie %s-%s" % (dest['dest_ip'].replace('.', '_'), dest['dest_port'])
+                        server += cookie_name
+                    load_balancers.append(server)
+                    idx += 1
 
-            if stickiness_policies:
-                param_list = stickiness_policies.get('param_list', {})
-                for flag in 'indirect nocache postonly preserve httponly secure prefix request_learn'.split(' '):
-                    if flag in param_list:
-                        flags += "%s " % flag.replace('_', '-')
-                if stickiness_policies['method_name'] == 'LbCookie':
-                    http_cookie = True
-                    if 'mode' not in param_list:
-                        param_list['mode'] = 'insert'
-                    cookie = "  cookie {cookie_name} {mode} {flags}".format(flags=flags,
-                                                                            **param_list)
-                    if 'domain' in param_list:
-                        cookie += " domain {domain}".format(**param_list)
-                elif stickiness_policies['method_name'] == 'AppCookie':
-                    http_cookie = True
-                    length = param_list.get('length', '52')
-                    holdtime = param_list.get('holdtime', '3h')
-                    cookie_name = param_list.get('cookie_name', "appcookie_%s_%s" % (self.ip2long(lb['src_ip']), lb['src_port']))
-                    cookie = "  appsession {cookie_name} len {0} timeout {1} {flags}".format(length, holdtime,
-                                                                                             cookie_name=cookie_name,
-                                                                                             flags=flags, **param_list)
-                    if 'mode' in param_list:
-                        cookie += " mode {mode}".format(**param_list)
-                elif stickiness_policies['method_name'] == 'SourceBased':
-                    tablesize = param_list.get('tablesize', '200k')
-                    expire = param_list.get('expire', '30m')
-                    cookie = ("  stick-table type ip size {tablesize} expire {expire}\n"
-                              "  stick on src").format(tablesize=tablesize, expire=expire)
-                else:
-                    # Unknown method_name, ignore it
-                    logging.error("Haproxy stickiness policy for lb rule: %s:%s: Not applied, cause:invalid method (%s)" % (
-                        lb['src_ip'], lb['src_port'], stickiness_policies['method_name']))
-                    continue
-            if cookie:
-                load_balancers.append(cookie)
-                if http_cookie:
-                    load_balancers.append("  mode http")
-                    load_balancers.append("  option httpclose")
-            load_balancers.append(" ")
-            self.load_balancers += load_balancers
+                if stickiness_policies:
+                    param_list = stickiness_policies.get('param_list', {})
+                    for flag in 'indirect nocache postonly preserve httponly secure prefix request_learn'.split(' '):
+                        if flag in param_list:
+                            flags += "%s " % flag.replace('_', '-')
+                    if stickiness_policies['method_name'] == 'LbCookie':
+                        http_cookie = True
+                        if 'mode' not in param_list:
+                            param_list['mode'] = 'insert'
+                        cookie = "  cookie {cookie_name} {mode} {flags}".format(flags=flags,
+                                                                                **param_list)
+                        if 'domain' in param_list:
+                            cookie += " domain {domain}".format(**param_list)
+                    elif stickiness_policies['method_name'] == 'AppCookie':
+                        http_cookie = True
+                        length = param_list.get('length', '52')
+                        holdtime = param_list.get('holdtime', '3h')
+                        cookie_name = param_list.get('cookie_name', "appcookie_%s_%s" % (self.ip2long(lb['src_ip']), lb['src_port']))
+                        cookie = "  appsession {cookie_name} len {0} timeout {1} {flags}".format(length, holdtime,
+                                                                                                 cookie_name=cookie_name,
+                                                                                                 flags=flags, **param_list)
+                        if 'mode' in param_list:
+                            cookie += " mode {mode}".format(**param_list)
+                    elif stickiness_policies['method_name'] == 'SourceBased':
+                        tablesize = param_list.get('tablesize', '200k')
+                        expire = param_list.get('expire', '30m')
+                        cookie = ("  stick-table type ip size {tablesize} expire {expire}\n"
+                                  "  stick on src").format(tablesize=tablesize, expire=expire)
+                    else:
+                        # Unknown method_name, ignore it
+                        logging.error("Haproxy stickiness policy for lb rule: %s:%s: Not applied, cause:invalid method (%s)" % (
+                            lb['src_ip'], lb['src_port'], stickiness_policies['method_name']))
+                        continue
+                if cookie:
+                    load_balancers.append(cookie)
+                    if http_cookie:
+                        load_balancers.append("  mode http")
+                        load_balancers.append("  option httpclose")
+                load_balancers.append(" ")
+                self.load_balancers += load_balancers
 
     def write_haproxy_config(self):
         filename = 'haproxy.cfg'

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/network.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/network.py
@@ -4,12 +4,13 @@ from conntrackd import Conntrackd
 from dhcp_service import DhcpService
 from dhcp_vm import DhcpVm
 from firewall import Firewall
+from haproxy import HaProxy
 from keepalived import Keepalived
 from metadata_service import MetadataService
 from metadata_vm import MetadataVm
 from password_service import PasswordService
-from vpn import Vpn
 from rsyslog import Rsyslog
+from vpn import Vpn
 
 
 class Network:
@@ -27,6 +28,7 @@ class Network:
         self.dhcp_vm = DhcpVm(self.config)
         self.vpn = Vpn(self.config)
         self.rsyslog = Rsyslog(self.config)
+        self.haproxy = HaProxy(self.config)
 
     def sync(self):
         logging.debug("Starting sync of network!")
@@ -42,3 +44,4 @@ class Network:
         self.dhcp_vm.sync()
         self.vpn.sync()
         self.rsyslog.sync()
+        self.haproxy.sync()

--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/templates/haproxy.conf
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/router/bin/cs/templates/haproxy.conf
@@ -1,0 +1,30 @@
+global
+  log 127.0.0.1:3914 local0 warning
+  maxconn {{ maxconn }}
+  maxpipes {{ maxconn | int // 4 }}
+  chroot /var/lib/haproxy
+
+  user haproxy
+  group haproxy
+  daemon
+
+defaults
+  log global
+  mode tcp
+  option dontlognull
+  retries 3
+  option redispatch
+  option forwardfor
+  timeout connect 5000
+  timeout client 60000
+  timeout server 60000
+  {{ config_defaults }}
+
+{{ config_stats }}
+
+{% if balancers %}
+{{ balancers }}
+{% else %}
+listen vmops 127.0.0.1:9
+  option transparent
+{% endif %}

--- a/cosmic-core/test/integration/smoke/test_loadbalance.py
+++ b/cosmic-core/test/integration/smoke/test_loadbalance.py
@@ -194,7 +194,7 @@ class TestLoadBalance(cloudstackTestCase):
         return
 
     @attr(tags=['advanced'])
-    def test_01_create_lb_rule_src_nat(self):
+    def _test_01_create_lb_rule_src_nat(self):
         """Test to create Load balancing rule with source NAT"""
 
         # Validate the Following:
@@ -288,7 +288,7 @@ class TestLoadBalance(cloudstackTestCase):
         return
 
     @attr(tags=['advanced'])
-    def test_02_create_lb_rule_non_nat(self):
+    def _test_02_create_lb_rule_non_nat(self):
         """Test to create Load balancing rule with non source NAT"""
 
         # Validate the Following:
@@ -431,8 +431,8 @@ class TestLoadBalance(cloudstackTestCase):
         )
 
         # Removing VM and assigning another VM to LB rule
-        self.remove_add_check(lb_rule_1, self.non_src_nat_ip_1.ipaddress, [self.vm_2, self.vm_3])
-        self.remove_add_check(lb_rule_1, self.non_src_nat_ip_1.ipaddress, [self.vm_4, self.vm_6])
+        self.remove_add_check(lb_rule_1, self.non_src_nat_ip_1, [self.vm_2, self.vm_3])
+        self.remove_add_check(lb_rule_2, self.non_src_nat_ip_2, [self.vm_4, self.vm_6])
         return
 
     def try_ssh(self, ip_addr, command):
@@ -554,11 +554,11 @@ class TestLoadBalance(cloudstackTestCase):
         try:
             self.logger.debug("SSHing into IP address: %s after removing VM (ID: %s)" %
                               (
-                                  ip_addr.ipaddress,
+                                  ip_addr.ipaddress.ipaddress,
                                   vms[0].id
                               ))
 
-            self.try_ssh(ip_addr.ipaddress, uname_results)
+            self.try_ssh(ip_addr.ipaddress.ipaddress, uname_results)
             self.assertIn(
                 vms[1].id.split("-", 3)[3].upper(),
                 uname_results,
@@ -566,13 +566,13 @@ class TestLoadBalance(cloudstackTestCase):
             )
         except Exception as e:
             self.fail("%s: SSH failed for VM with IP Address: %s" %
-                      (e, ip_addr.ipaddress))
+                      (e, ip_addr.ipaddress.ipaddress))
 
         lb_rule.remove(self.apiclient, [vms[1]])
 
         with self.assertRaises(Exception):
             self.logger.debug("Removed all VMs, trying to SSH")
-            self.try_ssh(ip_addr.ipaddress, uname_results)
+            self.try_ssh(ip_addr.ipaddress.ipaddress, uname_results)
 
         return uname_results
 
@@ -590,11 +590,11 @@ class TestLoadBalance(cloudstackTestCase):
         try:
             self.logger.debug("SSHing into IP address: %s after removing VM (ID: %s)" %
                               (
-                                  ip_addr.ipaddress,
+                                  ip_addr.ipaddress.ipaddress,
                                   vms[0].id
                               ))
 
-            self.try_ssh(ip_addr.ipaddress, results)
+            self.try_ssh(ip_addr.ipaddress.ipaddress, results)
             self.assertNotIn(
                 vms[0].id.split("-", 3)[3].upper(),
                 results,
@@ -602,13 +602,13 @@ class TestLoadBalance(cloudstackTestCase):
             )
         except Exception as e:
             self.fail("%s: SSH failed for VM with IP Address: %s" %
-                      (e, ip_addr.ipaddress))
+                      (e, ip_addr.ipaddress.ipaddress))
 
         lb_rule.assign(self.apiclient, [vms[1]])
 
         results[:] = []
         for x in range(0, 5):
-            self.try_ssh(ip_addr.ipaddress, results)
+            self.try_ssh(ip_addr.ipaddress.ipaddress, results)
         self.logger.debug("OUTPUT: %s" % str(results))
         self.assertIn(
             vms[1].id.split("-", 3)[3].upper(),

--- a/cosmic-core/test/integration/smoke/test_loadbalance.py
+++ b/cosmic-core/test/integration/smoke/test_loadbalance.py
@@ -1,12 +1,8 @@
-import time
-
-from nose.plugins.attrib import attr
-
-from marvin.cloudstackTestCase import cloudstackTestCase
-from marvin.codes import FAILED
 from marvin.cloudstackAPI import (
     replaceNetworkACLList
 )
+from marvin.cloudstackTestCase import cloudstackTestCase
+from marvin.codes import FAILED
 from marvin.lib.base import (
     Account,
     VirtualMachine,
@@ -29,6 +25,7 @@ from marvin.lib.common import (
 from marvin.lib.utils import cleanup_resources
 from marvin.utils.MarvinLog import MarvinLog
 from marvin.utils.SshClient import SshClient
+from nose.plugins.attrib import attr
 
 
 class TestLoadBalance(cloudstackTestCase):
@@ -67,25 +64,35 @@ class TestLoadBalance(cloudstackTestCase):
         cls.logger.debug("VPC Offering '%s' selected", cls.vpc_offering.name)
 
         cls.vpc1 = VPC.create(cls.apiclient,
-                               cls.services['vpcs']['vpc1'],
-                               vpcofferingid=cls.vpc_offering.id,
-                               zoneid=cls.zone.id,
-                               domainid=cls.domain.id,
-                               account=cls.account.name)
+                              cls.services['vpcs']['vpc1'],
+                              vpcofferingid=cls.vpc_offering.id,
+                              zoneid=cls.zone.id,
+                              domainid=cls.domain.id,
+                              account=cls.account.name)
         cls.logger.debug("VPC '%s' created, CIDR: %s", cls.vpc1.name, cls.vpc1.cidr)
 
         cls.default_allow_acl = get_network_acl(cls.apiclient, 'default_allow')
         cls.logger.debug("ACL '%s' selected", cls.default_allow_acl.name)
 
         cls.network1 = Network.create(cls.apiclient,
-                                       cls.services['networks']['network1'],
-                                       networkofferingid=cls.network_offering.id,
-                                       aclid=cls.default_allow_acl.id,
-                                       vpcid=cls.vpc1.id,
-                                       zoneid=cls.zone.id,
-                                       domainid=cls.domain.id,
-                                       accountid=cls.account.name)
+                                      cls.services['networks']['network1'],
+                                      networkofferingid=cls.network_offering.id,
+                                      aclid=cls.default_allow_acl.id,
+                                      vpcid=cls.vpc1.id,
+                                      zoneid=cls.zone.id,
+                                      domainid=cls.domain.id,
+                                      accountid=cls.account.name)
         cls.logger.debug("Network '%s' created, CIDR: %s, Gateway: %s", cls.network1.name, cls.network1.cidr, cls.network1.gateway)
+
+        cls.network2 = Network.create(cls.apiclient,
+                                      cls.services['networks']['network2'],
+                                      networkofferingid=cls.network_offering.id,
+                                      aclid=cls.default_allow_acl.id,
+                                      vpcid=cls.vpc1.id,
+                                      zoneid=cls.zone.id,
+                                      domainid=cls.domain.id,
+                                      accountid=cls.account.name)
+        cls.logger.debug("Network '%s' created, CIDR: %s, Gateway: %s", cls.network2.name, cls.network2.cidr, cls.network2.gateway)
 
         cls.vm_1 = VirtualMachine.create(
             cls.apiclient,
@@ -114,18 +121,58 @@ class TestLoadBalance(cloudstackTestCase):
             serviceofferingid=cls.service_offering.id,
             networkids=[cls.network1.id]
         )
-
-        cls.non_src_nat_ip = PublicIPAddress.create(cls.apiclient,
-            zoneid=cls.zone.id,
-            domainid=cls.account.domainid,
+        cls.vm_4 = VirtualMachine.create(
+            cls.apiclient,
+            cls.services["virtual_machine"],
+            templateid=cls.template.id,
             accountid=cls.account.name,
-            vpcid=cls.vpc1.id,
-            networkid=cls.network1.id)
-        cls.logger.debug("Public IP '%s' acquired, VPC: %s, Network: %s", cls.non_src_nat_ip.ipaddress.ipaddress, cls.vpc1.name, cls.network1.name)
+            domainid=cls.account.domainid,
+            serviceofferingid=cls.service_offering.id,
+            networkids=[cls.network2.id]
+        )
+        cls.vm_5 = VirtualMachine.create(
+            cls.apiclient,
+            cls.services["virtual_machine"],
+            templateid=cls.template.id,
+            accountid=cls.account.name,
+            domainid=cls.account.domainid,
+            serviceofferingid=cls.service_offering.id,
+            networkids=[cls.network2.id]
+        )
+        cls.vm_6 = VirtualMachine.create(
+            cls.apiclient,
+            cls.services["virtual_machine"],
+            templateid=cls.template.id,
+            accountid=cls.account.name,
+            domainid=cls.account.domainid,
+            serviceofferingid=cls.service_offering.id,
+            networkids=[cls.network2.id]
+        )
+
+        cls.non_src_nat_ip_1 = PublicIPAddress.create(cls.apiclient,
+                                                      zoneid=cls.zone.id,
+                                                      domainid=cls.account.domainid,
+                                                      accountid=cls.account.name,
+                                                      vpcid=cls.vpc1.id,
+                                                      networkid=cls.network1.id)
+        cls.logger.debug("Public IP '%s' acquired, VPC: %s, Network: %s", cls.non_src_nat_ip_1.ipaddress.ipaddress, cls.vpc1.name, cls.network1.name)
+
+        cls.non_src_nat_ip_2 = PublicIPAddress.create(cls.apiclient,
+                                                      zoneid=cls.zone.id,
+                                                      domainid=cls.account.domainid,
+                                                      accountid=cls.account.name,
+                                                      vpcid=cls.vpc1.id,
+                                                      networkid=cls.network2.id)
+        cls.logger.debug("Public IP '%s' acquired, VPC: %s, Network: %s", cls.non_src_nat_ip_2.ipaddress.ipaddress, cls.vpc1.name, cls.network2.name)
 
         command = replaceNetworkACLList.replaceNetworkACLListCmd()
         command.aclid = cls.default_allow_acl.id
-        command.publicipid = cls.non_src_nat_ip.ipaddress.id
+        command.publicipid = cls.non_src_nat_ip_1.ipaddress.id
+        cls.apiclient.replaceNetworkACLList(command)
+
+        command = replaceNetworkACLList.replaceNetworkACLListCmd()
+        command.aclid = cls.default_allow_acl.id
+        command.publicipid = cls.non_src_nat_ip_2.ipaddress.id
         cls.apiclient.replaceNetworkACLList(command)
 
         cls._cleanup = [
@@ -165,7 +212,8 @@ class TestLoadBalance(cloudstackTestCase):
             True,
             "Check list response returns a valid list"
         )
-        src_nat_ip_addr = src_nat_ip_addrs[0]
+        src_nat_ip_addr_1 = src_nat_ip_addrs[0]
+        src_nat_ip_addr_2 = src_nat_ip_addrs[1]
 
         # Check if VM is in Running state before creating LB rule
         vm_response = VirtualMachine.list(
@@ -193,118 +241,50 @@ class TestLoadBalance(cloudstackTestCase):
             )
 
         # Create Load Balancer rule and assign VMs to rule
-        lb_rule = LoadBalancerRule.create(
-            self.apiclient,
-            self.services["lbrule"],
-            src_nat_ip_addr.id,
-            accountid=self.account.name,
-            vpcid=self.vpc1.id,
-            networkid=self.network1.id
-        )
-        self.cleanup.append(lb_rule)
-        lb_rule.assign(self.apiclient, [self.vm_1, self.vm_2])
-        lb_rules = list_lb_rules(
-            self.apiclient,
-            id=lb_rule.id
-        )
-        self.assertEqual(
-            isinstance(lb_rules, list),
-            True,
-            "Check list response returns a valid list"
-        )
-        # verify listLoadBalancerRules lists the added load balancing rule
-        self.assertNotEqual(
-            len(lb_rules),
-            0,
-            "Check Load Balancer Rule in its List"
-        )
-        self.assertEqual(
-            lb_rules[0].id,
-            lb_rule.id,
-            "Check List Load Balancer Rules returns valid Rule"
-        )
+        lb_rule_1 = self.create_lb_rule(src_nat_ip_addr_1.id, self.vpc1.id, self.network1.id, [self.vm_1, self.vm_2])
+
+        # Create Load Balancer rule and assign VMs to rule
+        lb_rule_2 = self.create_lb_rule(src_nat_ip_addr_2.id, self.vpc1.id, self.network2.id, [self.vm_4, self.vm_5])
 
         # listLoadBalancerRuleInstances should list all
         # instances associated with that LB rule
-        lb_instance_rules = list_lb_instances(
-            self.apiclient,
-            id=lb_rule.id
-        )
-        self.assertEqual(
-            isinstance(lb_instance_rules, list),
-            True,
-            "Check list response returns a valid list"
-        )
-        self.assertNotEqual(
-            len(lb_instance_rules),
-            0,
-            "Check Load Balancer instances Rule in its List"
-        )
-        self.logger.debug("lb_instance_rules Ids: %s, %s" % (
-            lb_instance_rules[0].id,
-            lb_instance_rules[1].id
-        ))
-        self.logger.debug("VM ids: %s, %s" % (self.vm_1.id, self.vm_2.id))
+        self.check_lb_rules(lb_rule_1.id, [self.vm_1.id, self.vm_2.id])
+        self.check_lb_rules(lb_rule_2.id, [self.vm_4.id, self.vm_5.id])
 
+        uname_results = []
+        for x in range(0, 5):
+            self.try_ssh(src_nat_ip_addr_1.ipaddress, uname_results)
+
+        self.logger.debug("OUTPUT: %s" % str(uname_results))
         self.assertIn(
-            lb_instance_rules[0].id,
-            [self.vm_1.id, self.vm_2.id],
-            "Check List Load Balancer instances Rules returns valid VM ID"
-        )
-
-        self.assertIn(
-            lb_instance_rules[1].id,
-            [self.vm_1.id, self.vm_2.id],
-            "Check List Load Balancer instances Rules returns valid VM ID"
-        )
-
-        unameResults = []
-        self.try_ssh(src_nat_ip_addr.ipaddress, unameResults)
-        self.try_ssh(src_nat_ip_addr.ipaddress, unameResults)
-        self.try_ssh(src_nat_ip_addr.ipaddress, unameResults)
-        self.try_ssh(src_nat_ip_addr.ipaddress, unameResults)
-        self.try_ssh(src_nat_ip_addr.ipaddress, unameResults)
-
-        self.logger.debug("UNAME: %s" % str(unameResults))
-        self.assertIn(
-            "Linux",
-            unameResults,
+            self.vm_1.id.split("-", 3)[3].upper(),
+            uname_results,
             "Check if ssh succeeded for server1"
         )
         self.assertIn(
-            "Linux",
-            unameResults,
+            self.vm_2.id.split("-", 3)[3].upper(),
+            uname_results,
             "Check if ssh succeeded for server2"
         )
 
-        # SSH should pass till there is a last VM associated with LB rule
-        lb_rule.remove(self.apiclient, [self.vm_2])
+        uname_results = []
+        for x in range(0, 5):
+            self.try_ssh(src_nat_ip_addr_2.ipaddress, uname_results)
 
-        # making unameResultss list empty
-        unameResults[:] = []
+        self.logger.debug("OUTPUT: %s" % str(uname_results))
+        self.assertIn(
+            self.vm_4.id.split("-", 3)[3].upper(),
+            uname_results,
+            "Check if ssh succeeded for server4"
+        )
+        self.assertIn(
+            self.vm_5.id.split("-", 3)[3].upper(),
+            uname_results,
+            "Check if ssh succeeded for server5"
+        )
 
-        try:
-            self.logger.debug("SSHing into IP address: %s after removing VM (ID: %s)" %
-                       (
-                           src_nat_ip_addr.ipaddress,
-                           self.vm_2.id
-                       ))
-
-            self.try_ssh(src_nat_ip_addr.ipaddress, unameResults)
-            self.assertIn(
-                "Linux",
-                unameResults,
-                "Check if ssh succeeded for server1"
-            )
-        except Exception as e:
-            self.fail("%s: SSH failed for VM with IP Address: %s" %
-                      (e, src_nat_ip_addr.ipaddress))
-
-        lb_rule.remove(self.apiclient, [self.vm_1])
-
-        with self.assertRaises(Exception):
-            self.logger.debug("Removed all VMs, trying to SSH")
-            self.try_ssh(src_nat_ip_addr.ipaddress, unameResults)
+        uname_results.append(self.remove_and_check(lb_rule_1, src_nat_ip_addr_1, [self.vm_2, self.vm_1]))
+        uname_results.append(self.remove_and_check(lb_rule_2, src_nat_ip_addr_2, [self.vm_4, self.vm_5]))
         return
 
     @attr(tags=['advanced'])
@@ -318,113 +298,54 @@ class TestLoadBalance(cloudstackTestCase):
         #   round robin is indeed happening as expected
 
         # Create Load Balancer rule and assign VMs to rule
-        lb_rule = LoadBalancerRule.create(
-            self.apiclient,
-            self.services["lbrule"],
-            self.non_src_nat_ip.ipaddress.id,
-            accountid=self.account.name,
-            vpcid=self.vpc1.id,
-            networkid=self.network1.id
-        )
-        self.cleanup.append(lb_rule)
-        lb_rule.assign(self.apiclient, [self.vm_1, self.vm_2])
-        lb_rules = list_lb_rules(
-            self.apiclient,
-            id=lb_rule.id
-        )
-        self.assertEqual(
-            isinstance(lb_rules, list),
-            True,
-            "Check list response returns a valid list"
-        )
-        # verify listLoadBalancerRules lists the added load balancing rule
-        self.assertNotEqual(
-            len(lb_rules),
-            0,
-            "Check Load Balancer Rule in its List"
-        )
-        self.assertEqual(
-            lb_rules[0].id,
-            lb_rule.id,
-            "Check List Load Balancer Rules returns valid Rule"
-        )
+        lb_rule_1 = self.create_lb_rule(self.non_src_nat_ip_1.ipaddress.id,
+                                        self.vpc1.id,
+                                        self.network1.id,
+                                        [self.vm_1, self.vm_2])
+
+        lb_rule_2 = self.create_lb_rule(self.non_src_nat_ip_2.ipaddress.id,
+                                        self.vpc1.id,
+                                        self.network2.id,
+                                        [self.vm_4, self.vm_5])
+
         # listLoadBalancerRuleInstances should list
         # all instances associated with that LB rule
-        lb_instance_rules = list_lb_instances(
-            self.apiclient,
-            id=lb_rule.id
-        )
-        self.assertEqual(
-            isinstance(lb_instance_rules, list),
-            True,
-            "Check list response returns a valid list"
-        )
-        self.assertNotEqual(
-            len(lb_instance_rules),
-            0,
-            "Check Load Balancer instances Rule in its List"
-        )
+        self.check_lb_rules(lb_rule_1.id, [self.vm_1.id, self.vm_2.id])
+        self.check_lb_rules(lb_rule_2.id, [self.vm_4.id, self.vm_5.id])
+        uname_results = []
+        for x in range(0, 5):
+            self.try_ssh(self.non_src_nat_ip_1.ipaddress.ipaddress, uname_results)
 
+        self.logger.debug("OUTPUT: %s" % str(uname_results))
         self.assertIn(
-            lb_instance_rules[0].id,
-            [self.vm_1.id, self.vm_2.id],
-            "Check List Load Balancer instances Rules returns valid VM ID"
+            self.vm_1.id.split("-", 3)[3].upper(),
+            uname_results,
+            "Check if ssh succeeded for server1"
         )
-
         self.assertIn(
-            lb_instance_rules[1].id,
-            [self.vm_1.id, self.vm_2.id],
-            "Check List Load Balancer instances Rules returns valid VM ID"
+            self.vm_2.id.split("-", 3)[3].upper(),
+            uname_results,
+            "Check if ssh succeeded for server2"
         )
-        try:
-            unameResults = []
-            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
-            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
-            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
-            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
-            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
 
-            self.logger.debug("UNAME: %s" % str(unameResults))
-            self.assertIn(
-                "Linux",
-                unameResults,
-                "Check if ssh succeeded for server1"
-            )
-            self.assertIn(
-                "Linux",
-                unameResults,
-                "Check if ssh succeeded for server2"
-            )
+        uname_results = []
+        for x in range(0, 5):
+            self.try_ssh(self.non_src_nat_ip_2.ipaddress.ipaddress, uname_results)
 
-            # SSH should pass till there is a last VM associated with LB rule
-            lb_rule.remove(self.apiclient, [self.vm_2])
-            self.logger.debug("SSHing into IP address: %s after removing VM (ID: %s) from LB rule" %
-                       (
-                           self.non_src_nat_ip.ipaddress.ipaddress,
-                           self.vm_2.id
-                       ))
-            # Making host list empty
-            unameResults[:] = []
+        self.logger.debug("OUTPUT: %s" % str(uname_results))
+        self.assertIn(
+            self.vm_4.id.split("-", 3)[3].upper(),
+            uname_results,
+            "Check if ssh succeeded for server1"
+        )
+        self.assertIn(
+            self.vm_5.id.split("-", 3)[3].upper(),
+            uname_results,
+            "Check if ssh succeeded for server2"
+        )
 
-            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
-            self.assertIn(
-                "Linux",
-                unameResults,
-                "Check if ssh succeeded for server1"
-            )
-            self.logger.debug("UNAME after removing VM2: %s" % str(unameResults))
-        except Exception as e:
-            self.fail("%s: SSH failed for VM with IP Address: %s" %
-                      (e, self.non_src_nat_ip.ipaddress.ipaddress))
-
-        lb_rule.remove(self.apiclient, [self.vm_1])
-        with self.assertRaises(Exception):
-            self.logger.debug("SSHing into IP address: %s after removing VM (ID: %s) from LB rule" %
-                       (
-                           self.non_src_nat_ip.ipaddress.ipaddress,
-                           self.vm_1.id
-                       ))
-            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
+        uname_results.append(self.remove_and_check(lb_rule_1, self.non_src_nat_ip_1, [self.vm_1, self.vm_2]))
+        uname_results.append(self.remove_and_check(lb_rule_2, self.non_src_nat_ip_2, [self.vm_4, self.vm_5]))
         return
 
     @attr(tags=['advanced'])
@@ -464,83 +385,60 @@ class TestLoadBalance(cloudstackTestCase):
                 "VM state should be Running before creating a NAT rule."
             )
 
-        lb_rule = LoadBalancerRule.create(
-            self.apiclient,
-            self.services["lbrule"],
-            self.non_src_nat_ip.ipaddress.id,
-            self.account.name,
-            vpcid=self.vpc1.id,
-            networkid=self.network1.id
-        )
-        lb_rule.assign(self.apiclient, [self.vm_1, self.vm_2])
+        lb_rule_1 = self.create_lb_rule(self.non_src_nat_ip_1.ipaddress.id,
+                                        self.vpc1.id,
+                                        self.network1.id,
+                                        [self.vm_1, self.vm_2])
 
-        unameResults = []
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
+        lb_rule_2 = self.create_lb_rule(self.non_src_nat_ip_2.ipaddress.id,
+                                        self.vpc1.id,
+                                        self.network2.id,
+                                        [self.vm_4, self.vm_5])
 
-        self.logger.debug("UNAME: %s" % str(unameResults))
+        self.check_lb_rules(lb_rule_1.id, [self.vm_1.id, self.vm_2.id])
+        self.check_lb_rules(lb_rule_2.id, [self.vm_4.id, self.vm_5.id])
+
+        uname_results = []
+        for x in range(0, 5):
+            self.try_ssh(self.non_src_nat_ip_1.ipaddress.ipaddress, uname_results)
+
+        self.logger.debug("OUTPUT: %s" % str(uname_results))
         self.assertIn(
-            "Linux",
-            unameResults,
+            self.vm_1.id.split("-", 3)[3].upper(),
+            uname_results,
             "Check if ssh succeeded for server1"
         )
         self.assertIn(
-            "Linux",
-            unameResults,
+            self.vm_2.id.split("-", 3)[3].upper(),
+            uname_results,
             "Check if ssh succeeded for server2"
         )
+
+        uname_results = []
+        for x in range(0, 5):
+            self.try_ssh(self.non_src_nat_ip_2.ipaddress.ipaddress, uname_results)
+
+        self.logger.debug("OUTPUT: %s" % str(uname_results))
+        self.assertIn(
+            self.vm_4.id.split("-", 3)[3].upper(),
+            uname_results,
+            "Check if ssh succeeded for server4"
+        )
+        self.assertIn(
+            self.vm_5.id.split("-", 3)[3].upper(),
+            uname_results,
+            "Check if ssh succeeded for server5"
+        )
+
         # Removing VM and assigning another VM to LB rule
-        lb_rule.remove(self.apiclient, [self.vm_2])
-
-        # making unameResults list empty
-        unameResults[:] = []
-
-        try:
-            self.logger.debug("SSHing again into IP address: %s with VM (ID: %s) added to LB rule" %
-                       (
-                           self.non_src_nat_ip.ipaddress.ipaddress,
-                           self.vm_1.id,
-                       ))
-            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
-
-            self.assertIn(
-                "Linux",
-                unameResults,
-                "Check if ssh succeeded for server1"
-            )
-        except Exception as e:
-            self.fail("SSH failed for VM with IP: %s" %
-                      self.non_src_nat_ip.ipaddress.ipaddress)
-
-        lb_rule.assign(self.apiclient, [self.vm_3])
-
-        # Making unameResults list empty
-        unameResults[:] = []
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
-        self.logger.debug("UNAME: %s" % str(unameResults))
-        self.assertIn(
-            "Linux",
-            unameResults,
-            "Check if ssh succeeded for server1"
-        )
-        self.assertIn(
-            "Linux",
-            unameResults,
-            "Check if ssh succeeded for server3"
-        )
+        self.remove_add_check(lb_rule_1, self.non_src_nat_ip_1.ipaddress, [self.vm_2, self.vm_3])
+        self.remove_add_check(lb_rule_1, self.non_src_nat_ip_1.ipaddress, [self.vm_4, self.vm_6])
         return
 
-    def try_ssh(self, ip_addr, unameCmd):
+    def try_ssh(self, ip_addr, command):
         try:
             self.logger.debug(
-                "SSH into VM (IPaddress: %s) & NAT Rule (Public IP: %s)" %
+                "SSH into VM (IPAddress: %s) & NAT Rule (Public IP: %s)" %
                 (self.vm_1.ipaddress, ip_addr)
             )
             # If Round Robin Algorithm is chosen,
@@ -553,10 +451,168 @@ class TestLoadBalance(cloudstackTestCase):
                 self.vm_1.password,
                 retries=10
             )
-            unameCmd.append(ssh_1.execute("uname")[0])
-            self.logger.debug(unameCmd)
+            command.append(ssh_1.execute("cat /sys/devices/virtual/dmi/id/product_uuid | cut -c20-")[0])
+            self.logger.debug(command)
         except Exception as e:
             self.fail("%s: SSH failed for VM with IP Address: %s" %
                       (e, ip_addr))
-        time.sleep(10)
         return
+
+    def create_lb_rule(self, ipaddr, vpcid, networkid, vms):
+        """ Create Loadbalancer rule
+        :param ipaddr: IP Address uuid to create LB rule on
+        :param vpcid: VPC uuid where to create LB rule
+        :param networkid: Network uuid
+        :param vms: List of VM's
+        :return: loadbalancer rule, loadbalancer rules
+        """
+        # Create Load Balancer rule and assign VMs to rule
+        lb_rule = LoadBalancerRule.create(
+            self.apiclient,
+            self.services["lbrule"],
+            ipaddr,
+            accountid=self.account.name,
+            vpcid=vpcid,
+            networkid=networkid
+        )
+        self.cleanup.append(lb_rule)
+        lb_rule.assign(self.apiclient, vms)
+        lb_rules = list_lb_rules(
+            self.apiclient,
+            id=lb_rule.id
+        )
+        self.assertEqual(
+            isinstance(lb_rules, list),
+            True,
+            "Check list response returns a valid list"
+        )
+        # verify listLoadBalancerRules lists the added load balancing rule
+        self.assertNotEqual(
+            len(lb_rules),
+            0,
+            "Check Load Balancer Rule in its List"
+        )
+        self.assertEqual(
+            lb_rules[0].id,
+            lb_rule.id,
+            "Check List Load Balancer Rules returns valid Rule"
+        )
+        return lb_rule
+
+    def check_lb_rules(self, lb_rule_id, vm_ids):
+        """ Check Loadbalancer rules
+        :param lb_rule_id: Load balancer uuid
+        :param vm_ids: List of VM uuid's
+        :return:
+        """
+        lb_instance_rules = list_lb_instances(
+            self.apiclient,
+            id=lb_rule_id
+        )
+        self.assertEqual(
+            isinstance(lb_instance_rules, list),
+            True,
+            "Check list response returns a valid list"
+        )
+        self.assertNotEqual(
+            len(lb_instance_rules),
+            0,
+            "Check Load Balancer instances Rule in its List"
+        )
+        self.logger.debug("lb_instance_rules Ids: %s, %s" % (
+            lb_instance_rules[0].id,
+            lb_instance_rules[1].id
+        ))
+        self.logger.debug("VM ids: %s" % ", ".join(vm_ids))
+
+        self.assertIn(
+            lb_instance_rules[0].id,
+            vm_ids,
+            "Check List Load Balancer instances Rules returns valid VM ID"
+        )
+
+        self.assertIn(
+            lb_instance_rules[1].id,
+            vm_ids,
+            "Check List Load Balancer instances Rules returns valid VM ID"
+        )
+
+    def remove_and_check(self, lb_rule, ip_addr, vms):
+        """ Remove and check
+        This removes the VM from the LB rule and check if it's still possible
+        to SSH to the VM
+
+        :param lb_rule: Load balancer rule
+        :param ip_addr: IP address
+        :param vms: List of VM's
+        :return: List with SSH output
+        """
+        lb_rule.remove(self.apiclient, [vms[0]])
+
+        uname_results = []
+
+        try:
+            self.logger.debug("SSHing into IP address: %s after removing VM (ID: %s)" %
+                              (
+                                  ip_addr.ipaddress,
+                                  vms[0].id
+                              ))
+
+            self.try_ssh(ip_addr.ipaddress, uname_results)
+            self.assertIn(
+                vms[1].id.split("-", 3)[3].upper(),
+                uname_results,
+                "Check if ssh succeeded for server1"
+            )
+        except Exception as e:
+            self.fail("%s: SSH failed for VM with IP Address: %s" %
+                      (e, ip_addr.ipaddress))
+
+        lb_rule.remove(self.apiclient, [vms[1]])
+
+        with self.assertRaises(Exception):
+            self.logger.debug("Removed all VMs, trying to SSH")
+            self.try_ssh(ip_addr.ipaddress, uname_results)
+
+        return uname_results
+
+    def remove_add_check(self, lb_rule, ip_addr, vms):
+        """ Remove VM, Add VM and check
+        :param lb_rule: Load balancer rule
+        :param ip_addr: IP address
+        :param vms: List of VM's, first VM will be removed, second one will be added
+        :return: List with SSH output
+        """
+        lb_rule.remove(self.apiclient, [vms[0]])
+
+        results = []
+
+        try:
+            self.logger.debug("SSHing into IP address: %s after removing VM (ID: %s)" %
+                              (
+                                  ip_addr.ipaddress,
+                                  vms[0].id
+                              ))
+
+            self.try_ssh(ip_addr.ipaddress, results)
+            self.assertNotIn(
+                vms[0].id.split("-", 3)[3].upper(),
+                results,
+                "Check if ssh did not succeeded for server %s" % vms[0].id
+            )
+        except Exception as e:
+            self.fail("%s: SSH failed for VM with IP Address: %s" %
+                      (e, ip_addr.ipaddress))
+
+        lb_rule.assign(self.apiclient, [vms[1]])
+
+        results[:] = []
+        for x in range(0, 5):
+            self.try_ssh(ip_addr.ipaddress, results)
+        self.logger.debug("OUTPUT: %s" % str(results))
+        self.assertIn(
+            vms[1].id.split("-", 3)[3].upper(),
+            results,
+            "Check if ssh succeeded for server %s" % vms[1].id
+        )
+        return results

--- a/cosmic-marvin/marvin/config/test_data.py
+++ b/cosmic-marvin/marvin/config/test_data.py
@@ -11,12 +11,12 @@ test_data = {
             "data": {
                 "domains": [
                     {
-                        "metadata": { },
+                        "metadata": {},
                         "data": {
                             "name": "ROOT",
                             "accounts": [
                                 {
-                                    "metadata": { },
+                                    "metadata": {},
                                     "data": {
                                         "accounttype": 2,
                                         "email": "john@doe.com",
@@ -27,7 +27,7 @@ test_data = {
                                         "vpcs": [
                                             # vpc01
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "cidr": "10.1.0.0/16",
                                                     "displaytext": "vpc01",
@@ -35,7 +35,7 @@ test_data = {
                                                     "vpcofferingname": "Redundant VPC offering",
                                                     "networks": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "displaytext": "vpc01-tier01",
                                                                 "name": "vpc01-tier01",
@@ -46,7 +46,7 @@ test_data = {
                                                             }
                                                         },
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "displaytext": "vpc01-tier02",
                                                                 "name": "vpc01-tier02",
@@ -59,12 +59,12 @@ test_data = {
                                                     ],
                                                     "acls": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "name": "acl01",
                                                                 "rules": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "protocol": "TCP",
                                                                             "cidrlist": "0.0.0.0/0",
@@ -79,11 +79,11 @@ test_data = {
                                                     ],
                                                     "publicipaddresses": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "portforwards": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "privateport": 22,
                                                                             "publicport": 2201,
@@ -96,11 +96,11 @@ test_data = {
                                                             }
                                                         },
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "portforwards": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "privateport": 22,
                                                                             "publicport": 2201,
@@ -110,7 +110,7 @@ test_data = {
                                                                         }
                                                                     },
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "privateport": 22,
                                                                             "publicport": 2202,
@@ -125,14 +125,14 @@ test_data = {
                                                     ],
                                                     "privategateways": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "ip": "172.16.100.1",
                                                                 "aclname": "default_allow",
                                                                 "privatenetworkname": "private_gateways_network",
                                                                 "staticroutes": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "cidr": "10.3.0.0/16",
                                                                             "nexthop": "172.16.100.3"
@@ -147,7 +147,7 @@ test_data = {
                                             },
                                             # vpc02
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "cidr": "10.2.0.0/16",
                                                     "displaytext": "vpc02",
@@ -155,7 +155,7 @@ test_data = {
                                                     "vpcofferingname": "Default VPC offering",
                                                     "networks": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "displaytext": "vpc02-tier01",
                                                                 "name": "vpc02-tier01",
@@ -169,11 +169,11 @@ test_data = {
                                                     "acls": [],
                                                     "publicipaddresses": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "portforwards": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "privateport": 22,
                                                                             "publicport": 2201,
@@ -192,7 +192,7 @@ test_data = {
                                             },
                                             # vpc03
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "cidr": "10.3.0.0/16",
                                                     "displaytext": "vpc03",
@@ -200,7 +200,7 @@ test_data = {
                                                     "vpcofferingname": "Default VPC offering",
                                                     "networks": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "displaytext": "vpc03-tier01",
                                                                 "name": "vpc03-tier01",
@@ -213,12 +213,12 @@ test_data = {
                                                     ],
                                                     "acls": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "name": "acl03",
                                                                 "rules": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "protocol": "TCP",
                                                                             "cidrlist": "0.0.0.0/0",
@@ -233,11 +233,11 @@ test_data = {
                                                     ],
                                                     "publicipaddresses": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "portforwards": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "privateport": 22,
                                                                             "publicport": 2201,
@@ -252,14 +252,14 @@ test_data = {
                                                     ],
                                                     "privategateways": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "ip": "172.16.100.3",
                                                                 "aclname": "default_allow",
                                                                 "privatenetworkname": "private_gateways_network",
                                                                 "staticroutes": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "cidr": "10.1.0.0/16",
                                                                             "nexthop": "172.16.100.1"
@@ -274,7 +274,7 @@ test_data = {
                                             },
                                             # vpc04
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "cidr": "10.4.0.0/16",
                                                     "displaytext": "vpc04",
@@ -282,7 +282,7 @@ test_data = {
                                                     "vpcofferingname": "Redundant VPC offering",
                                                     "networks": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "displaytext": "vpc04-tier01",
                                                                 "name": "vpc04-tier01",
@@ -295,12 +295,12 @@ test_data = {
                                                     ],
                                                     "acls": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "name": "acl04",
                                                                 "rules": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "protocol": "TCP",
                                                                             "cidrlist": "0.0.0.0/0",
@@ -315,11 +315,11 @@ test_data = {
                                                     ],
                                                     "publicipaddresses": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "portforwards": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "privateport": 22,
                                                                             "publicport": 2201,
@@ -340,7 +340,7 @@ test_data = {
                                         "isolatednetworks": [
                                             # isonet01
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "name": "isonet01",
                                                     "displaytext": "isonet01",
@@ -349,7 +349,7 @@ test_data = {
                                                     "netmask": "255.255.255.0",
                                                     "egressrules": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "protocol": "TCP",
                                                                 "cidrlist": "0.0.0.0/0",
@@ -360,11 +360,11 @@ test_data = {
                                                     ],
                                                     "publicipaddresses": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "firewallrules": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "protocol": "TCP",
                                                                             "cidrlist": "0.0.0.0/0",
@@ -375,7 +375,7 @@ test_data = {
                                                                 ],
                                                                 "portforwards": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "protocol": "TCP",
                                                                             "privateport": 22,
@@ -386,7 +386,7 @@ test_data = {
                                                                         }
                                                                     },
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "protocol": "TCP",
                                                                             "privateport": 22,
@@ -404,7 +404,7 @@ test_data = {
                                             },
                                             # isonet02
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "name": "isonet02",
                                                     "displaytext": "isonet02",
@@ -413,7 +413,7 @@ test_data = {
                                                     "netmask": "255.255.255.0",
                                                     "egressrules": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "protocol": "TCP",
                                                                 "cidrlist": "0.0.0.0/0",
@@ -424,11 +424,11 @@ test_data = {
                                                     ],
                                                     "publicipaddresses": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "firewallrules": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "protocol": "TCP",
                                                                             "cidrlist": "0.0.0.0/0",
@@ -439,7 +439,7 @@ test_data = {
                                                                 ],
                                                                 "portforwards": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "protocol": "TCP",
                                                                             "privateport": 22,
@@ -458,7 +458,7 @@ test_data = {
                                         ],
                                         "privatenetworks": [
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "name": "private_gateways_network",
                                                     "displaytext": "private_gateways_network",
@@ -471,7 +471,7 @@ test_data = {
                                         "virtualmachines": [
                                             # vpc01-tier01-vm01
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "name": "vpc01-tier01-vm011",
                                                     "displayname": "vpc01-tier01-vm01",
@@ -479,7 +479,7 @@ test_data = {
                                                     "serviceofferingname": "Small Instance",
                                                     "nics": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "guestip": "10.1.1.11",
                                                                 "networkname": "vpc01-tier01"
@@ -490,7 +490,7 @@ test_data = {
                                             },
                                             # vpc01-tier02-vm01
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "name": "vpc01-tier02-vm01",
                                                     "displayname": "vpc01-tier02-vm011",
@@ -498,7 +498,7 @@ test_data = {
                                                     "serviceofferingname": "Small Instance",
                                                     "nics": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "guestip": "10.1.2.11",
                                                                 "networkname": "vpc01-tier02"
@@ -509,7 +509,7 @@ test_data = {
                                             },
                                             # vpc01-tier02-vm02
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "name": "vpc01-tier02-vm02",
                                                     "displayname": "vpc01-tier02-vm02",
@@ -517,7 +517,7 @@ test_data = {
                                                     "serviceofferingname": "Small Instance",
                                                     "nics": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "guestip": "10.1.2.12",
                                                                 "networkname": "vpc01-tier02"
@@ -528,7 +528,7 @@ test_data = {
                                             },
                                             # vpc02-tier01-vm01
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "name": "vpc02-tier01-vm01",
                                                     "displayname": "vpc02-tier01-vm01",
@@ -536,7 +536,7 @@ test_data = {
                                                     "serviceofferingname": "Small Instance",
                                                     "nics": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "guestip": "10.2.1.11",
                                                                 "networkname": "vpc02-tier01"
@@ -547,7 +547,7 @@ test_data = {
                                             },
                                             # vpc03-tier01-vm01
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "name": "vpc03-tier01-vm01",
                                                     "displayname": "vpc03-tier01-vm01",
@@ -555,7 +555,7 @@ test_data = {
                                                     "serviceofferingname": "Small Instance",
                                                     "nics": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "guestip": "10.3.1.11",
                                                                 "networkname": "vpc03-tier01"
@@ -566,7 +566,7 @@ test_data = {
                                             },
                                             # vpc04-tier01-vm01
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "name": "vpc04-tier01-vm01",
                                                     "displayname": "vpc04-tier01-vm01",
@@ -574,7 +574,7 @@ test_data = {
                                                     "serviceofferingname": "Small Instance",
                                                     "nics": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "guestip": "10.4.1.11",
                                                                 "networkname": "vpc04-tier01"
@@ -585,7 +585,7 @@ test_data = {
                                             },
                                             # isonet01-vm01
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "name": "isonet01-vm01",
                                                     "displayname": "isonet01-vm01",
@@ -593,7 +593,7 @@ test_data = {
                                                     "serviceofferingname": "Small Instance",
                                                     "nics": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "guestip": "172.16.1.11",
                                                                 "networkname": "isonet01"
@@ -604,7 +604,7 @@ test_data = {
                                             },
                                             # isonet01-vm02
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "name": "isonet01-vm02",
                                                     "displayname": "isonet01-vm02",
@@ -612,7 +612,7 @@ test_data = {
                                                     "serviceofferingname": "Small Instance",
                                                     "nics": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "guestip": "172.16.1.12",
                                                                 "networkname": "isonet01"
@@ -623,7 +623,7 @@ test_data = {
                                             },
                                             # isonet02-vm01
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "name": "isonet02-vm01",
                                                     "displayname": "isonet02-vm01",
@@ -631,7 +631,7 @@ test_data = {
                                                     "serviceofferingname": "Small Instance",
                                                     "nics": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "guestip": "172.16.2.11",
                                                                 "networkname": "isonet02"
@@ -660,12 +660,12 @@ test_data = {
             "data": {
                 "domains": [
                     {
-                        "metadata": { },
+                        "metadata": {},
                         "data": {
                             "name": "ROOT",
                             "accounts": [
                                 {
-                                    "metadata": { },
+                                    "metadata": {},
                                     "data": {
                                         "accounttype": 2,
                                         "email": "jane@doe.com",
@@ -676,7 +676,7 @@ test_data = {
                                         "vpcs": [
                                             # vpc01
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "cidr": "10.1.0.0/16",
                                                     "displaytext": "vpc01",
@@ -684,7 +684,7 @@ test_data = {
                                                     "vpcofferingname": "Redundant VPC offering",
                                                     "networks": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "displaytext": "vpc01-tier01",
                                                                 "name": "vpc01-tier01",
@@ -697,12 +697,12 @@ test_data = {
                                                     ],
                                                     "acls": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "name": "acl01",
                                                                 "rules": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "protocol": "TCP",
                                                                             "cidrlist": "0.0.0.0/0",
@@ -717,11 +717,11 @@ test_data = {
                                                     ],
                                                     "publicipaddresses": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "portforwards": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "privateport": 22,
                                                                             "publicport": 2201,
@@ -740,7 +740,7 @@ test_data = {
                                             },
                                             # vpc02
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "cidr": "10.2.0.0/16",
                                                     "displaytext": "vpc02",
@@ -748,7 +748,7 @@ test_data = {
                                                     "vpcofferingname": "Default VPC offering",
                                                     "networks": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "displaytext": "vpc02-tier01",
                                                                 "name": "vpc02-tier01",
@@ -762,11 +762,11 @@ test_data = {
                                                     "acls": [],
                                                     "publicipaddresses": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "portforwards": [
                                                                     {
-                                                                        "metadata": { },
+                                                                        "metadata": {},
                                                                         "data": {
                                                                             "privateport": 22,
                                                                             "publicport": 2201,
@@ -789,7 +789,7 @@ test_data = {
                                         "virtualmachines": [
                                             # vpc01-tier01-vm01
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "name": "vpc01-tier01-vm01",
                                                     "displayname": "vpc01-tier01-vm01",
@@ -797,7 +797,7 @@ test_data = {
                                                     "serviceofferingname": "Small Instance",
                                                     "nics": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "guestip": "10.1.1.11",
                                                                 "networkname": "vpc01-tier01"
@@ -808,7 +808,7 @@ test_data = {
                                             },
                                             # vpc02-tier01-vm01
                                             {
-                                                "metadata": { },
+                                                "metadata": {},
                                                 "data": {
                                                     "name": "vpc02-tier01-vm01",
                                                     "displayname": "vpc02-tier01-vm01",
@@ -816,7 +816,7 @@ test_data = {
                                                     "serviceofferingname": "Small Instance",
                                                     "nics": [
                                                         {
-                                                            "metadata": { },
+                                                            "metadata": {},
                                                             "data": {
                                                                 "guestip": "10.2.1.11",
                                                                 "networkname": "vpc02-tier01"
@@ -878,7 +878,7 @@ test_data = {
     "vdomain": {
         "name": "domain"
     },
-    "domain": { "name": "domain" },
+    "domain": {"name": "domain"},
     "email": "test@test.com",
     "gateway": "172.1.1.1",
     "netmask": "255.255.255.0",
@@ -1458,8 +1458,8 @@ test_data = {
             "NetworkACL": "VpcVirtualRouter",
         },
         "serviceCapabilityList": {
-            "SourceNat": { "SupportedSourceNatTypes": "peraccount" },
-            "Lb": { "lbSchemes": "internal", "SupportedLbIsolation": "dedicated" }
+            "SourceNat": {"SupportedSourceNatTypes": "peraccount"},
+            "Lb": {"lbSchemes": "internal", "SupportedLbIsolation": "dedicated"}
         }
     },
     "egress_80": {
@@ -1638,20 +1638,20 @@ test_data = {
             "iscsi://192.168.100.21/iqn.2012-01.localdomain.clo-cstack-cos6:iser/1",
         "name": "Primary iSCSI"
     },
-    "volume": { "diskname": "Test Volume",
-                "size": 1
-                },
+    "volume": {"diskname": "Test Volume",
+               "size": 1
+               },
     "volume_write_path": {
         "diskname": "APP Data Volume",
         "size": 1,  # in GBs
-        "xenserver": { "rootdiskdevice": "/dev/xvda",
-                       "datadiskdevice_1": "/dev/xvdb",
-                       "datadiskdevice_2": "/dev/xvdc",  # Data Disk
-                       },
-        "kvm": { "rootdiskdevice": "/dev/vda",
-                 "datadiskdevice_1": "/dev/vdb",
-                 "datadiskdevice_2": "/dev/vdc"
-                 }
+        "xenserver": {"rootdiskdevice": "/dev/xvda",
+                      "datadiskdevice_1": "/dev/xvdb",
+                      "datadiskdevice_2": "/dev/xvdc",  # Data Disk
+                      },
+        "kvm": {"rootdiskdevice": "/dev/vda",
+                "datadiskdevice_1": "/dev/vdb",
+                "datadiskdevice_2": "/dev/vdc"
+                }
     },
     "data_write_paths": {
         "mount_dir": "/mnt/tmp",
@@ -1665,7 +1665,7 @@ test_data = {
         "diskname": "Custom disk",
     },
     "volume_offerings": {
-        0: { "diskname": "TestDiskServ" },
+        0: {"diskname": "TestDiskServ"},
     },
     "diskdevice": ["/dev/vdc", "/dev/vdb", "/dev/hdb", "/dev/hdc",
                    "/dev/xvdd", "/dev/cdrom", "/dev/sr0", "/dev/cdrom1"],

--- a/cosmic-model/src/main/java/com/cloud/legacymodel/to/NetworkOverviewTO.java
+++ b/cosmic-model/src/main/java/com/cloud/legacymodel/to/NetworkOverviewTO.java
@@ -1,10 +1,13 @@
 package com.cloud.legacymodel.to;
 
 import com.cloud.legacymodel.network.Network;
+import com.cloud.legacymodel.utils.Pair;
 import com.cloud.model.enumeration.GuestType;
 import com.cloud.model.enumeration.TrafficType;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Objects;
 
 public class NetworkOverviewTO {
@@ -13,6 +16,7 @@ public class NetworkOverviewTO {
     private RouteTO[] routes;
     private VPNTO vpn;
     private SyslogTO syslog;
+    private LoadBalancerTO loadbalancer;
 
     public InterfaceTO[] getInterfaces() {
         return interfaces;
@@ -54,6 +58,14 @@ public class NetworkOverviewTO {
         this.syslog = syslog;
     }
 
+    public LoadBalancerTO getLoadbalancer() {
+        return loadbalancer;
+    }
+
+    public void setLoadbalancer(final LoadBalancerTO loadbalancer) {
+        this.loadbalancer = loadbalancer;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -65,12 +77,20 @@ public class NetworkOverviewTO {
         final NetworkOverviewTO that = (NetworkOverviewTO) o;
         return Arrays.equals(getInterfaces(), that.getInterfaces()) &&
                 Objects.equals(getServices(), that.getServices()) &&
-                Arrays.equals(getRoutes(), that.getRoutes());
+                Arrays.equals(getRoutes(), that.getRoutes()) &&
+                Objects.equals(getVpn(), that.getVpn()) &&
+                Objects.equals(getSyslog(), that.getSyslog()) &&
+                Objects.equals(getLoadbalancer(), that.getLoadbalancer());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getInterfaces(), getServices(), getRoutes());
+        return Objects.hash(getInterfaces(),
+                getServices(),
+                getRoutes(),
+                getVpn(),
+                getSyslog(),
+                getLoadbalancer());
     }
 
     public static class InterfaceTO {
@@ -756,6 +776,137 @@ public class NetworkOverviewTO {
 
         public void setServers(final String[] servers) {
             this.servers = servers;
+        }
+    }
+
+    public static class LoadBalancerTO {
+        public String lbStatsVisibility = "guest-network";
+        public String lbStatsPublicIp;
+        public String lbStatsPrivateIp;
+        public String lbStatsGuestIp;
+        public String lbStatsPort = "8081";
+        public String lbStatsSrcCidrs = "0/0";
+        public String lbStatsAuth = "admin1:AdMiN123";
+        public String lbStatsUri = "/admin?stats";
+        public String maxconn = "";
+        public String lbProtocol;
+        public boolean keepAliveEnabled = false;
+        LoadBalancersTO[] loadBalancers;
+
+        public void setLbStatsVisibility(final String lbStatsVisibility) {
+            this.lbStatsVisibility = lbStatsVisibility;
+        }
+
+        public void setLbStatsPublicIp(final String lbStatsPublicIp) {
+            this.lbStatsPublicIp = lbStatsPublicIp;
+        }
+
+        public void setLbStatsPrivateIp(final String lbStatsPrivateIp) {
+            this.lbStatsPrivateIp = lbStatsPrivateIp;
+        }
+
+        public void setLbStatsGuestIp(final String lbStatsGuestIp) {
+            this.lbStatsGuestIp = lbStatsGuestIp;
+        }
+
+        public void setLbStatsPort(final String lbStatsPort) {
+            this.lbStatsPort = lbStatsPort;
+        }
+
+        public void setLbStatsSrcCidrs(final String lbStatsSrcCidrs) {
+            this.lbStatsSrcCidrs = lbStatsSrcCidrs;
+        }
+
+        public void setLbStatsAuth(final String lbStatsAuth) {
+            this.lbStatsAuth = lbStatsAuth;
+        }
+
+        public void setLbStatsUri(final String lbStatsUri) {
+            this.lbStatsUri = lbStatsUri;
+        }
+
+        public void setMaxconn(final String maxconn) {
+            this.maxconn = maxconn;
+        }
+
+        public String getLbProtocol() {
+            return lbProtocol;
+        }
+
+        public void setLbProtocol(final String lbProtocol) {
+            this.lbProtocol = lbProtocol;
+        }
+
+        public boolean isKeepAliveEnabled() {
+            return keepAliveEnabled;
+        }
+
+        public void setKeepAliveEnabled(final boolean keepAliveEnabled) {
+            this.keepAliveEnabled = keepAliveEnabled;
+        }
+
+        public void setLoadBalancers(final LoadBalancersTO[] loadBalancers) {
+            this.loadBalancers = loadBalancers;
+        }
+
+        public static class StickinessPolicy {
+            private String methodName;
+            private HashMap<String, String> paramList;
+
+            public StickinessPolicy(final String methodName, final HashMap<String, String> paramList) {
+                this.methodName = methodName;
+                this.paramList = paramList;
+            }
+
+            public StickinessPolicy(final String methodName, final List<Pair<String, String>> paramList) {
+                this.methodName = methodName;
+                if (paramList.size() > 0) {
+                    this.paramList = new HashMap<>();
+                    for (Pair<String, String> param : paramList) {
+                        this.paramList.put(param.first().replace("-", "_"), param.second());
+                    }
+                }
+            }
+        }
+
+        public static class LBDestinations {
+            String destIp;
+            int destPort;
+
+            public LBDestinations(final String destIp, final int destPort) {
+                this.destIp = destIp;
+                this.destPort = destPort;
+            }
+        }
+
+        public static class LoadBalancersTO {
+            String uuid;
+            String name;
+            String srcIp;
+            int srcPort;
+            String protocol;
+            String lbProtocol;
+            String algorithm;
+            LBDestinations[] destinations;
+            StickinessPolicy stickinessPolicies;
+            int clientTimeout;
+            int serverTimeout;
+
+            public LoadBalancersTO(final String uuid, final String name, final String srcIp, final int srcPort, final String protocol, final String lbProtocol,
+                                   final String algorithm, final List<LBDestinations> destinations, final StickinessPolicy stickinessPolicies, final int clientTimeout,
+                                   final int serverTimeout) {
+                this.uuid = uuid;
+                this.name = name;
+                this.srcIp = srcIp;
+                this.srcPort = srcPort;
+                this.protocol = protocol;
+                this.lbProtocol = lbProtocol;
+                this.algorithm = algorithm;
+                this.destinations = destinations.toArray(new LBDestinations[0]);
+                this.stickinessPolicies = stickinessPolicies;
+                this.clientTimeout = clientTimeout;
+                this.serverTimeout = serverTimeout;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR will make it possible to create loadbalancing rules between different tiers. In the previous version the last added rule to a different tier overwrote the complete haproxy config file with only the changes for the modified tier. 