### PR TITLE
Extend updateVolume to allow name changes

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/storage.js
+++ b/cosmic-client/src/main/webapp/scripts/storage.js
@@ -928,6 +928,10 @@
                                     title: 'label.action.edit.disk',
                                     desc: 'label.action.edit.disk',
                                     fields: {
+                                        name: {
+                                            label: 'label.name',
+                                            defaultValue: function(args) { return args.volumes[0].name }
+                                        },
                                         diskController: {
                                             label: 'label.disk.controller',
                                             docID: 'helpDiskController',
@@ -956,7 +960,8 @@
                                 action: function (args) {
                                     var data = {
                                         id: args.context.volumes[0].id,
-                                        diskcontroller: args.data.diskController
+                                        diskcontroller: args.data.diskController,
+                                        name: args.data.name
                                     };
 
                                     $.ajax({

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/UpdateVolumeCmdByAdmin.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/admin/volume/UpdateVolumeCmdByAdmin.java
@@ -18,8 +18,8 @@ public class UpdateVolumeCmdByAdmin extends UpdateVolumeCmd {
     @Override
     public void execute() {
         CallContext.current().setEventDetails("Volume Id: " + getId());
-        final Volume result = _volumeService.updateVolume(getId(), getPath(), getState(), getStorageId(), getDisplayVolume(),
-                getCustomId(), getEntityOwnerId(), getChainInfo(), getDiskController());
+        final Volume result = _volumeService.updateVolume(getId(), getVolumeName(), getPath(), getState(), getStorageId(),
+                getDisplayVolume(), getCustomId(), getEntityOwnerId(), getChainInfo(), getDiskController());
         if (result != null) {
             final VolumeResponse response = _responseGenerator.createVolumeResponse(ResponseView.Full, result);
             response.setResponseName(getCommandName());

--- a/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/UpdateVolumeCmd.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/command/user/volume/UpdateVolumeCmd.java
@@ -68,6 +68,12 @@ public class UpdateVolumeCmd extends BaseAsyncCustomIdCmd {
             description = "the disk controller to use. Either 'IDE', 'VIRTIO' or 'SCSI'")
     private String diskController;
 
+    @Parameter(name = ApiConstants.NAME,
+            required = false,
+            type = CommandType.STRING,
+            description = "the name of the disk volume")
+    private String volumeName;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -91,6 +97,11 @@ public class UpdateVolumeCmd extends BaseAsyncCustomIdCmd {
         if (getState() != null) {
             desc.append(", state " + getState());
         }
+
+        if (getVolumeName() != null) {
+            desc.append(", name " + getVolumeName());
+        }
+
         return desc.toString();
     }
 
@@ -111,6 +122,10 @@ public class UpdateVolumeCmd extends BaseAsyncCustomIdCmd {
     public String getPath() {
         return path;
     }
+
+    public String getVolumeName() {
+        return volumeName;
+    }
     /////////////////////////////////////////////////////
     /////////////// API Implementation///////////////////
     /////////////////////////////////////////////////////
@@ -126,8 +141,8 @@ public class UpdateVolumeCmd extends BaseAsyncCustomIdCmd {
     @Override
     public void execute() {
         CallContext.current().setEventDetails("Volume Id: " + getId());
-        final Volume result = _volumeService.updateVolume(getId(), getPath(), getState(), getStorageId(), getDisplayVolume(),
-                getCustomId(), getEntityOwnerId(), getChainInfo(), getDiskController());
+        final Volume result = _volumeService.updateVolume(getId(), getVolumeName(), getPath(), getState(), getStorageId(),
+                getDisplayVolume(), getCustomId(), getEntityOwnerId(), getChainInfo(), getDiskController());
         if (result != null) {
             final VolumeResponse response = _responseGenerator.createVolumeResponse(ResponseView.Restricted, result);
             response.setResponseName(getCommandName());

--- a/cosmic-core/api/src/main/java/com/cloud/storage/VolumeApiService.java
+++ b/cosmic-core/api/src/main/java/com/cloud/storage/VolumeApiService.java
@@ -67,7 +67,7 @@ public interface VolumeApiService {
 
     Snapshot allocSnapshot(Long volumeId, Long policyId, String snapshotName) throws ResourceAllocationException;
 
-    Volume updateVolume(long volumeId, String path, String state, Long storageId, Boolean displayVolume, String customId, long owner, String chainInfo, DiskControllerType diskControllerType);
+    Volume updateVolume(long volumeId, String name, String path, String state, Long storageId, Boolean displayVolume, String customId, long owner, String chainInfo, DiskControllerType diskControllerType);
 
     /**
      * Extracts the volume to a particular location.

--- a/cosmic-core/api/src/test/java/com/cloud/api/command/user/volume/UpdateVolumeCmdTest.java
+++ b/cosmic-core/api/src/test/java/com/cloud/api/command/user/volume/UpdateVolumeCmdTest.java
@@ -1,0 +1,63 @@
+package com.cloud.api.command.user.volume;
+
+import com.cloud.api.ResponseGenerator;
+import com.cloud.api.ResponseObject;
+import com.cloud.api.ServerApiException;
+import com.cloud.api.response.VolumeResponse;
+import com.cloud.legacymodel.storage.Volume;
+import com.cloud.model.enumeration.DiskControllerType;
+import com.cloud.storage.VolumeApiService;
+import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class UpdateVolumeCmdTest {
+
+    private VolumeApiService volumeService;
+    private ResponseGenerator responseGenerator;
+    private UpdateVolumeCmd updateVolumeCmd;
+
+    @Before
+    public void setUp() {
+        volumeService = Mockito.mock(VolumeApiService.class);
+        responseGenerator = Mockito.mock(ResponseGenerator.class);
+        updateVolumeCmd = new UpdateVolumeCmd() {
+            @Override
+            public Long getId() {
+                return 1L;
+            }
+        };
+    }
+
+    @Test
+    public void testUpdateSuccess() {
+        final Volume volume = Mockito.mock(Volume.class);
+
+        updateVolumeCmd._volumeService = volumeService;
+        updateVolumeCmd._responseGenerator = responseGenerator;
+
+        Mockito.when(volume.getAccountId()).thenReturn(1L);
+        Mockito.when(responseGenerator.findVolumeById(Mockito.anyLong())).thenReturn(volume);
+        Mockito.when(volumeService.updateVolume(Mockito.eq(1L), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyLong(), Mockito.anyBoolean(), Mockito.anyString(), Mockito.eq(1L), Mockito.anyString(), Mockito.any(DiskControllerType.class))).thenReturn(volume);
+
+        final VolumeResponse response = new VolumeResponse();
+        Mockito.when(responseGenerator.createVolumeResponse(ResponseObject.ResponseView.Restricted, volume)).thenReturn(response);
+
+        updateVolumeCmd.execute();
+    }
+
+    @Test(expected = ServerApiException.class)
+    public void testUpdateFailure() {
+        final Volume volume = Mockito.mock(Volume.class);
+
+        updateVolumeCmd._volumeService = volumeService;
+        updateVolumeCmd._responseGenerator = responseGenerator;
+
+        Mockito.when(volume.getAccountId()).thenReturn(1L);
+        Mockito.when(responseGenerator.findVolumeById(Mockito.anyLong())).thenReturn(volume);
+        Mockito.when(volumeService.updateVolume(Mockito.eq(1L), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyLong(), Mockito.anyBoolean(), Mockito.anyString(), Mockito.eq(1L), Mockito.anyString(), Mockito.any(DiskControllerType.class))).thenReturn(null);
+
+        updateVolumeCmd.execute();
+    }
+}

--- a/cosmic-core/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2470,7 +2470,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_VOLUME_UPDATE, eventDescription = "updating volume", async = true)
-    public Volume updateVolume(final long volumeId, final String path, final String state, final Long storageId, final Boolean displayVolume, final String customId, final long
+    public Volume updateVolume(final long volumeId, final String name, final String path, final String state, final Long storageId, final Boolean displayVolume, final String customId, final long
             entityOwnerId, final String chainInfo, final DiskControllerType diskControllerType) {
 
         final VolumeVO volume = this._volsDao.findById(volumeId);
@@ -2485,6 +2485,10 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
         if (volume == null) {
             throw new InvalidParameterValueException("The volume id doesn't exist");
+        }
+
+        if (name != null) {
+            volume.setName(name);
         }
 
         if (path != null) {

--- a/cosmic-core/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
+++ b/cosmic-core/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
@@ -395,6 +395,12 @@ public class VolumeApiServiceImplTest {
         }
     }
 
+    @Test
+    public void testUpdateVolume() {
+        _svc.updateVolume(2L, "toor", null, null, null, null, null, 1L, null, null);
+        Assert.assertEquals("toor", _svc._volsDao.findById(2L).getName());
+    }
+
     @After
     public void tearDown() {
         CallContext.unregister();


### PR DESCRIPTION
Adds `name` as a parameter to the `updateVolume` API call, which allows name changes.

Also added the name field to the edit volume dialog of the UI.

Resolves #866.