### PR TITLE
Remove SSL

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/setup_ssvm.py
+++ b/cosmic-core/systemvm/patches/centos7/opt/cosmic/startup/setup_ssvm.py
@@ -83,7 +83,6 @@ class SecondaryStorageVM:
         vhost = """
 server {
     listen       %s:80;
-    listen       %s:443 ssl;
     server_name  _;
     root         /var/www/html;
 
@@ -93,7 +92,7 @@ server {
         autoindex off;
     }
 }
-""" % (self.cmdline["publicip"], self.cmdline["publicip"])
+""" % (self.cmdline["publicip"])
 
         filename = "/etc/nginx/conf.d/vhost-%s.conf" % (self.cmdline["publicip"])
 


### PR DESCRIPTION
The `extractVolume` command doesn't work because we don't have SSL certificates installed. Remove ssl from the nginx config.