### PR TITLE
Fix 100% CPU bug in console proxy

### DIFF
--- a/cosmic-core/systemvm/patches/centos7/usr/lib/systemd/system/cosmic-agent.service
+++ b/cosmic-core/systemvm/patches/centos7/usr/lib/systemd/system/cosmic-agent.service
@@ -9,7 +9,7 @@ Environment=JAVA_HEAP_INITIAL=256m
 Environment=JAVA_HEAP_MAX=2048m
 WorkingDirectory=/opt/cosmic/agent/
 ExecStart=/bin/sh -ec '\
-    ${JAVA_HOME}/bin/java -Xms${JAVA_HEAP_INITIAL} -Xmx${JAVA_HEAP_MAX} ${JAVA_REMOTE_DEBUG} -jar /opt/cosmic/agent/cloud-agent-*.jar'
+    ${JAVA_HOME}/bin/java -Djdk.tls.acknowledgeCloseNotify=true -Xms${JAVA_HEAP_INITIAL} -Xmx${JAVA_HEAP_MAX} ${JAVA_REMOTE_DEBUG} -jar /opt/cosmic/agent/cloud-agent-*.jar'
 Restart=always
 RestartSec=10s
 SuccessExitStatus=143


### PR DESCRIPTION
This PR fixes a bug where the TLS sockets are kept open in a thread which will exhaust the CPU by not closing threads because it's still waiting for the TLS socket to be closed.  