### PR TITLE
Fix marvin error during tests

### DIFF
--- a/cosmic-marvin/marvin/marvinPlugin.py
+++ b/cosmic-marvin/marvin/marvinPlugin.py
@@ -152,7 +152,7 @@ class MarvinPlugin(Plugin):
         if not self.__testName:
             self.__testName = "test"
         self.__testClient.identifier = '-'. \
-            join([self.__identifier, self.__testName])
+            join([self.__identifier if self.__identifier != None else "marvinTest", self.__testName])
         if self.__tcRunLogger:
             self.__tcRunLogger.name = test.__str__()
 


### PR DESCRIPTION
This will fix the error:
```marvin - EXCEPTION: Failure:: (<type 'exceptions.TypeError'>, TypeError('sequence item 0: expected string, NoneType found',), <traceback object at 0x7ff575dc92d8>)```