### PR TITLE
Fix downloading templates in multiple zones

### DIFF
--- a/cosmic-core/engine/schema/src/main/java/com/cloud/storage/dao/VMTemplateDao.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/storage/dao/VMTemplateDao.java
@@ -54,7 +54,7 @@ public interface VMTemplateDao extends GenericDao<VMTemplateVO, Long>, StateDao<
 
     VMTemplateVO findSystemVMReadyTemplate(long zoneId, HypervisorType hypervisorType);
 
-    VMTemplateVO findRoutingTemplate(HypervisorType type, String templateName);
+    VMTemplateVO findRoutingTemplate(HypervisorType type, String templateName, long zoneId);
 
     List<Long> listPrivateTemplatesByHost(Long hostId);
 

--- a/cosmic-core/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
@@ -975,7 +975,7 @@ public class ConsoleProxyManagerImpl extends SystemVmManagerBase implements Cons
 
         final HypervisorType availableHypervisor = this._resourceMgr.getAvailableHypervisor(dataCenterId);
         final String templateName = retrieveTemplateName(dataCenterId);
-        final VMTemplateVO template = this._templateDao.findRoutingTemplate(availableHypervisor, templateName);
+        final VMTemplateVO template = this._templateDao.findRoutingTemplate(availableHypervisor, templateName, dataCenterId);
 
         if (template == null) {
             throw new CloudRuntimeException("Not able to find the System templates or not downloaded in zone " + dataCenterId);
@@ -1163,7 +1163,8 @@ public class ConsoleProxyManagerImpl extends SystemVmManagerBase implements Cons
             Transaction.execute(new TransactionCallbackNoReturn() {
                 @Override
                 public void doInTransactionWithoutResult(final TransactionStatus status) {
-                    ConsoleProxyManagerImpl.this._configDao.update(Config.ConsoleProxyManagementLastState.key(), Config.ConsoleProxyManagementLastState.getCategory(), lastState.toString());
+                    ConsoleProxyManagerImpl.this._configDao.update(Config.ConsoleProxyManagementLastState.key(), Config.ConsoleProxyManagementLastState.getCategory(),
+                            lastState.toString());
                     ConsoleProxyManagerImpl.this._configDao.update(Config.ConsoleProxyManagementState.key(), Config.ConsoleProxyManagementState.getCategory(), state.toString());
                 }
             });

--- a/cosmic-core/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
@@ -63,7 +63,6 @@ import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.VMTemplateDao;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.user.AccountManager;
-import com.cloud.user.AccountVO;
 import com.cloud.user.UserVO;
 import com.cloud.user.dao.UserDao;
 import com.cloud.utils.maint.Version;
@@ -543,7 +542,7 @@ public class NetworkHelperImpl implements NetworkHelper {
                 logger.debug(String.format("Allocating the VR with id=%s in datacenter %s with the hypervisor type %s", id, routerDeploymentDefinition.getDest().getZone(), hType));
 
                 final String templateName = retrieveTemplateName(hType, routerDeploymentDefinition.getDest().getZone().getId());
-                final VMTemplateVO template = _templateDao.findRoutingTemplate(hType, templateName);
+                final VMTemplateVO template = _templateDao.findRoutingTemplate(hType, templateName, routerDeploymentDefinition.getDest().getZone().getId());
 
                 if (template == null) {
                     logger.debug(hType + " won't support system vm, skip it");
@@ -567,7 +566,8 @@ public class NetworkHelperImpl implements NetworkHelper {
                 router = new DomainRouterVO(id, routerOffering.getId(), routerDeploymentDefinition.getVirtualProvider().getId(), VirtualMachineName.getRouterName(id,
                         s_vmInstanceName), template.getId(), template.getHypervisorType(), template.getGuestOSId(), owner.getDomainId(), owner.getId(),
                         userId, routerDeploymentDefinition.isRedundant(), RedundantState.UNKNOWN, offerHA, false, vpcId,
-                        template.getOptimiseFor(), template.getManufacturerString(), template.getCpuFlags(), template.getMacLearning(), false, template.getMaintenancePolicy(), routerUnicastId);
+                        template.getOptimiseFor(), template.getManufacturerString(), template.getCpuFlags(), template.getMacLearning(), false, template.getMaintenancePolicy(),
+                        routerUnicastId);
 
                 router.setDynamicallyScalable(template.isDynamicallyScalable());
                 router.setRole(Role.VIRTUAL_ROUTER);

--- a/cosmic-core/server/src/main/java/com/cloud/storage/secondary/SecondaryStorageManagerImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/storage/secondary/SecondaryStorageManagerImpl.java
@@ -1124,7 +1124,7 @@ public class SecondaryStorageManagerImpl extends SystemVmManagerBase implements 
 
         final HypervisorType availableHypervisor = this._resourceMgr.getAvailableHypervisor(dataCenterId);
         final String templateName = retrieveTemplateName(dataCenterId);
-        final VMTemplateVO template = this._templateDao.findRoutingTemplate(availableHypervisor, templateName);
+        final VMTemplateVO template = this._templateDao.findRoutingTemplate(availableHypervisor, templateName, dataCenterId);
 
         if (template == null) {
             throw new CloudRuntimeException("Not able to find the System templates or not downloaded in zone " + dataCenterId);


### PR DESCRIPTION
This fix will query the systemvm not only by name which causes the following error:
```
2020-07-24 10:14:36.517 WARN  [c.c.alerts] (logid: bce6ceb8) (ctx: 9c790d24)  alertType:: 19 // dataCenterId:: 1 // podId:: null // clusterId:: null // message:: Secondary Storage Vm creation failure. zone: MCCT-SHARED-1, error details: Template 272 has not been completely downloaded to zone 1
```
but will also do an inner join on the table `template_zone_ref` to get the correct uuid of the template.