### PR TITLE
Make image creation creation work again

### DIFF
--- a/cosmic-agent/src/main/java/com/cloud/agent/resource/kvm/storage/utils/QemuImg.java
+++ b/cosmic-agent/src/main/java/com/cloud/agent/resource/kvm/storage/utils/QemuImg.java
@@ -64,6 +64,8 @@ public class QemuImg {
             s.add(backingFile.getFormat().toString().toLowerCase());
             s.add("-b");
             s.add(backingFile.getFileName());
+            s.add("-F");
+            s.add(backingFile.getFormat().toString().toLowerCase());
         } else {
             s.add(file.getFormat().toString().toLowerCase());
         }


### PR DESCRIPTION
Parameter -F is now required else we get an error

```
2022-06-09 09:32:39.498 DEBUG [c.c.u.s.Script] (logid: 64cbb924) Executing: qemu-img create -o preallocation=off -f qcow2 -b /mnt/0d3a2a49-850b-381d-af4a-e7455f3f96e0/af168d81-e163-4aa8-aa51-d1ea2d97a7ab /mnt/0d3a2a49-850b-381d-af4a-e7455f3f96e
0/9ce1fbf2-9318-4d2e-9cde-5fc4fa050398 21474836480 
2022-06-09 09:32:39.503 DEBUG [c.c.u.s.Script] (logid: 64cbb924) Exit value is 1
```
