### PR TITLE
Display number of cores without HyperThreading

### DIFF
--- a/cosmic-core/api/src/main/java/com/cloud/api/response/HostForMigrationResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/HostForMigrationResponse.java
@@ -75,6 +75,10 @@ public class HostForMigrationResponse extends BaseResponse {
     @Param(description = "the CPU number of the host")
     private Integer cpuNumber;
 
+    @SerializedName("cpunumberht")
+    @Param(description = "the CPU number of the host including Hyper-Threading")
+    private Integer cpuNumberHyperThreading;
+
     @SerializedName("cpuallocated")
     @Param(description = "the amount of the host's CPU currently allocated")
     private String cpuAllocated;
@@ -283,6 +287,10 @@ public class HostForMigrationResponse extends BaseResponse {
 
     public void setCpuNumber(final Integer cpuNumber) {
         this.cpuNumber = cpuNumber;
+    }
+
+    public void setCpuNumberHyperThreading(Integer cpuNumberHyperThreading) {
+        this.cpuNumberHyperThreading = cpuNumberHyperThreading;
     }
 
     public String getCpuAllocated() {

--- a/cosmic-core/api/src/main/java/com/cloud/api/response/HostResponse.java
+++ b/cosmic-core/api/src/main/java/com/cloud/api/response/HostResponse.java
@@ -82,6 +82,10 @@ public class HostResponse extends BaseResponse {
     @Param(description = "the CPU number of the host")
     private Integer cpuNumber;
 
+    @SerializedName("cpunumberht")
+    @Param(description = "the CPU number of the host including Hyper-Threading")
+    private Integer cpuNumberHyperThreading;
+
     @SerializedName("cpuallocated")
     @Param(description = "the amount of the host's CPU currently allocated")
     private String cpuAllocated;
@@ -320,6 +324,10 @@ public class HostResponse extends BaseResponse {
 
     public void setCpuNumber(final Integer cpuNumber) {
         this.cpuNumber = cpuNumber;
+    }
+
+    public void setCpuNumberHyperThreading(Integer cpuNumberHyperThreading) {
+        this.cpuNumberHyperThreading = cpuNumberHyperThreading;
     }
 
     public String getCpuAllocated() {

--- a/cosmic-core/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
@@ -83,7 +83,8 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
         hostResponse.setCapabilities(host.getCapabilities());
         hostResponse.setClusterId(host.getClusterUuid());
         hostResponse.setCpuSockets(host.getCpuSockets());
-        hostResponse.setCpuNumber(host.getCpus());
+        hostResponse.setCpuNumber(host.getCpusWithoutHyperThreading());
+        hostResponse.setCpuNumberHyperThreading(host.getCpus());
         hostResponse.setZoneId(host.getZoneUuid());
         hostResponse.setDisconnectedOn(host.getDisconnectedOn());
         hostResponse.setHypervisor(host.getHypervisorType());
@@ -277,7 +278,8 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
         hostResponse.setId(host.getUuid());
         hostResponse.setCapabilities(host.getCapabilities());
         hostResponse.setClusterId(host.getClusterUuid());
-        hostResponse.setCpuNumber(host.getCpus());
+        hostResponse.setCpuNumber(host.getCpusWithoutHyperThreading());
+        hostResponse.setCpuNumberHyperThreading(host.getCpus());
         hostResponse.setZoneId(host.getZoneUuid());
         hostResponse.setDisconnectedOn(host.getDisconnectedOn());
         hostResponse.setHypervisor(host.getHypervisorType());

--- a/cosmic-core/server/src/main/java/com/cloud/api/query/vo/HostJoinVO.java
+++ b/cosmic-core/server/src/main/java/com/cloud/api/query/vo/HostJoinVO.java
@@ -4,9 +4,11 @@ import com.cloud.legacymodel.Identity;
 import com.cloud.legacymodel.InternalIdentity;
 import com.cloud.legacymodel.dc.Cluster;
 import com.cloud.legacymodel.dc.HostStatus;
+import com.cloud.legacymodel.exceptions.NoTransitionException;
 import com.cloud.legacymodel.resource.ResourceState;
 import com.cloud.model.enumeration.HostType;
 import com.cloud.model.enumeration.HypervisorType;
+import com.cloud.storage.Snapshot;
 import com.cloud.utils.db.GenericDao;
 
 import javax.persistence.Column;
@@ -373,6 +375,14 @@ public class HostJoinVO extends BaseViewVO implements InternalIdentity, Identity
 
     public Integer getCpus() {
         return cpus;
+    }
+
+    public Integer getCpusWithoutHyperThreading() {
+        try {
+            return cpus / 2;
+        } catch (final NullPointerException e) {
+            return cpus;
+        }
     }
 
     public long getTotalMemory() {


### PR DESCRIPTION
```    {
      "capabilities": "hvm,snapshot",
      "clusterid": "e2da6a3c-1eed-4788-be74-3f236257fe55",
      "clustername": "MCCT-KVM-1",
      "clustertype": "CloudManaged",
      "cpuallocated": "0.0%",
      "cpunumber": 6,
      "cpunumberht": 12,
      "cpusockets": 12,
      "cpuused": "0.65%",
      "cpuwithoverprovisioning": "12.0",
      "created": "2020-11-09T15:26:57+0100",
      "dedicated": false,
      "details": {
        "Host.OS": "CentOS",
        "Host.OS.Kernel.Version": "3.10.0-1127.19.1.el7.x86_64",
        "Host.OS.Version": "7.8.2003",
        "com.cloud.model.enumeration.RouterPrivateIpStrategy": "HostLocal"
      },
      "events": "HostDown; StartAgentRebalance; Remove; ShutdownRequested; AgentDisconnected; ManagementServerDown; PingTimeout; AgentConnected; Ping",
      "hahost": false,
      "hosttags": "KVM",
      "hypervisor": "KVM",
      "hypervisorversion": "CentOS 7.8.2003 with kernel 3.10.0-1127.19.1.el7.x86_64",
      "id": "bfb78487-7a37-4ac2-a556-10fc1d2d104c",
      "ipaddress": "192.168.22.22",
      "islocalstorageactive": false,
      "lastpinged": "1970-01-19T04:21:56+0100",
      "managementserverid": 90520732674657,
      "memoryallocated": 0,
      "memorytotal": 25017704448,
      "memoryused": 1377828864,
      "name": "kvm2",
      "networkkbsread": 2,
      "networkkbswrite": 0,
      "podid": "eb75f8eb-b13f-490e-a2fd-5c1db014ceb0",
      "podname": "MCCT-POD-1",
      "resourcestate": "Enabled",
      "state": "Up",
      "type": "Routing",
      "version": "6.9.4-SNAPSHOT",
      "zoneid": "1b11df74-75b9-4693-86d3-079d03a02636",
      "zonename": "MCCT-SHARED-1"
    }
```