### PR TITLE
Fix/template downloads new secstorvm

### DIFF
--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/secondarystorage/NfsSecondaryStorageResource.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/secondarystorage/NfsSecondaryStorageResource.java
@@ -365,7 +365,7 @@ public class NfsSecondaryStorageResource extends AgentResourceBase implements Se
                 ) {
                     // KVM didn't change template unique name, just used the template name passed from orchestration layer, so no need
                     // to send template name back.
-                    bufferWriter.write("uniquename=" + destData.getName());
+                    bufferWriter.write("uniquename=" + destData.getUniqueName());
                     bufferWriter.write("\n");
                     bufferWriter.write("filename=" + fileName);
                     bufferWriter.write("\n");

--- a/cosmic-core/engine/storage/default/src/main/java/com/cloud/storage/image/TemplateServiceImpl.java
+++ b/cosmic-core/engine/storage/default/src/main/java/com/cloud/storage/image/TemplateServiceImpl.java
@@ -139,6 +139,8 @@ public class TemplateServiceImpl implements TemplateService {
 
     @Override
     public void createTemplateAsync(final TemplateInfo template, final DataStore store, final AsyncCompletionCallback<TemplateApiResult> callback) {
+        // remove old template_store_ref entry
+        store.delete(template);
         // persist template_store_ref entry
         final TemplateObject templateOnStore = (TemplateObject) store.create(template);
         // update template_store_ref and template state

--- a/cosmic-core/engine/storage/default/src/main/java/com/cloud/storage/image/TemplateServiceImpl.java
+++ b/cosmic-core/engine/storage/default/src/main/java/com/cloud/storage/image/TemplateServiceImpl.java
@@ -139,8 +139,6 @@ public class TemplateServiceImpl implements TemplateService {
 
     @Override
     public void createTemplateAsync(final TemplateInfo template, final DataStore store, final AsyncCompletionCallback<TemplateApiResult> callback) {
-        // remove old template_store_ref entry
-        store.delete(template);
         // persist template_store_ref entry
         final TemplateObject templateOnStore = (TemplateObject) store.create(template);
         // update template_store_ref and template state

--- a/cosmic-core/engine/storage/default/src/main/java/com/cloud/storage/image/store/TemplateObject.java
+++ b/cosmic-core/engine/storage/default/src/main/java/com/cloud/storage/image/store/TemplateObject.java
@@ -404,12 +404,12 @@ public class TemplateObject implements TemplateInfo {
         }
         if (dataStore == null) {
             to = new TemplateObjectTO(this.getInstallPath(), this.getUrl(), this.getUuid(), this.getId(), this.getFormat(), this.getAccountId(), this.getChecksum(), this.getDisplayText(),
-                    dataStoreTO, this.getName(), null, null, null, this.getHypervisorType());
+                    dataStoreTO, this.getName(), this.getUniqueName(), null, null, null, this.getHypervisorType());
         } else {
             to = dataStore.getDriver().getTO(this);
             if (to == null) {
                 to = new TemplateObjectTO(this.getInstallPath(), this.getUrl(), this.getUuid(), this.getId(), this.getFormat(), this.getAccountId(), this.getChecksum(), this.getDisplayText(),
-                        dataStoreTO, this.getName(), null, null, null, this.getHypervisorType());
+                        dataStoreTO, this.getName(), this.getUniqueName(), null, null, null, this.getHypervisorType());
             }
         }
 

--- a/cosmic-model/src/main/java/com/cloud/legacymodel/communication/command/DownloadCommand.java
+++ b/cosmic-model/src/main/java/com/cloud/legacymodel/communication/command/DownloadCommand.java
@@ -54,7 +54,7 @@ public class DownloadCommand extends AbstractDownloadCommand implements Internal
 
     public DownloadCommand(final TemplateObjectTO template, final Long maxDownloadSizeInBytes) {
 
-        super(template.getName(), template.getOrigUrl(), template.getFormat(), template.getAccountId());
+        super(template.getUniqueName(), template.getOrigUrl(), template.getFormat(), template.getAccountId());
         _store = template.getDataStore();
         installPath = template.getPath();
         checksum = template.getChecksum();

--- a/cosmic-model/src/main/java/com/cloud/legacymodel/to/TemplateObjectTO.java
+++ b/cosmic-model/src/main/java/com/cloud/legacymodel/to/TemplateObjectTO.java
@@ -15,6 +15,7 @@ public class TemplateObjectTO implements DataTO {
     private String displayText;
     private DataStoreTO imageDataStore;
     private String name;
+    private String uniqueName;
     private String guestOsType;
     private Long size;
     private Long physicalSize;
@@ -25,7 +26,7 @@ public class TemplateObjectTO implements DataTO {
     }
 
     public TemplateObjectTO(final String path, final String origUrl, final String uuid, final long id, final ImageFormat format, final long accountId, final String checksum, final String
-            displayText, final DataStoreTO imageDataStore, final String name, final String guestOsType, final Long size, final Long physicalSize, final HypervisorType hypervisorType) {
+            displayText, final DataStoreTO imageDataStore, final String name, final String uniqueName, final String guestOsType, final Long size, final Long physicalSize, final HypervisorType hypervisorType) {
         this.path = path;
         this.origUrl = origUrl;
         this.uuid = uuid;
@@ -36,6 +37,7 @@ public class TemplateObjectTO implements DataTO {
         this.displayText = displayText;
         this.imageDataStore = imageDataStore;
         this.name = name;
+        this.uniqueName = uniqueName;
         this.guestOsType = guestOsType;
         this.size = size;
         this.physicalSize = physicalSize;
@@ -130,8 +132,16 @@ public class TemplateObjectTO implements DataTO {
         return name;
     }
 
+    public String getUniqueName() {
+        return uniqueName;
+    }
+
     public void setName(final String name) {
         this.name = name;
+    }
+
+    public void setUniqueName(final String uniqueName) {
+        this.uniqueName = uniqueName;
     }
 
     public String getOrigUrl() {


### PR DESCRIPTION
Fix for #889, I now correctly recognises existing templates, and removes records in the DB of previously existing and or failed downloads when attemping to download again.  

Before: 
```
#
#Mon Oct 05 07:34:42 GMT 2020
filename=6c545b64-5572-3546-93d7-275f534f95e8.qcow2
id=201
qcow2.size=2037579776
public=true
uniquename=centos
qcow2.virtualsize=8589934592
virtualsize=8589934592
checksum=f05daf6ed4c97c387cd6fdac6386d671
hvm=false
description=centos
qcow2=true
qcow2.filename=6c545b64-5572-3546-93d7-275f534f95e8.qcow2
size=2037579776
```
After:
```
#
#Mon Oct 05 08:47:59 GMT 2020
filename=e1a6da25-c7db-3e7a-b96f-49dc2c20dff0.qcow2
id=201
qcow2.size=2037579776
public=true
uniquename=201-2-f217520e-6dd3-3823-a4c2-56359ceccc0d
qcow2.virtualsize=8589934592
virtualsize=8589934592
checksum=f05daf6ed4c97c387cd6fdac6386d671
hvm=false
description=centos
qcow2=true
qcow2.filename=e1a6da25-c7db-3e7a-b96f-49dc2c20dff0.qcow2
size=2037579776
```