### PR TITLE
VNC password limit to 8

### DIFF
--- a/cosmic-core/engine/schema/src/main/java/com/cloud/engine/cloud/entity/api/db/VMEntityVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/engine/cloud/entity/api/db/VMEntityVO.java
@@ -249,7 +249,11 @@ public class VMEntityVO implements VirtualMachine, FiniteStateObject<State> {
 
     @Override
     public String getVncPassword() {
-        return vncPassword;
+        // Libvirt 8.x only allows VPC passwd of 8 chars
+        if (vncPassword != null) {
+            return vncPassword.substring(0, 8);
+        }
+        return "FakeVNC8";
     }
 
     public void setVncPassword(final String vncPassword) {

--- a/cosmic-core/engine/schema/src/main/java/com/cloud/vm/VMInstanceVO.java
+++ b/cosmic-core/engine/schema/src/main/java/com/cloud/vm/VMInstanceVO.java
@@ -377,7 +377,11 @@ public class VMInstanceVO implements VirtualMachine, FiniteStateObject<State> {
 
     @Override
     public String getVncPassword() {
-        return vncPassword;
+        // Libvirt 8.x only allows VPC passwd of 8 chars
+        if (vncPassword != null) {
+            return vncPassword.substring(0, 8);
+        }
+        return "FakeVNC8";
     }
 
     public void setVncPassword(final String vncPassword) {

--- a/cosmic-model/src/main/java/com/cloud/legacymodel/to/VirtualMachineTO.java
+++ b/cosmic-model/src/main/java/com/cloud/legacymodel/to/VirtualMachineTO.java
@@ -192,7 +192,11 @@ public class VirtualMachineTO {
     }
 
     public String getVncPassword() {
-        return vncPassword;
+        // Libvirt 8.x only allows VPC passwd of 8 chars
+        if (vncPassword != null) {
+            return vncPassword.substring(0, 8);
+        }
+        return "FakeVNC8";
     }
 
     public void setVncPassword(final String vncPassword) {


### PR DESCRIPTION
Libvirt 8.x only allows VPC passwd of 8 chars

Thanks to upstream CloudStack project for some of the code used in this pr.