### PR TITLE
Fix isrouting problem for non-admins

### DIFF
--- a/cosmic-client/src/main/webapp/scripts/templates.js
+++ b/cosmic-client/src/main/webapp/scripts/templates.js
@@ -398,6 +398,10 @@
                                     isrouting: (args.data.isrouting === "on")
                                 };
 
+                                if (isAdmin()) {
+                                    data['isrouting'] = (args.data.isrouting === "on");
+                                }
+
                                 if (args.$form.find('.form-item[rel=isPublic]').css("display") != "none") {
                                     $.extend(data, {
                                         ispublic: (args.data.isPublic == "on")


### PR DESCRIPTION
With this PR non-admins can upload templates again. The `isrouting` parameter is not send if you're a non-admin user.