### PR TITLE
Fix 'Multiple JSON fields' bug

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/response/AsyncJobResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/AsyncJobResponse.java
@@ -13,9 +13,9 @@ import com.google.gson.annotations.SerializedName;
 
 @EntityReference(value = JobInfo.class)
 public class AsyncJobResponse extends BaseResponse {
-    @SerializedName(ApiConstants.JOB_STATUS)
-    @Param(description = "The current status of the latest async job acting on this object, should be 0 for PENDING")
-    private Integer jobStatus;
+    //    @SerializedName(ApiConstants.JOB_STATUS)
+    //    @Param(description = "The current status of the latest async job acting on this object, should be 0 for PENDING")
+    //    private Integer jobStatus;
 
     @SerializedName("accountid")
     @Param(description = "the account that executed the async command")
@@ -69,10 +69,10 @@ public class AsyncJobResponse extends BaseResponse {
         this.cmd = cmd;
     }
 
-    @Override
-    public void setJobStatus(final Integer jobStatus) {
-        this.jobStatus = jobStatus;
-    }
+    //    @Override
+    //    public void setJobStatus(final Integer jobStatus) {
+    //        this.jobStatus = jobStatus;
+    //    }
 
     public void setJobProcStatus(final Integer jobProcStatus) {
         this.jobProcStatus = jobProcStatus;

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/AsyncJobResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/AsyncJobResponse.java
@@ -13,9 +13,6 @@ import com.google.gson.annotations.SerializedName;
 
 @EntityReference(value = JobInfo.class)
 public class AsyncJobResponse extends BaseResponse {
-    //    @SerializedName(ApiConstants.JOB_STATUS)
-    //    @Param(description = "The current status of the latest async job acting on this object, should be 0 for PENDING")
-    //    private Integer jobStatus;
 
     @SerializedName("accountid")
     @Param(description = "the account that executed the async command")
@@ -68,12 +65,7 @@ public class AsyncJobResponse extends BaseResponse {
     public void setCmd(final String cmd) {
         this.cmd = cmd;
     }
-
-    //    @Override
-    //    public void setJobStatus(final Integer jobStatus) {
-    //        this.jobStatus = jobStatus;
-    //    }
-
+    
     public void setJobProcStatus(final Integer jobProcStatus) {
         this.jobProcStatus = jobProcStatus;
     }

--- a/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseGsonHelper.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/ApiResponseGsonHelper.java
@@ -21,15 +21,13 @@ public class ApiResponseGsonHelper {
         s_gBuilder.setVersion(1.3);
         s_gBuilder.registerTypeAdapter(ResponseObject.class, new ResponseObjectTypeAdapter());
         s_gBuilder.registerTypeAdapter(String.class, new EncodedStringTypeAdapter());
-        s_gBuilder.setExclusionStrategies(new SuperclassExclusionStrategy());
-        s_gBuilder.setExclusionStrategies(new ApiResponseExclusionStrategy());
+        s_gBuilder.setExclusionStrategies(new SuperclassExclusionStrategy(), new ApiResponseExclusionStrategy());
 
         s_gLogBuilder = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
         s_gLogBuilder.setVersion(1.3);
         s_gLogBuilder.registerTypeAdapter(ResponseObject.class, new ResponseObjectTypeAdapter());
         s_gLogBuilder.registerTypeAdapter(String.class, new EncodedStringTypeAdapter());
-        s_gLogBuilder.setExclusionStrategies(new SuperclassExclusionStrategy());
-        s_gLogBuilder.setExclusionStrategies(new LogExclusionStrategy());
+        s_gLogBuilder.setExclusionStrategies(new SuperclassExclusionStrategy(), new LogExclusionStrategy());
     }
 
     public static GsonBuilder getBuilder() {


### PR DESCRIPTION
Remove unused fields in `AsyncJobResponse` which causes the `Multiple JSON fields` exceptions.