### PR TITLE
Security fixes

### DIFF
--- a/cosmic-agent/src/main/java/com/cloud/agent/AgentApplication.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/AgentApplication.java
@@ -1,5 +1,7 @@
 package com.cloud.agent;
 
+import java.security.Security;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
@@ -10,7 +12,13 @@ import org.springframework.context.annotation.FilterType;
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.REGEX, pattern = "(?!com.cloud.agent.service).*")
         })
+
 public class AgentApplication {
+    static {
+        Security.setProperty("jdk.tls.disabledAlgorithms", "SSLv3, TLSv1, TLSv1.1");
+        Security.setProperty("jdk.tls.ephemeralDHKeySize", "2048");
+    }
+
     public static void main(final String[] args) {
         SpringApplication.run(AgentApplication.class, args);
     }

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxy.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxy.java
@@ -1,7 +1,11 @@
 package com.cloud.agent.resource.consoleproxy;
 
+import static com.cloud.utils.security.SecurityHeaders.addSecurityHeaders;
+
 import com.cloud.utils.PropertiesUtil;
 import com.google.gson.Gson;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
@@ -17,6 +21,7 @@ import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.security.Security;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.Properties;
@@ -222,13 +227,10 @@ public class ConsoleProxy {
         try {
             final Class<?> clz = Class.forName(factoryClzName);
             try {
-                final ConsoleProxyServerFactory factory = (ConsoleProxyServerFactory) clz.newInstance();
+                final ConsoleProxyServerFactory factory = (ConsoleProxyServerFactory) clz.getDeclaredConstructor().newInstance();
                 factory.init(ConsoleProxy.ksBits, ConsoleProxy.ksPassword);
                 return factory;
-            } catch (final InstantiationException e) {
-                s_logger.error(e.getMessage(), e);
-                return null;
-            } catch (final IllegalAccessException e) {
+            } catch (final InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
                 s_logger.error(e.getMessage(), e);
                 return null;
             }

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyAjaxHandler.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyAjaxHandler.java
@@ -1,6 +1,7 @@
 package com.cloud.agent.resource.consoleproxy;
 
 import static com.cloud.utils.AutoCloseableUtil.closeAutoCloseable;
+import static com.cloud.utils.security.SecurityHeaders.addSecurityHeaders;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -41,7 +42,7 @@ public class ConsoleProxyAjaxHandler implements HttpHandler {
         } catch (final IllegalArgumentException e) {
             s_logger.warn("Exception, ", e);
             final Headers hds = t.getResponseHeaders();
-            hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+            addSecurityHeaders(hds);
             t.sendResponseHeaders(400, -1);     // bad request
         } finally {
             t.close();
@@ -209,7 +210,7 @@ public class ConsoleProxyAjaxHandler implements HttpHandler {
     private void sendResponse(final HttpExchange t, final String contentType, final String response) throws IOException {
         final Headers hds = t.getResponseHeaders();
         hds.set("Content-Type", contentType);
-        hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+        addSecurityHeaders(hds);
 
         t.sendResponseHeaders(200, response.length());
         final OutputStream os = t.getResponseBody();
@@ -389,7 +390,7 @@ public class ConsoleProxyAjaxHandler implements HttpHandler {
     private void handleClientKickoff(final HttpExchange t, final ConsoleProxyClient viewer) throws IOException {
         final String response = viewer.onAjaxClientKickoff();
         final Headers hds = t.getResponseHeaders();
-        hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+        addSecurityHeaders(hds);
         t.sendResponseHeaders(200, response.length());
         final OutputStream os = t.getResponseBody();
         try {
@@ -407,7 +408,7 @@ public class ConsoleProxyAjaxHandler implements HttpHandler {
         hds.set("Content-Type", "text/html");
         hds.set("Cache-Control", "no-cache");
         hds.set("Cache-Control", "no-store");
-        hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+        addSecurityHeaders(hds);
         t.sendResponseHeaders(200, response.length());
 
         final OutputStream os = t.getResponseBody();
@@ -423,7 +424,7 @@ public class ConsoleProxyAjaxHandler implements HttpHandler {
 
         final Headers hds = t.getResponseHeaders();
         hds.set("Content-Type", "text/javascript");
-        hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+        addSecurityHeaders(hds);
         t.sendResponseHeaders(200, response.length());
 
         final OutputStream os = t.getResponseBody();

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyAjaxImageHandler.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyAjaxImageHandler.java
@@ -1,5 +1,7 @@
 package com.cloud.agent.resource.consoleproxy;
 
+import static com.cloud.utils.security.SecurityHeaders.addSecurityHeaders;
+
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
@@ -34,7 +36,7 @@ public class ConsoleProxyAjaxImageHandler implements HttpHandler {
         } catch (final IllegalArgumentException e) {
             s_logger.warn("Exception, ", e);
             final Headers hds = t.getResponseHeaders();
-            hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+            addSecurityHeaders(hds);
             t.sendResponseHeaders(400, -1);     // bad request
         } finally {
             t.close();
@@ -115,7 +117,7 @@ public class ConsoleProxyAjaxImageHandler implements HttpHandler {
             hds.set("Content-Type", "image/jpeg");
             hds.set("Cache-Control", "no-cache");
             hds.set("Cache-Control", "no-store");
-            hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+            addSecurityHeaders(hds);
             t.sendResponseHeaders(200, bs.length);
             final OutputStream os = t.getResponseBody();
             os.write(bs);
@@ -127,7 +129,7 @@ public class ConsoleProxyAjaxImageHandler implements HttpHandler {
             if (img != null) {
                 final Headers hds = t.getResponseHeaders();
                 hds.set("Content-Type", "image/jpeg");
-                hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+                addSecurityHeaders(hds);
                 t.sendResponseHeaders(200, img.length);
 
                 final OutputStream os = t.getResponseBody();
@@ -141,7 +143,7 @@ public class ConsoleProxyAjaxImageHandler implements HttpHandler {
                     s_logger.info("Image has already been swept out, key: " + key);
                 }
                 final Headers hds = t.getResponseHeaders();
-                hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+                addSecurityHeaders(hds);
                 t.sendResponseHeaders(404, -1);
             }
         }

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyClientBase.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyClientBase.java
@@ -1,8 +1,8 @@
 package com.cloud.agent.resource.consoleproxy;
 
-import com.cloud.consoleproxy.util.TileInfo;
-import com.cloud.consoleproxy.util.TileTracker;
-import com.cloud.consoleproxy.vnc.FrameBufferCanvas;
+import com.cloud.agent.resource.consoleproxy.util.TileInfo;
+import com.cloud.agent.resource.consoleproxy.util.TileTracker;
+import com.cloud.agent.resource.consoleproxy.vnc.FrameBufferCanvas;
 
 import java.awt.Image;
 import java.awt.Rectangle;
@@ -344,7 +344,7 @@ public abstract class ConsoleProxyClientBase implements ConsoleProxyClient, Cons
                         "<span id=\"light\" class=\"dark\" cmd=\"toggle_logwin\"></span>", "</div>", "<div id=\"main_panel\" tabindex=\"1\"></div>",
                         "<script language=\"javascript\">", "var acceptLanguages = '" + sbLanguages.toString() + "';", "var tileMap = [ " + tileSequence + " ];",
                         "var ajaxViewer = new AjaxViewer('main_panel', '" + imgUrl + "', '" + updateUrl + "', '" + locale + "', '" + guest + "', tileMap, ",
-                        String.valueOf(width) + ", " + String.valueOf(height) + ", " + String.valueOf(tileWidth) + ", " + String.valueOf(tileHeight) + ");",
+                        width + ", " + height + ", " + tileWidth + ", " + tileHeight + ");",
 
                         "$(function() {", "ajaxViewer.start();", "});",
 

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyCmdHandler.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyCmdHandler.java
@@ -1,5 +1,7 @@
 package com.cloud.agent.resource.consoleproxy;
 
+import static com.cloud.utils.security.SecurityHeaders.addSecurityHeaders;
+
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 
@@ -33,7 +35,7 @@ public class ConsoleProxyCmdHandler implements HttpHandler {
 
             final Headers hds = t.getResponseHeaders();
             hds.set("Content-Type", "text/plain");
-            hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+            addSecurityHeaders(hds);
             t.sendResponseHeaders(200, 0);
             final OutputStreamWriter os = new OutputStreamWriter(t.getResponseBody(), "UTF-8");
             statsCollector.getStatsReport(os);

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyResource.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyResource.java
@@ -15,8 +15,10 @@ import com.cloud.legacymodel.communication.command.PingCommand;
 import com.cloud.legacymodel.communication.command.ReadyCommand;
 import com.cloud.legacymodel.communication.command.StartConsoleProxyAgentHttpHandlerCommand;
 import com.cloud.legacymodel.communication.command.WatchConsoleProxyLoadCommand;
+import com.cloud.legacymodel.communication.command.agentcontrol.ConsoleProxyLoadReportCommand;
 import com.cloud.legacymodel.communication.command.startup.StartupCommand;
 import com.cloud.legacymodel.communication.command.startup.StartupProxyCommand;
+import com.cloud.legacymodel.exceptions.AgentControlChannelException;
 import com.cloud.model.enumeration.ExitStatus;
 import com.cloud.model.enumeration.HostType;
 import com.cloud.utils.NumbersUtil;
@@ -298,5 +300,22 @@ public class ConsoleProxyResource extends AgentResourceBase implements AgentReso
 
     @Override
     public void setName(final String name) {
+    }
+
+    public void reportLoadInfo(String gsonLoadInfo) {
+        ConsoleProxyLoadReportCommand cmd = new ConsoleProxyLoadReportCommand(_proxyVmId, gsonLoadInfo);
+        try {
+            getAgentControl().postRequest(cmd);
+
+            if (s_logger.isDebugEnabled())
+                s_logger.debug("Report proxy load info, proxy : " + _proxyVmId + ", load: " + gsonLoadInfo);
+        } catch (AgentControlChannelException e) {
+            s_logger.error("Unable to send out load info due to " + e.getMessage(), e);
+        }
+    }
+
+    public String ensureRoute(String address) {
+        // Unused
+        return null;
     }
 }

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyResourceHandler.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyResourceHandler.java
@@ -1,5 +1,7 @@
 package com.cloud.agent.resource.consoleproxy;
 
+import static com.cloud.utils.security.SecurityHeaders.addSecurityHeaders;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -81,7 +83,7 @@ public class ConsoleProxyResourceHandler implements HttpHandler {
                 s_logger.info("Resource access is forbidden, uri: " + path);
             }
             final Headers hds = t.getResponseHeaders();
-            hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+            addSecurityHeaders(hds);
             t.sendResponseHeaders(403, -1);     // forbidden
             return;
         }
@@ -95,7 +97,7 @@ public class ConsoleProxyResourceHandler implements HttpHandler {
                 if (d + 1000 >= lastModified) {
                     final Headers hds = t.getResponseHeaders();
                     hds.set("Content-Type", contentType);
-                    hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+                    addSecurityHeaders(hds);
                     t.sendResponseHeaders(304, -1);
 
                     if (s_logger.isInfoEnabled()) {
@@ -109,7 +111,7 @@ public class ConsoleProxyResourceHandler implements HttpHandler {
             final Headers hds = t.getResponseHeaders();
             hds.set("Content-Type", contentType);
             hds.set("Last-Modified", new Date(lastModified).toGMTString());
-            hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+            addSecurityHeaders(hds);
             t.sendResponseHeaders(200, length);
             responseFileContent(t, f);
 
@@ -121,7 +123,7 @@ public class ConsoleProxyResourceHandler implements HttpHandler {
                 s_logger.info("file does not exist" + path);
             }
             final Headers hds = t.getResponseHeaders();
-            hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+            addSecurityHeaders(hds);
             t.sendResponseHeaders(404, -1);
         }
     }

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyThumbnailHandler.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyThumbnailHandler.java
@@ -1,5 +1,7 @@
 package com.cloud.agent.resource.consoleproxy;
 
+import static com.cloud.utils.security.SecurityHeaders.addSecurityHeaders;
+
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.FontMetrics;
@@ -60,7 +62,7 @@ public class ConsoleProxyThumbnailHandler implements HttpHandler {
             final String response = "Bad query string";
             s_logger.error(response + ", request URI : " + t.getRequestURI());
             final Headers hds = t.getResponseHeaders();
-            hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+            addSecurityHeaders(hds);
             t.sendResponseHeaders(200, response.length());
             final OutputStream os = t.getResponseBody();
             os.write(response.getBytes());
@@ -122,7 +124,7 @@ public class ConsoleProxyThumbnailHandler implements HttpHandler {
             hds.set("Content-Type", "image/jpeg");
             hds.set("Cache-Control", "no-cache");
             hds.set("Cache-Control", "no-store");
-            hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+            addSecurityHeaders(hds);
             t.sendResponseHeaders(200, bs.length);
             final OutputStream os = t.getResponseBody();
             os.write(bs);
@@ -145,7 +147,7 @@ public class ConsoleProxyThumbnailHandler implements HttpHandler {
         hds.set("Content-Type", "image/jpeg");
         hds.set("Cache-Control", "no-cache");
         hds.set("Cache-Control", "no-store");
-        hds.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+        addSecurityHeaders(hds);
         t.sendResponseHeaders(200, bs.length);
         final OutputStream os = t.getResponseBody();
         os.write(bs);

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyVncClient.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/ConsoleProxyVncClient.java
@@ -1,8 +1,9 @@
 package com.cloud.agent.resource.consoleproxy;
 
-import com.cloud.consoleproxy.vnc.FrameBufferCanvas;
-import com.cloud.consoleproxy.vnc.RfbConstants;
-import com.cloud.consoleproxy.vnc.VncClient;
+import com.cloud.agent.resource.consoleproxy.vnc.VncClient;
+import com.cloud.agent.resource.consoleproxy.vnc.FrameBufferCanvas;
+import com.cloud.agent.resource.consoleproxy.vnc.RfbConstants;
+import com.cloud.agent.resource.consoleproxy.vnc.VncClient;
 
 import java.io.IOException;
 import java.net.URI;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/util/ITileScanListener.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/util/ITileScanListener.java
@@ -1,4 +1,4 @@
-package com.cloud.consoleproxy.util;
+package com.cloud.agent.resource.consoleproxy.util;
 
 import java.awt.Rectangle;
 import java.util.List;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/util/ImageHelper.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/util/ImageHelper.java
@@ -1,4 +1,4 @@
-package com.cloud.consoleproxy.util;
+package com.cloud.agent.resource.consoleproxy.util;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/util/RawHTTP.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/util/RawHTTP.java
@@ -1,4 +1,4 @@
-package com.cloud.consoleproxy.util;
+package com.cloud.agent.resource.consoleproxy.util;
 
 import com.cloud.utils.security.SSLUtils;
 import com.cloud.utils.security.SecureSSLSocketFactory;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/util/Region.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/util/Region.java
@@ -1,4 +1,4 @@
-package com.cloud.consoleproxy.util;
+package com.cloud.agent.resource.consoleproxy.util;
 
 import java.awt.Rectangle;
 import java.util.ArrayList;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/util/RegionClassifier.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/util/RegionClassifier.java
@@ -1,4 +1,4 @@
-package com.cloud.consoleproxy.util;
+package com.cloud.agent.resource.consoleproxy.util;
 
 import java.awt.Rectangle;
 import java.util.ArrayList;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/util/TileInfo.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/util/TileInfo.java
@@ -1,4 +1,4 @@
-package com.cloud.consoleproxy.util;
+package com.cloud.agent.resource.consoleproxy.util;
 
 import java.awt.Rectangle;
 

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/util/TileTracker.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/util/TileTracker.java
@@ -1,4 +1,4 @@
-package com.cloud.consoleproxy.util;
+package com.cloud.agent.resource.consoleproxy.util;
 
 import java.awt.Rectangle;
 import java.util.ArrayList;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/BufferedImageCanvas.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/BufferedImageCanvas.java
@@ -1,7 +1,7 @@
-package com.cloud.consoleproxy.vnc;
+package com.cloud.agent.resource.consoleproxy.vnc;
 
-import com.cloud.consoleproxy.util.ImageHelper;
-import com.cloud.consoleproxy.util.TileInfo;
+import com.cloud.agent.resource.consoleproxy.util.ImageHelper;
+import com.cloud.agent.resource.consoleproxy.util.TileInfo;
 
 import java.awt.Canvas;
 import java.awt.Color;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/FrameBufferCanvas.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/FrameBufferCanvas.java
@@ -1,6 +1,6 @@
-package com.cloud.consoleproxy.vnc;
+package com.cloud.agent.resource.consoleproxy.vnc;
 
-import com.cloud.consoleproxy.util.TileInfo;
+import com.cloud.agent.resource.consoleproxy.util.TileInfo;
 
 import java.awt.Image;
 import java.util.List;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/FrameBufferUpdateListener.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/FrameBufferUpdateListener.java
@@ -1,4 +1,4 @@
-package com.cloud.consoleproxy.vnc;
+package com.cloud.agent.resource.consoleproxy.vnc;
 
 public interface FrameBufferUpdateListener {
 

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/PaintNotificationListener.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/PaintNotificationListener.java
@@ -1,4 +1,4 @@
-package com.cloud.consoleproxy.vnc;
+package com.cloud.agent.resource.consoleproxy.vnc;
 
 public interface PaintNotificationListener {
 

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/RfbConstants.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/RfbConstants.java
@@ -1,4 +1,4 @@
-package com.cloud.consoleproxy.vnc;
+package com.cloud.agent.resource.consoleproxy.vnc;
 
 import java.nio.charset.Charset;
 

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/VncClient.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/VncClient.java
@@ -1,9 +1,9 @@
-package com.cloud.consoleproxy.vnc;
+package com.cloud.agent.resource.consoleproxy.vnc;
 
 import com.cloud.agent.resource.consoleproxy.ConsoleProxyClientListener;
-import com.cloud.consoleproxy.util.RawHTTP;
-import com.cloud.consoleproxy.vnc.packet.client.KeyboardEventPacket;
-import com.cloud.consoleproxy.vnc.packet.client.MouseEventPacket;
+import com.cloud.agent.resource.consoleproxy.util.RawHTTP;
+import com.cloud.agent.resource.consoleproxy.vnc.packet.client.KeyboardEventPacket;
+import com.cloud.agent.resource.consoleproxy.vnc.packet.client.MouseEventPacket;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/VncClientPacketSender.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/VncClientPacketSender.java
@@ -1,11 +1,11 @@
-package com.cloud.consoleproxy.vnc;
+package com.cloud.agent.resource.consoleproxy.vnc;
 
-import com.cloud.consoleproxy.vnc.packet.client.ClientPacket;
-import com.cloud.consoleproxy.vnc.packet.client.FramebufferUpdateRequestPacket;
-import com.cloud.consoleproxy.vnc.packet.client.KeyboardEventPacket;
-import com.cloud.consoleproxy.vnc.packet.client.MouseEventPacket;
-import com.cloud.consoleproxy.vnc.packet.client.SetEncodingsPacket;
-import com.cloud.consoleproxy.vnc.packet.client.SetPixelFormatPacket;
+import com.cloud.agent.resource.consoleproxy.vnc.packet.client.ClientPacket;
+import com.cloud.agent.resource.consoleproxy.vnc.packet.client.FramebufferUpdateRequestPacket;
+import com.cloud.agent.resource.consoleproxy.vnc.packet.client.KeyboardEventPacket;
+import com.cloud.agent.resource.consoleproxy.vnc.packet.client.MouseEventPacket;
+import com.cloud.agent.resource.consoleproxy.vnc.packet.client.SetEncodingsPacket;
+import com.cloud.agent.resource.consoleproxy.vnc.packet.client.SetPixelFormatPacket;
 
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/VncScreenDescription.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/VncScreenDescription.java
@@ -1,4 +1,4 @@
-package com.cloud.consoleproxy.vnc;
+package com.cloud.agent.resource.consoleproxy.vnc;
 
 /**
  * VncScreenDescription - contains information about remote VNC screen.

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/VncServerPacketReceiver.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/VncServerPacketReceiver.java
@@ -1,8 +1,8 @@
-package com.cloud.consoleproxy.vnc;
+package com.cloud.agent.resource.consoleproxy.vnc;
 
 import com.cloud.agent.resource.consoleproxy.ConsoleProxyClientListener;
-import com.cloud.consoleproxy.vnc.packet.server.FramebufferUpdatePacket;
-import com.cloud.consoleproxy.vnc.packet.server.ServerCutText;
+import com.cloud.agent.resource.consoleproxy.vnc.packet.server.FramebufferUpdatePacket;
+import com.cloud.agent.resource.consoleproxy.vnc.packet.server.ServerCutText;
 
 import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/client/ClientPacket.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/client/ClientPacket.java
@@ -1,4 +1,4 @@
-package com.cloud.consoleproxy.vnc.packet.client;
+package com.cloud.agent.resource.consoleproxy.vnc.packet.client;
 
 import java.io.DataOutputStream;
 import java.io.IOException;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/client/FramebufferUpdateRequestPacket.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/client/FramebufferUpdateRequestPacket.java
@@ -1,6 +1,6 @@
-package com.cloud.consoleproxy.vnc.packet.client;
+package com.cloud.agent.resource.consoleproxy.vnc.packet.client;
 
-import com.cloud.consoleproxy.vnc.RfbConstants;
+import com.cloud.agent.resource.consoleproxy.vnc.RfbConstants;
 
 import java.io.DataOutputStream;
 import java.io.IOException;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/client/KeyboardEventPacket.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/client/KeyboardEventPacket.java
@@ -1,6 +1,6 @@
-package com.cloud.consoleproxy.vnc.packet.client;
+package com.cloud.agent.resource.consoleproxy.vnc.packet.client;
 
-import com.cloud.consoleproxy.vnc.RfbConstants;
+import com.cloud.agent.resource.consoleproxy.vnc.RfbConstants;
 
 import java.io.DataOutputStream;
 import java.io.IOException;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/client/MouseEventPacket.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/client/MouseEventPacket.java
@@ -1,6 +1,6 @@
-package com.cloud.consoleproxy.vnc.packet.client;
+package com.cloud.agent.resource.consoleproxy.vnc.packet.client;
 
-import com.cloud.consoleproxy.vnc.RfbConstants;
+import com.cloud.agent.resource.consoleproxy.vnc.RfbConstants;
 
 import java.io.DataOutputStream;
 import java.io.IOException;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/client/SetEncodingsPacket.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/client/SetEncodingsPacket.java
@@ -1,6 +1,6 @@
-package com.cloud.consoleproxy.vnc.packet.client;
+package com.cloud.agent.resource.consoleproxy.vnc.packet.client;
 
-import com.cloud.consoleproxy.vnc.RfbConstants;
+import com.cloud.agent.resource.consoleproxy.vnc.RfbConstants;
 
 import java.io.DataOutputStream;
 import java.io.IOException;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/client/SetPixelFormatPacket.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/client/SetPixelFormatPacket.java
@@ -1,7 +1,7 @@
-package com.cloud.consoleproxy.vnc.packet.client;
+package com.cloud.agent.resource.consoleproxy.vnc.packet.client;
 
-import com.cloud.consoleproxy.vnc.RfbConstants;
-import com.cloud.consoleproxy.vnc.VncScreenDescription;
+import com.cloud.agent.resource.consoleproxy.vnc.RfbConstants;
+import com.cloud.agent.resource.consoleproxy.vnc.VncScreenDescription;
 
 import java.io.DataOutputStream;
 import java.io.IOException;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/server/AbstractRect.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/server/AbstractRect.java
@@ -1,4 +1,4 @@
-package com.cloud.consoleproxy.vnc.packet.server;
+package com.cloud.agent.resource.consoleproxy.vnc.packet.server;
 
 public abstract class AbstractRect implements Rect {
 

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/server/CopyRect.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/server/CopyRect.java
@@ -1,4 +1,4 @@
-package com.cloud.consoleproxy.vnc.packet.server;
+package com.cloud.agent.resource.consoleproxy.vnc.packet.server;
 
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/server/FrameBufferSizeChangeRequest.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/server/FrameBufferSizeChangeRequest.java
@@ -1,6 +1,6 @@
-package com.cloud.consoleproxy.vnc.packet.server;
+package com.cloud.agent.resource.consoleproxy.vnc.packet.server;
 
-import com.cloud.consoleproxy.vnc.BufferedImageCanvas;
+import com.cloud.agent.resource.consoleproxy.vnc.BufferedImageCanvas;
 
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/server/FramebufferUpdatePacket.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/server/FramebufferUpdatePacket.java
@@ -1,9 +1,9 @@
-package com.cloud.consoleproxy.vnc.packet.server;
+package com.cloud.agent.resource.consoleproxy.vnc.packet.server;
 
+import com.cloud.agent.resource.consoleproxy.vnc.BufferedImageCanvas;
+import com.cloud.agent.resource.consoleproxy.vnc.VncScreenDescription;
+import com.cloud.agent.resource.consoleproxy.vnc.RfbConstants;
 import com.cloud.agent.resource.consoleproxy.ConsoleProxyClientListener;
-import com.cloud.consoleproxy.vnc.BufferedImageCanvas;
-import com.cloud.consoleproxy.vnc.RfbConstants;
-import com.cloud.consoleproxy.vnc.VncScreenDescription;
 
 import java.io.DataInputStream;
 import java.io.IOException;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/server/RawRect.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/server/RawRect.java
@@ -1,6 +1,6 @@
-package com.cloud.consoleproxy.vnc.packet.server;
+package com.cloud.agent.resource.consoleproxy.vnc.packet.server;
 
-import com.cloud.consoleproxy.vnc.VncScreenDescription;
+import com.cloud.agent.resource.consoleproxy.vnc.VncScreenDescription;
 
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/server/Rect.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/server/Rect.java
@@ -1,4 +1,4 @@
-package com.cloud.consoleproxy.vnc.packet.server;
+package com.cloud.agent.resource.consoleproxy.vnc.packet.server;
 
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;

--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/server/ServerCutText.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/consoleproxy/vnc/packet/server/ServerCutText.java
@@ -1,6 +1,6 @@
-package com.cloud.consoleproxy.vnc.packet.server;
+package com.cloud.agent.resource.consoleproxy.vnc.packet.server;
 
-import com.cloud.consoleproxy.vnc.RfbConstants;
+import com.cloud.agent.resource.consoleproxy.vnc.RfbConstants;
 
 import java.io.DataInputStream;
 import java.io.IOException;

--- a/cosmic-common/pom.xml
+++ b/cosmic-common/pom.xml
@@ -122,6 +122,20 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/cosmic-common/src/main/java/com/cloud/utils/security/SSLUtils.java
+++ b/cosmic-common/src/main/java/com/cloud/utils/security/SSLUtils.java
@@ -16,12 +16,12 @@ public class SSLUtils {
     public static String[] getSupportedProtocols(final String[] protocols) {
         final Set<String> set = new HashSet<>();
         for (final String s : protocols) {
-            if (s.equals("SSLv3") || s.equals("SSLv2Hello")) {
+            if (s.equals("SSLv3") || s.equals("SSLv2Hello") || s.equals("TLSv1") || s.equals("TLSv1.1")) {
                 continue;
             }
             set.add(s);
         }
-        return (String[]) set.toArray(new String[set.size()]);
+        return set.toArray(new String[0]);
     }
 
     public static String[] getSupportedCiphers() throws NoSuchAlgorithmException {
@@ -31,22 +31,33 @@ public class SSLUtils {
     }
 
     public static SSLContext getSSLContext() throws NoSuchAlgorithmException {
-        return SSLContext.getInstance("TLSv1.2");
+        try {
+            return SSLContext.getInstance("TLSv1.3");
+        } catch (NoSuchAlgorithmException e) {
+            return SSLContext.getInstance("TLSv1.2");
+        }
     }
 
     public static SSLContext getSSLContext(final String provider) throws NoSuchAlgorithmException, NoSuchProviderException {
-        return SSLContext.getInstance("TLSv1.2", provider);
+        try {
+            return SSLContext.getInstance("TLSv1.3", provider);
+        } catch (NoSuchAlgorithmException e) {
+            return SSLContext.getInstance("TLSv1.2", provider);
+        }
     }
 
     public static String[] getRecommendedProtocols() {
-        return new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
+        return new String[] { "TLSv1.3", "TLSv1.2" };
     }
 
     public static String[] getRecommendedCiphers() {
-        return new String[] { "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
-                "TLS_RSA_WITH_AES_128_GCM_SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-                "TLS_DHE_RSA_WITH_AES_256_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
-                "TLS_RSA_WITH_AES_256_GCM_SHA384", "TLS_RSA_WITH_AES_256_CBC_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384" };
-
-        }
+        return new String[]{
+                "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+                "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"
+        };
+    }
 }

--- a/cosmic-common/src/main/java/com/cloud/utils/security/SecurityHeaders.java
+++ b/cosmic-common/src/main/java/com/cloud/utils/security/SecurityHeaders.java
@@ -1,0 +1,36 @@
+package com.cloud.utils.security;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.sun.net.httpserver.Headers;
+
+public class SecurityHeaders {
+    static Map<String, String> headers  = new HashMap<String, String>() {{
+        put("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+        put("X-XSS-Protection", "0");
+        put("Content-Security-Policy", "unsafe-inline");
+        put("X-Content-Type-Options", "nosniff");
+    }};
+
+    public static <T>void addSecurityHeaders(final T hds) {
+        if (hds instanceof Headers) {
+            headers.forEach(((Headers) hds)::set);
+        }
+        if (hds instanceof HttpServletResponse) {
+            headers.forEach((k, v) -> {
+                if (((HttpServletResponse) hds).containsHeader(k)) {
+                    ((HttpServletResponse) hds).setHeader(k, v);
+                } else {
+                    ((HttpServletResponse) hds).addHeader(k, v);
+                }
+            });
+        }
+    }
+
+    public static void addSecurityHeaders(final Headers hds, Map<String, String> addHeaders) {
+        addSecurityHeaders(hds);
+        addHeaders.forEach(hds::set);
+    }
+}

--- a/cosmic-core/server/src/main/java/com/cloud/servlet/ConsoleProxyServlet.java
+++ b/cosmic-core/server/src/main/java/com/cloud/servlet/ConsoleProxyServlet.java
@@ -1,5 +1,7 @@
 package com.cloud.servlet;
 
+import static com.cloud.utils.security.SecurityHeaders.addSecurityHeaders;
+
 import com.cloud.dao.EntityManager;
 import com.cloud.framework.security.keys.KeysManager;
 import com.cloud.host.HostVO;
@@ -188,7 +190,7 @@ public class ConsoleProxyServlet extends HttpServlet {
         String account = null;
         Account accountObj = null;
 
-        resp.addHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+        addSecurityHeaders(resp);
 
         final Map<String, Object[]> params = new HashMap<>();
         params.putAll(req.getParameterMap());
@@ -304,7 +306,7 @@ public class ConsoleProxyServlet extends HttpServlet {
         }
 
         try {
-            resp.addHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+            addSecurityHeaders(resp);
             resp.sendRedirect(composeThumbnailUrl(rootUrl, vm, host, w, h));
         } catch (final IOException e) {
             s_logger.info("Client may already close the connection", e);
@@ -499,7 +501,7 @@ public class ConsoleProxyServlet extends HttpServlet {
     private void sendResponse(final HttpServletResponse resp, final String content) {
         try {
             resp.setContentType("text/html");
-            resp.addHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+            addSecurityHeaders(resp);
             resp.getWriter().print(content);
         } catch (final IOException e) {
             s_logger.info("Client may already close the connection", e);


### PR DESCRIPTION
This PR fixes the following things:
- Security headers
- Ability to use Java 14
- Enable TLSv1.3 when Java > 9 is installed, otherwise fallback to TLSv1.2
- Rename package to folder structure